### PR TITLE
Expose theta and phi builders publicly

### DIFF
--- a/imitation/reward_net.py
+++ b/imitation/reward_net.py
@@ -194,11 +194,12 @@ def build_basic_theta_network(hid_sizes, obs_space, act_space,
 
   Arguments:
     hid_sizes (Optional[List[int]]): Number of units at each hidden layer.
+        Default is [], i.e. linear.
     obs_space (gym.Space): Observation space.
     act_space (gym.Space): Action space.
     old_obs_input (Optional[tf.Tensor]): Previous observation.
     new_obs_input (Optional[tf.Tensor]): Next observation.
-    act_input (tf.Tensor): Action.
+    act_input (Optional[tf.Tensor]): Action.
 
   Returns:
     tf.Tensor: Predicted reward.
@@ -266,12 +267,13 @@ def build_basic_phi_network(hid_sizes, obs_space, old_obs_input, new_obs_input):
 
   Arguments:
     hid_sizes (Optional[List[int]]): Number of units at each hidden layer.
+        Default is [32, 32].
     obs_space (gym.Space): Observation space.
     old_obs_input (Optional[tf.Tensor]): Previous observation.
     new_obs_input (Optional[tf.Tensor]): Next observation.
 
   Returns:
-    Tuple[tf.Tensor]: potential for the old and new observations.
+    Tuple[tf.Tensor, tf.Tensor]: potential for the old and new observations.
   """
   if hid_sizes is None:
     hid_sizes = [32, 32]

--- a/imitation/reward_net.py
+++ b/imitation/reward_net.py
@@ -277,8 +277,8 @@ def build_basic_phi_network(hid_sizes, obs_space, old_obs_input, new_obs_input):
     hid_sizes = [32, 32]
 
   with tf.variable_scope("phi", reuse=tf.AUTO_REUSE):
-    old_o = util.flat(old_obs_input, obs_space)
-    new_o = util.flat(new_obs_input, obs_space)
+    old_o = util.flat(old_obs_input, obs_space.shape)
+    new_o = util.flat(new_obs_input, obs_space.shape)
 
     # Weight share, just with different inputs old_o and new_o
     old_shaping_output = tf.identity(


### PR DESCRIPTION
For my use case it's helpful to be able to build the networks outside of the reward shaping classes when desired. I expect this to also be helpful to other users, who might be working outside of `reward_net.py`  but still want to use similar architectures.

I've also generalized `build_basic_theta_network` to be able to depend on the next observation.

*Note*: the `docstrings` base will need to be changed.