### PR TITLE
Rollout hotfix: add truncate option

### DIFF
--- a/imitation/bc.py
+++ b/imitation/bc.py
@@ -36,7 +36,7 @@ class BCTrainer:
     self.policy_class = policy_class
     self.expert_trainers = expert_trainers
     self.batch_size = batch_size
-    expert_obs, expert_acts, expert_nobs = rollout.generate_multiple(
+    expert_obs, expert_acts, _ = rollout.generate_transitions_multiple(
         expert_trainers, self.env, n_expert_timesteps, truncate=False)
     self.expert_dataset = Dataset(
         {

--- a/imitation/trainer.py
+++ b/imitation/trainer.py
@@ -144,9 +144,9 @@ class Trainer:
     environment until `self._n_disc_samples_per_buffer` obs-act-obs samples are
     produced, and then stores these samples.
     """
-    gen_rollouts = rollout.flatten_trajectories(rollout.generate(
+    gen_rollouts = rollout.generate(
         self.gen_policy, self.env,
-        n_timesteps=self._n_disc_samples_per_buffer))[:3]
+        n_timesteps=self._n_disc_samples_per_buffer)[:3]
     self._gen_replay_buffer.store(*gen_rollouts)
 
   def train(self, *, n_epochs=100, n_gen_steps_per_epoch=None,

--- a/imitation/trainer.py
+++ b/imitation/trainer.py
@@ -108,7 +108,7 @@ class Trainer:
     self._gen_replay_buffer = ReplayBuffer(gen_replay_buffer_capacity, self.env)
     self._populate_gen_replay_buffer()
 
-    exp_rollouts = rollout.generate_multiple(
+    exp_rollouts = rollout.generate_transitions_multiple(
         self.expert_policies, self.env, n_expert_samples)[:3]
     self._exp_replay_buffer = ReplayBuffer.from_data(*exp_rollouts)
 
@@ -144,7 +144,7 @@ class Trainer:
     environment until `self._n_disc_samples_per_buffer` obs-act-obs samples are
     produced, and then stores these samples.
     """
-    gen_rollouts = rollout.generate(
+    gen_rollouts = rollout.generate_transitions(
         self.gen_policy, self.env,
         n_timesteps=self._n_disc_samples_per_buffer)[:3]
     self._gen_replay_buffer.store(*gen_rollouts)

--- a/imitation/util/rollout.py
+++ b/imitation/util/rollout.py
@@ -54,8 +54,8 @@ def get_action_policy(policy, observation, deterministic=False):
 class _TrajectoryAccumulator:
   """Accumulates trajectories step-by-step.
 
-  Used in `generate()` only, for collecting completed trajectories while
-  ignoring partially-completed trajectories.
+  Used in `generate_trajectories()` only, for collecting completed trajectories
+  while ignoring partially-completed trajectories.
   """
 
   def __init__(self):
@@ -84,11 +84,11 @@ class _TrajectoryAccumulator:
     self.partial_trajectories[idx].append(step_dict)
 
 
-def generate(policy, env, *, n_timesteps=None, n_episodes=None
-             ) -> List[Dict[str, np.ndarray]]:
+def generate_trajectories(policy, env, *, n_timesteps=None, n_episodes=None
+                          ) -> List[Dict[str, np.ndarray]]:
   """
-  Generate old_obs-action-new_obs-reward tuples from a policy and an
-  environment.
+  Generate a list of old_obs-action-new_obs-reward trajectories from a policy
+  and an environment.
 
   Args:
     policy (BasePolicy or BaseRLModel): A stable_baselines policy or RLModel,
@@ -103,7 +103,7 @@ def generate(policy, env, *, n_timesteps=None, n_episodes=None
         Set exactly one of `n_timesteps` and `n_episodes`, or this function will
         error.
 
-  Return:
+  Returns:
     trajectories: List of trajectory dictionaries. Each trajectory dictionary
         `traj` has the following keys and values:
          - traj["obs"] is an observations array with N+1 rows, where N depends
@@ -226,13 +226,13 @@ def rollout_stats(policy, env, **kwargs):
           collecting rewards. Rewards from parallel episodes that are underway
           when the final episode is finished are also included in the return.
 
-  Return:
+  Returns:
       Dictionary containing `n_traj` collected (int), along with return
       statistics (keys: `return_{min,mean,std,max}`, float values) and
       trajectory length statistics (keys: `len_{min,mean,std,max}`, float
       values).
   """
-  trajectories = generate(policy, env, **kwargs)
+  trajectories = generate_trajectories(policy, env, **kwargs)
   out_stats = {"n_traj": len(trajectories)}
   traj_descriptors = {
     "return": np.asarray([sum(t["rew"]) for t in trajectories]),
@@ -297,8 +297,52 @@ def flatten_trajectories(trajectories: Sequence[Dict[str, np.ndarray]]
       cat_parts["rew"]
 
 
-def generate_multiple(policies, env, n_timesteps, *, truncate=True):
-  """Generate obs-act-obs triples from several policies.
+def generate(policy, env, *, n_timesteps=None, n_episodes=None, truncate=True,
+             ) -> Tuple[np.ndarray, ...]:
+  """
+  Generate old_obs-action-new_obs-reward tuples from a policy and an
+  environment.
+
+  Args:
+    policy (BasePolicy or BaseRLModel): A stable_baselines policy or RLModel,
+        trained on the gym environment.
+    env (VecEnv or Env or str): The environment(s) to interact with.
+    n_timesteps (int): The minimum number of obs-action-obs-reward tuples to
+        collect (may collect more if episodes run too long). Set exactly one of
+        `n_timesteps` and `n_episodes`, or this function will error.
+    n_episodes (int): The number of episodes to finish before returning
+        collected tuples. Tuples from parallel episodes underway when the final
+        episode is finished will not be returned.
+        Set exactly one of `n_timesteps` and `n_episodes`, or this function will
+        error.
+    truncate (bool): If True and n_timesteps is not None, then drop any
+        additional samples to ensure that exactly `n_timesteps` samples are
+        returned.
+  Returns:
+    rollout_obs_old (array): A numpy array with shape
+        `[n_samples] + env.observation_space.shape`. The ith observation in
+        this array is the observation seen with the agent chooses action
+        `rollout_act[i]`.
+    rollout_act (array): A numpy array with shape
+        `[n_samples] + env.action_space.shape`.
+    rollout_obs_new (array): A numpy array with shape
+        `[n_samples] + env.observation_space.shape`. The ith observation in
+        this array is from the transition state after the agent chooses action
+        `rollout_act[i]`.
+    rollout_rewards (array): A numpy array with shape `[n_samples]`. The
+        reward received on the ith timestep is `rollout_rewards[i]`.
+  """
+  traj = generate_trajectories(policy, env, n_timesteps=n_timesteps,
+                               n_episodes=n_episodes)
+  rollout_arrays = flatten_trajectories(traj)
+  if truncate and n_timesteps is not None:
+    rollout_arrays = tuple(arr[:n_timesteps] for arr in rollout_arrays)
+  return rollout_arrays
+
+
+def generate_multiple(policies, env, n_timesteps, *, truncate=True
+                      ) -> Tuple[np.ndarray, ...]:
+  """Generate obs-act-obs-rew triples from several policies.
 
   Splits the desired number of timesteps evenly between all the policies given.
 
@@ -312,25 +356,28 @@ def generate_multiple(policies, env, n_timesteps, *, truncate=True):
           episode completion states, the last obs-state-obs triple in every
           episode is omitted. (See GitHub issue #1)
       env (gym.Env): The environment the policy should act in.
-      n_timesteps (int): The number of obs-action-obs
-          triples to generate. If the number of policies given doesn't
-          divide this number evenly, then the last policy generates
-          more timesteps.
-      truncate (bool): should collected episodes be truncated so that *only*
-          `n_timesteps` are returned? Otherwise this will potentially return
-          more timesteps.
+      n_timesteps (int): The minimum number of obs-action-obs-reward tuples to
+          collect (may collect more if episodes run too long). Set exactly one
+          of `n_timesteps` and `n_episodes`, or this function will error.
+          If the number of policies given doesn't divide this number evenly,
+          then the last policy generates more timesteps than the other policies.
+      truncate (bool): If True and n_timesteps is not None, then drop any
+          additional samples to ensure that exactly `n_timesteps` samples are
+          returned.
 
   Returns:
       rollout_obs_old (array): A numpy array with shape
-          `[n_timesteps] + env.observation_space.shape`. The ith observation in
+          `[n_samples] + env.observation_space.shape`. The ith observation in
           this array is the observation seen with the agent chooses action
           `rollout_act[i]`.
       rollout_act (array): A numpy array with shape
-          `[n_timesteps] + env.action_space.shape`.
+          `[n_samples] + env.action_space.shape`.
       rollout_obs_new (array): A numpy array with shape
-          `[n_timesteps] + env.observation_space.shape`. The ith observation in
+          `[n_samples] + env.observation_space.shape`. The ith observation in
           this array is from the transition state after the agent chooses
           action `rollout_act[i]`.
+      rollout_rew (array): A numpy array with shape `[n_samples]`. The
+          reward received on the ith timestep is `rew[i]`.
   """
   try:
     policies = list(policies)
@@ -350,8 +397,7 @@ def generate_multiple(policies, env, n_timesteps, *, truncate=True):
       # n_policies doesn't evenly divide n_timesteps.
       n_timesteps_ += rem
 
-    obs_old_, act_, obs_new_, _ = flatten_trajectories(
-        generate(pol, env, n_timesteps=n_timesteps_))
+    obs_old_, act_, obs_new_, _ = generate(pol, env, n_timesteps=n_timesteps_)
     assert len(obs_new_) == len(act_), (len(obs_new_), len(act_))
     assert len(obs_old_) == len(act_), (len(obs_old_), len(act_))
 

--- a/tests/test_script_train.py
+++ b/tests/test_script_train.py
@@ -1,0 +1,21 @@
+import gin
+import gin.tf
+import tensorflow as tf
+
+from imitation.scripts.train import train_and_plot
+
+gin.parse_config_file("configs/classical_control.gin")
+gin.bind_parameter('train_and_plot.env', 'CartPole-v1')
+gin.bind_parameter('init_trainer.use_gail', False)
+
+
+def test_train_and_plot_no_crash():
+  train_and_plot(n_epochs=2,
+                 n_plots_each_per_epoch=1,
+                 n_disc_steps_per_epoch=1,
+                 n_gen_steps_per_epoch=1,
+                 interactive=False)
+  tf.reset_default_graph()
+
+
+# TODO(shwang): edit notebooks to match new params

--- a/tests/test_script_train.py
+++ b/tests/test_script_train.py
@@ -16,6 +16,3 @@ def test_train_and_plot_no_crash():
                  n_gen_steps_per_epoch=1,
                  interactive=False)
   tf.reset_default_graph()
-
-
-# TODO(shwang): edit notebooks to match new params

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -27,7 +27,7 @@ def test_init_no_crash(use_gail, env='CartPole-v1'):
 def test_train_disc_no_crash(use_gail, env='CartPole-v1', n_timesteps=200):
   trainer = init_trainer(env, use_gail=use_gail)
   trainer.train_disc()
-  obs_old, act, obs_new, _ = rollout.generate(
+  obs_old, act, obs_new, _ = rollout.generate_transitions(
       trainer.gen_policy, env, n_timesteps=n_timesteps)
   trainer.train_disc(gen_old_obs=obs_old, gen_act=act,
                      gen_new_obs=obs_new)
@@ -44,7 +44,7 @@ def test_train_gen_no_crash(use_gail, env='CartPole-v1', n_steps=10):
 def test_train_disc_improve_D(use_gail, env='CartPole-v1', n_timesteps=200,
                               n_steps=1000):
   trainer = init_trainer(env, use_gail=use_gail)
-  obs_old, act, obs_new, _ = rollout.generate(
+  obs_old, act, obs_new, _ = rollout.generate_transitions(
       trainer.gen_policy, env, n_timesteps=n_timesteps)
   kwargs = dict(gen_old_obs=obs_old, gen_act=act, gen_new_obs=obs_new)
   loss1 = trainer.eval_disc_loss(**kwargs)
@@ -63,7 +63,7 @@ def test_train_gen_degrade_D(use_gail=False, env='CartPole-v1', n_timesteps=200,
   if use_gail:
     kwargs = {}
   else:
-    obs_old, act, obs_new, _ = rollout.generate(
+    obs_old, act, obs_new, _ = rollout.generate_transitions(
         trainer.gen_policy, env, n_timesteps=n_timesteps)
     kwargs = dict(gen_old_obs=obs_old, gen_act=act, gen_new_obs=obs_new)
 
@@ -83,7 +83,7 @@ def test_train_disc_then_gen(use_gail=False, env='CartPole-v1', n_timesteps=200,
   if use_gail:
     kwargs = {}
   else:
-    obs_old, act, obs_new, _ = rollout.generate(
+    obs_old, act, obs_new, _ = rollout.generate_transitions(
         trainer.gen_policy, env, n_timesteps=n_timesteps)
     kwargs = dict(gen_old_obs=obs_old, gen_act=act, gen_new_obs=obs_new)
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -27,8 +27,8 @@ def test_init_no_crash(use_gail, env='CartPole-v1'):
 def test_train_disc_no_crash(use_gail, env='CartPole-v1', n_timesteps=200):
   trainer = init_trainer(env, use_gail=use_gail)
   trainer.train_disc()
-  obs_old, act, obs_new, _ = rollout.flatten_trajectories(rollout.generate(
-      trainer.gen_policy, env, n_timesteps=n_timesteps))
+  obs_old, act, obs_new, _ = rollout.generate(
+      trainer.gen_policy, env, n_timesteps=n_timesteps)
   trainer.train_disc(gen_old_obs=obs_old, gen_act=act,
                      gen_new_obs=obs_new)
 
@@ -44,8 +44,8 @@ def test_train_gen_no_crash(use_gail, env='CartPole-v1', n_steps=10):
 def test_train_disc_improve_D(use_gail, env='CartPole-v1', n_timesteps=200,
                               n_steps=1000):
   trainer = init_trainer(env, use_gail=use_gail)
-  obs_old, act, obs_new, _ = rollout.flatten_trajectories(rollout.generate(
-      trainer.gen_policy, env, n_timesteps=n_timesteps))
+  obs_old, act, obs_new, _ = rollout.generate(
+      trainer.gen_policy, env, n_timesteps=n_timesteps)
   kwargs = dict(gen_old_obs=obs_old, gen_act=act, gen_new_obs=obs_new)
   loss1 = trainer.eval_disc_loss(**kwargs)
   trainer.train_disc(n_steps=n_steps, **kwargs)
@@ -63,8 +63,8 @@ def test_train_gen_degrade_D(use_gail=False, env='CartPole-v1', n_timesteps=200,
   if use_gail:
     kwargs = {}
   else:
-    obs_old, act, obs_new, _ = rollout.flatten_trajectories(rollout.generate(
-        trainer.gen_policy, env, n_timesteps=n_timesteps))
+    obs_old, act, obs_new, _ = rollout.generate(
+        trainer.gen_policy, env, n_timesteps=n_timesteps)
     kwargs = dict(gen_old_obs=obs_old, gen_act=act, gen_new_obs=obs_new)
 
   loss1 = trainer.eval_disc_loss(**kwargs)
@@ -83,8 +83,8 @@ def test_train_disc_then_gen(use_gail=False, env='CartPole-v1', n_timesteps=200,
   if use_gail:
     kwargs = {}
   else:
-    obs_old, act, obs_new, _ = rollout.flatten_trajectories(rollout.generate(
-        trainer.gen_policy, env, n_timesteps=n_timesteps))
+    obs_old, act, obs_new, _ = rollout.generate(
+        trainer.gen_policy, env, n_timesteps=n_timesteps)
     kwargs = dict(gen_old_obs=obs_old, gen_act=act, gen_new_obs=obs_new)
 
   loss1 = trainer.eval_disc_loss(**kwargs)


### PR DESCRIPTION
Fixes a notebook-crashing problem where `rollouts.flatten_trajectory(rollouts.generate(..., n_timesteps=1000))` was generating more than 1000 samples, leading to an error from ReplayBuffer of capacity 1000.

* Re-do rollouts API: now `generate` and `generate_multiple` both return obs-act-obs-rew tuples, and `generate_traj` returns lists of trajectory dictionaries. (`generate` used to return list of traj dicts)
* `generate` now automatically truncates the length of trajectories to `n_timesteps` if `truncate=True`. (Matching the behavior of `generate_traj`.)
* Add a test to check if `scripts/train.py` is running properly, using a gin configuration similar to the notebook.
