### PR TITLE
Hotfix: ReplayBuffer returns in-order entries

### DIFF
--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -37,21 +37,21 @@ def test_buffer(capacity, chunk_len, sample_shape):
     FIFO insertion.
   * Mutating the inserted chunk shouldn't mutate the buffer.
   """
-  buf = Buffer(capacity, sample_shape=sample_shape, dtypes=float)
+  buf = Buffer(capacity, sample_shapes={'k': sample_shape}, dtypes={'k': float})
 
   for i in range(0, capacity*3, chunk_len):
     chunk = _fill_chunk(i, chunk_len, sample_shape)
     assert len(buf) == min(i, capacity)
     assert buf._idx == i % capacity
-    buf.store(chunk)
-    samples = buf.sample(100)
+    buf.store({'k': chunk})
+    samples = buf.sample(100)['k']
     assert samples.shape == (100,) + sample_shape
 
     _check_bound(i + chunk_len, capacity, samples)
 
   # Confirm that buffer is not mutable from inserted sample.
   chunk[:] = np.nan
-  assert not np.any(np.isnan(buf._buffer))
+  assert not np.any(np.isnan(buf._buffer['k']))
 
 
 @pytest.mark.parametrize("capacity", [30, 60])

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -115,7 +115,7 @@ def test_buffer_store_errors(sample_shape):
   dtype = "float32"
 
   def buf():
-      return Buffer(capacity, {'k': sample_shape}, {'k': dtype})
+    return Buffer(capacity, {'k': sample_shape}, {'k': dtype})
 
   # Unexpected keys
   b = buf()
@@ -130,23 +130,23 @@ def test_buffer_store_errors(sample_shape):
   # `data` is empty.
   b = buf()
   with pytest.raises(ValueError):
-      b.store({'k': np.empty((0,) + sample_shape, dtype=dtype)})
+    b.store({'k': np.empty((0,) + sample_shape, dtype=dtype)})
 
   # `data` has too many samples.
   b = buf()
   with pytest.raises(ValueError):
-      b.store({'k': np.empty((capacity + 1,) + sample_shape, dtype=dtype)})
+    b.store({'k': np.empty((capacity + 1,) + sample_shape, dtype=dtype)})
 
   # `data` has the wrong sample shape.
   b = buf()
   with pytest.raises(ValueError):
-      b.store({'k': np.empty((1, 3, 3, 3, 3), dtype=dtype)})
+    b.store({'k': np.empty((1, 3, 3, 3, 3), dtype=dtype)})
 
 
 def test_buffer_sample_errors():
   b = Buffer(10, {'k': (2, 1)}, dtypes={'k': bool})
   with pytest.raises(ValueError):
-      b.sample(5)
+    b.sample(5)
 
 
 def test_buffer_init_errors():
@@ -158,16 +158,16 @@ def test_replay_buffer_init_errors():
   with pytest.raises(ValueError, match=r"Specified.* and environment"):
     ReplayBuffer(15, env="MockEnv", obs_shape=(10, 10))
   with pytest.raises(ValueError, match=r"Shape or dtype missing.*"):
-      ReplayBuffer(15, obs_shape=(10, 10), act_shape=(15,), obs_dtype=bool)
+    ReplayBuffer(15, obs_shape=(10, 10), act_shape=(15,), obs_dtype=bool)
   with pytest.raises(ValueError, match=r"Shape or dtype missing.*"):
-      ReplayBuffer(15, obs_shape=(10, 10), obs_dtype=bool, act_dtype=bool)
+    ReplayBuffer(15, obs_shape=(10, 10), obs_dtype=bool, act_dtype=bool)
 
 
 def test_replay_buffer_store_errors():
   b = ReplayBuffer(10, obs_shape=(), obs_dtype=bool, act_shape=(),
                    act_dtype=float)
   with pytest.raises(ValueError, match=".* same length.*"):
-      b.store(np.ones(4), np.ones(4), np.ones(3))
+    b.store(np.ones(4), np.ones(4), np.ones(3))
 
 
 def test_buffer_from_data():

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -49,9 +49,9 @@ def test_buffer(capacity, chunk_len, sample_shape):
 
     _check_bound(i + chunk_len, capacity, samples)
 
-  # Confirm that buffer is not mutable from inserted sample.
-  chunk[:] = np.nan
-  assert not np.any(np.isnan(buf._buffer['k']))
+    # Confirm that buffer is not mutable from inserted sample.
+    chunk[:] = np.nan
+    assert not np.any(np.isnan(buf._arrays['k']))
 
 
 @pytest.mark.parametrize("capacity", [30, 60])
@@ -149,6 +149,11 @@ def test_buffer_sample_errors():
       b.sample(5)
 
 
+def test_buffer_init_errors():
+  with pytest.raises(KeyError, match=r"sample_shape and dtypes.*"):
+    Buffer(10, dict(a=(2, 1), b=(3,)), dtypes=dict(a="float32", c=bool))
+
+
 def test_replay_buffer_init_errors():
   with pytest.raises(ValueError, match=r"Specified.* and environment"):
     ReplayBuffer(15, env="MockEnv", obs_shape=(10, 10))
@@ -168,9 +173,9 @@ def test_replay_buffer_store_errors():
 def test_buffer_from_data():
   data = np.ndarray([50, 30], dtype=bool)
   buf = Buffer.from_data({'k': data})
-  assert buf._buffer['k'] is not data
-  assert data.dtype == buf._buffer['k'].dtype
-  assert np.array_equal(buf._buffer['k'], data)
+  assert buf._arrays['k'] is not data
+  assert data.dtype == buf._arrays['k'].dtype
+  assert np.array_equal(buf._arrays['k'], data)
 
 
 def test_replay_buffer_from_data():
@@ -178,9 +183,9 @@ def test_replay_buffer_from_data():
   act = np.ones((2, 6), dtype=float)
   new_obs = np.array([7, 8], dtype=int)
   buf = ReplayBuffer.from_data(old_obs, act, new_obs)
-  assert np.array_equal(buf._buffer._buffer['old_obs'], old_obs)
-  assert np.array_equal(buf._buffer._buffer['new_obs'], new_obs)
-  assert np.array_equal(buf._buffer._buffer['act'], act)
+  assert np.array_equal(buf._buffer._arrays['old_obs'], old_obs)
+  assert np.array_equal(buf._buffer._arrays['new_obs'], new_obs)
+  assert np.array_equal(buf._buffer._arrays['act'], act)
 
   with pytest.raises(ValueError, match=r".*same length."):
     new_obs_toolong = np.array([7, 8, 9], dtype=int)


### PR DESCRIPTION
`ReplayBuffer` had a bug: we sampled *independently* from the different buffers, so did not sample state-action-next state transitions. This PR fixes this by changing `Buffer` to operate on a dict of NumPy arrays, with `ReplayBuffer` being a simple wrapper around this.

There are some things here that could be improved. I haven't really pushed through the fact that `ReplayBuffer` is now a simple wrapper. So for example there's some testing specific to `ReplayBuffer` to check for out-of-order sequences, that should really be in the test for `Buffer` instead. I don't have time to do this now, but someone else is welcome to clean up.

Reviewing this is moderately urgent (i.e. look at this before you do other work, but don't work on a holiday because of it) -- the codebase as-is is currently broken, so will be hard to make progress on anything.