### PR TITLE
Take mean of loss for consistent loss magnitude

### DIFF
--- a/imitation/airl.py
+++ b/imitation/airl.py
@@ -145,7 +145,7 @@ class AIRLTrainer():
             discriminator's classification.
     """
     fd = self._build_disc_feed_dict(**kwargs)
-    return np.sum(self._sess.run(self.discrim.disc_loss, feed_dict=fd))
+    return np.mean(self._sess.run(self.discrim.disc_loss, feed_dict=fd))
 
   def wrap_env_train_reward(self, env):
     """Returns the given Env wrapped with a reward function that returns
@@ -194,9 +194,9 @@ class AIRLTrainer():
   def _build_disc_train(self):
     # Construct Train operation.
     self._disc_opt = tf.train.AdamOptimizer()
-    # XXX: I am passing a [None] Tensor as loss. Can this be problematic?
     self._disc_train_op = self._disc_opt.minimize(
-        self.discrim.disc_loss, global_step=self._global_step)
+        tf.reduce_mean(self.discrim.disc_loss),
+        global_step=self._global_step)
 
   def _build_disc_feed_dict(self, gen_old_obs=None, gen_act=None,
                             gen_new_obs=None):


### PR DESCRIPTION
The scale of the discrim loss shown the following plot was previously taken as a sum over losses. This led to discrim loss plots with magnitudes proportional to the discrim batch size. Now we take the average for consistency.

![image](https://user-images.githubusercontent.com/1750835/60496658-2141c100-9c68-11e9-989c-fc0e2e4bf2aa.png)


Also made the discriminator gradient step over a `tf.reduce_mean(loss)` rather than just `loss` in case we had the same magnitude problem.

Based on a few runs of Cartpole+GAIL, I don't think that using `opt.minimize(loss)` (where loss is a Tensor with shape `(4000,)`) is different than using `opt.minimize(tf.reduce_meanloss))`. 


Before:
![image](https://user-images.githubusercontent.com/1750835/60496749-4df5d880-9c68-11e9-9cda-5bc618c3ff3d.png)

After (trial 1):
![image](https://user-images.githubusercontent.com/1750835/60496769-577f4080-9c68-11e9-9e09-1dce5896eab3.png)

After (trial 2):
![image](https://user-images.githubusercontent.com/1750835/60496794-62d26c00-9c68-11e9-8943-6f02a062bbdd.png)


EDIT: This is CartPole+GAIL, not CartPole+AIRL is less stable