### PR TITLE
Save reward and discriminator networks, and other improved logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
   - name: "3.7 Coverage Tests"
     python: "3.7"
     script:
-      - py.test -vv --cov-report=xml --cov=${VIRTUAL_ENV}/lib/python3.7/site-packages/imitation tests/
+      - py.test --concurrency=multiprocessing -vv --cov-report=xml --cov=${VIRTUAL_ENV}/lib/python3.7/site-packages/imitation tests/
     after_success:
       - mv .coverage .coverage.imitation
       - coverage combine  # rewrite paths

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
   - name: "3.7 Coverage Tests"
     python: "3.7"
     script:
-      - py.test --concurrency=multiprocessing -vv --cov-report=xml --cov=${VIRTUAL_ENV}/lib/python3.7/site-packages/imitation tests/
+      - py.test -vv --cov-report=xml --cov=${VIRTUAL_ENV}/lib/python3.7/site-packages/imitation tests/
     after_success:
       - mv .coverage .coverage.imitation
       - coverage combine  # rewrite paths

--- a/imitation/discrim_net.py
+++ b/imitation/discrim_net.py
@@ -166,6 +166,7 @@ class DiscrimNetAIRL(DiscrimNet):
     return self._log_D - self.entropy_weight * self._log_D_compl
 
   def save(self, directory):
+    os.makedirs(directory, exist_ok=True)
     params = {
         "entropy_weight": self.entropy_weight,
         "reward_net_cls": type(self.reward_net),

--- a/imitation/discrim_net.py
+++ b/imitation/discrim_net.py
@@ -1,13 +1,16 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
+import os
+import pickle
 from typing import Iterable, Optional
 
 import gym
 import tensorflow as tf
 
 from imitation import reward_net, util
+from imitation.util import serialize
 
 
-class DiscrimNet(ABC):
+class DiscrimNet(serialize.Serializable):
   """Abstract base class for discriminator, used in multiple IRL methods."""
 
   def __init__(self):
@@ -40,15 +43,15 @@ class DiscrimNet(ABC):
     # Holds the label of every state-action pair that the discriminator
     # is being trained on. Use 0.0 for expert policy. Use 1.0 for generated
     # policy.
-    self.labels_ph = tf.placeholder(shape=(None,), dtype=tf.int32,
-                                    name="discrim_labels")
+    self._labels_ph = tf.placeholder(shape=(None,), dtype=tf.int32,
+                                     name="discrim_labels")
 
     # This placeholder holds the generator-policy log action probabilities,
     # $\log \pi(a \mid s)$, of each state-action pair. This includes both
     # actions taken by the generator *and* those by the expert (we can
     # ask our policy for action probabilities even if we don't take them).
     # TODO(adam): this is only used by AIRL; sad we have to always include it
-    self.log_policy_act_prob_ph = tf.placeholder(
+    self._log_policy_act_prob_ph = tf.placeholder(
         shape=(None,), dtype=tf.float32, name="log_ro_act_prob_ph")
 
   @abstractmethod
@@ -58,20 +61,30 @@ class DiscrimNet(ABC):
   @property
   @abstractmethod
   def old_obs_ph(self):
-    """Gets the old observation placeholder."""
+    """The old observation placeholder."""
     pass
 
   @property
   @abstractmethod
   def act_ph(self):
-    """Gets the action placeholder."""
+    """The action placeholder."""
     pass
 
   @property
   @abstractmethod
   def new_obs_ph(self):
-    """Gets the new observation placeholder."""
+    """The new observation placeholder."""
     pass
+
+  @property
+  def labels_ph(self):
+    """The expert (0.0) or generated (1.0) labels placeholder."""
+    return self._labels_ph
+
+  @property
+  def log_policy_act_prob_ph(self):
+    """The log-probability of policy actions placeholder."""
+    return self._log_policy_act_prob_ph
 
 
 class DiscrimNetAIRL(DiscrimNet):
@@ -152,8 +165,25 @@ class DiscrimNetAIRL(DiscrimNet):
     # Note self._log_D_compl is effectively an entropy term.
     return self._log_D - self.entropy_weight * self._log_D_compl
 
+  def save(self, directory):
+    params = {
+        "entropy_weight": self.entropy_weight,
+        "reward_net_cls": type(self.reward_net),
+    }
+    with open(os.path.join(directory, "args"), "wb") as f:
+      pickle.dump(params, f)
+    return self.reward_net.save(os.path.join(directory, "reward_net"))
 
-class DiscrimNetGAIL(DiscrimNet):
+  @classmethod
+  def load(cls, directory):
+    with open(os.path.join(directory, "args"), "rb") as f:
+      params = pickle.load(f)
+    reward_net_cls = params.pop("reward_net_cls")
+    reward_net = reward_net_cls.load(os.path.join(directory, "reward_net"))
+    return cls(reward_net=reward_net, **params)
+
+
+class DiscrimNetGAIL(DiscrimNet, serialize.LayersSerializable):
   """The discriminator to use for GAIL."""
 
   def __init__(self,
@@ -161,16 +191,18 @@ class DiscrimNetGAIL(DiscrimNet):
                action_space: gym.Space,
                hid_sizes: Optional[Iterable[int]] = None,
                scale: bool = False):
+    args = locals()
     inputs = util.build_inputs(observation_space, action_space, scale=scale)
     self._old_obs_ph, self._act_ph, self._new_obs_ph = inputs[:3]
     self.old_obs_inp, self.act_inp, self.new_obs_inp = inputs[3:]
 
     self.hid_sizes = hid_sizes
     with tf.variable_scope("discrim_network"):
-      self._discrim_logits = self.build_discrm_network(
+      discrim_mlp, self._discrim_logits = self.build_discrm_network(
           self.old_obs_inp, self.act_inp)
 
-    super().__init__()
+    DiscrimNet.__init__(self)
+    serialize.LayersSerializable.__init__(**args, layers=discrim_mlp)
 
     tf.logging.info("using GAIL")
 
@@ -197,7 +229,7 @@ class DiscrimNetGAIL(DiscrimNet):
     discrim_mlp = util.build_mlp(hid_sizes=hid_sizes)
     discrim_logits = util.sequential(inputs, discrim_mlp)
 
-    return discrim_logits
+    return discrim_mlp, discrim_logits
 
   def build_policy_train_reward(self):
     super().build_policy_train_reward()

--- a/imitation/discrim_net.py
+++ b/imitation/discrim_net.py
@@ -194,7 +194,8 @@ class DiscrimNetGAIL(DiscrimNet):
     hid_sizes = self.hid_sizes
     if hid_sizes is None:
       hid_sizes = (32, 32)
-    discrim_logits = util.apply_ff(inputs, hid_sizes=hid_sizes)
+    discrim_mlp = util.build_mlp(hid_sizes=hid_sizes)
+    discrim_logits = util.sequential(inputs, discrim_mlp)
 
     return discrim_logits
 

--- a/imitation/reward_net.py
+++ b/imitation/reward_net.py
@@ -97,7 +97,7 @@ class RewardNet(serialize.Serializable):
 
   @abstractmethod
   def build_theta_network(self, obs_input: tf.Tensor, act_input: tf.Tensor,
-                          ) -> Tuple[tf.Tensor, util.Layers]:
+                          ) -> Tuple[tf.Tensor, util.LayersDict]:
     """Builds the test reward network.
 
     The output of the network is the same as the reward used for transfer
@@ -176,7 +176,7 @@ class RewardNetShaped(RewardNet):
   def build_phi_network(self,
                         old_obs_input: tf.Tensor,
                         new_obs_input: tf.Tensor,
-                        ) -> Tuple[tf.Tensor, tf.Tensor, util.Layers]:
+                        ) -> Tuple[tf.Tensor, tf.Tensor, util.LayersDict]:
     """Build the reward shaping network (disentangles dynamics from reward).
 
     XXX: We could potentially make it easier on the subclasser by requiring

--- a/imitation/scripts/config/data_collect.py
+++ b/imitation/scripts/config/data_collect.py
@@ -1,16 +1,26 @@
+import os
+
 import sacred
 
 from imitation.scripts.config.common import DEFAULT_BLANK_POLICY_KWARGS
-from imitation.util import FeedForward64Policy
+from imitation.util import util
 
 data_collect_ex = sacred.Experiment("data_collect")
 
 
 @data_collect_ex.config
 def data_collect_defaults():
+    env_name = "CartPole-v1"
     total_timesteps = int(1e6)
     num_vec = 8
+    parallel = True  # Use SubprocVecEnv (generally faster if num_vec>1)
     make_blank_policy_kwargs = DEFAULT_BLANK_POLICY_KWARGS
+
+
+@data_collect_ex.config
+def logging(env_name):
+    log_dir = os.path.join("output", "data_collect",
+                           env_name.replace('/', '_'), util.make_timestamp())
 
 
 @data_collect_ex.named_config
@@ -39,5 +49,5 @@ def pendulum():
 def swimmer():
     env_name = "Swimmer-v2"
     make_blank_policy_kwargs = dict(
-        policy_network_class=FeedForward64Policy,
+        policy_network_class=util.FeedForward64Policy,
     )

--- a/imitation/scripts/config/train.py
+++ b/imitation/scripts/config/train.py
@@ -1,13 +1,18 @@
+"""Configuration for imitation.scripts.train."""
+
+import os
+
 import sacred
 
+from imitation import util
 from imitation.scripts.config.common import DEFAULT_BLANK_POLICY_KWARGS
-from imitation.util import FeedForward64Policy
 
 train_ex = sacred.Experiment("train", interactive=True)
 
 
 @train_ex.config
 def train_defaults():
+    env_name = "CartPole-v1"  # environment to train on
     n_epochs = 50
     n_disc_steps_per_epoch = 50
     n_gen_steps_per_epoch = 2048
@@ -15,6 +20,7 @@ def train_defaults():
     init_trainer_kwargs = dict(
         use_random_expert=False,
         num_vec=8,  # NOTE: changing this also changes the effective n_steps!
+        parallel=True,  # Use SubprocVecEnv (generally faster if num_vec>1)
         reward_kwargs=dict(
             theta_units=[32, 32],
             phi_units=[32, 32],
@@ -35,6 +41,14 @@ def train_defaults():
 
         make_blank_policy_kwargs=DEFAULT_BLANK_POLICY_KWARGS,
     )
+
+    checkpoint_interval = 5  # number of epochs at which to checkpoint
+
+
+@train_ex.config
+def logging(env_name):
+    log_dir = os.path.join("output", env_name.replace('/', '_'),
+                           util.make_timestamp())
 
 
 @train_ex.named_config
@@ -83,7 +97,7 @@ def swimmer():
     n_epochs = 1000
     init_trainer_kwargs = dict(
         make_blank_policy_kwargs=dict(
-            policy_network_class=FeedForward64Policy,
+            policy_network_class=util.FeedForward64Policy,
         ),
     )
 
@@ -95,3 +109,6 @@ def debug():
     n_disc_steps_per_epoch = 1
     n_gen_steps_per_epoch = 1
     n_episodes_per_reward_data = 1
+    init_trainer_kwargs = dict(
+        parallel=False,  # easier to debug with everything in one process
+    )

--- a/imitation/scripts/config/train.py
+++ b/imitation/scripts/config/train.py
@@ -47,8 +47,8 @@ def train_defaults():
 
 @train_ex.config
 def logging(env_name):
-    log_dir = os.path.join("output", env_name.replace('/', '_'),
-                           util.make_timestamp())
+    log_dir = os.path.join("output", "train",
+                           env_name.replace('/', '_'), util.make_timestamp())
 
 
 @train_ex.named_config

--- a/imitation/scripts/data_collect.py
+++ b/imitation/scripts/data_collect.py
@@ -1,29 +1,28 @@
 import os.path as osp
 
 from sacred.observers import FileStorageObserver
+from stable_baselines import logger as sb_logger
 import tensorflow as tf
 
 from imitation.scripts.config.data_collect import data_collect_ex
 import imitation.util as util
 
 
-def make_PPO2(env_name, num_vec, **make_blank_policy_kwargs):
-  env = util.make_vec_env(env_name, num_vec)
+@data_collect_ex.main
+def main(_seed, env_name, log_dir, parallel, total_timesteps,
+         num_vec=8, make_blank_policy_kwargs={}):
+  tf.logging.set_verbosity(tf.logging.INFO)
+  sb_logger.configure(folder=osp.join(log_dir, 'rl'),
+                      format_strs=['tensorboard', 'stdout'])
+
+  env = util.make_vec_env(env_name, num_vec, seed=_seed,
+                          parallel=parallel, log_dir=log_dir)
   # TODO(adam): add support for wrapping env with VecNormalize
   # (This is non-trivial since we'd need to make sure it's also applied
   # when the policy is re-loaded to generate rollouts.)
-  policy = util.make_blank_policy(env, verbose=1, init_tensorboard=True,
-                                  **make_blank_policy_kwargs)
-  return policy
+  policy = util.make_blank_policy(env, verbose=1, **make_blank_policy_kwargs)
 
-
-@data_collect_ex.main
-def main(env_name, total_timesteps, num_vec=8, make_blank_policy_kwargs={}):
-  tf.logging.set_verbosity(tf.logging.INFO)
-
-  policy = make_PPO2(env_name, num_vec, **make_blank_policy_kwargs)
-
-  callback = util.make_save_policy_callback("data/")
+  callback = util.make_save_policy_callback(osp.join(log_dir, 'checkpoints'))
   policy.learn(total_timesteps, callback=callback)
 
 

--- a/imitation/scripts/train.py
+++ b/imitation/scripts/train.py
@@ -77,131 +77,131 @@ def train_and_plot(_seed: int,
         used to initialize the trainer.
   """
   assert n_epochs_per_plot is None or n_epochs_per_plot >= 1
-  sess = tf.Session()
-  with sess.as_default():
-    trainer = init_trainer(env_name, seed=_seed, log_dir=log_dir,
-                           **init_trainer_kwargs)
+  with tf.Session() as sess:
+    with sess.as_default():
+      trainer = init_trainer(env_name, seed=_seed, log_dir=log_dir,
+                             **init_trainer_kwargs)
 
-    tf.logging.info("Logging to %s", log_dir)
-    os.makedirs(log_dir, exist_ok=True)
-    sb_logger.configure(folder=osp.join(log_dir, 'generator'),
-                        format_strs=['tensorboard', 'stdout'])
+      tf.logging.info("Logging to %s", log_dir)
+      os.makedirs(log_dir, exist_ok=True)
+      sb_logger.configure(folder=osp.join(log_dir, 'generator'),
+                          format_strs=['tensorboard', 'stdout'])
 
-    plot_idx = 0
-    gen_data = ([], [])
-    disc_data = ([], [])
+      plot_idx = 0
+      gen_data = ([], [])
+      disc_data = ([], [])
 
-    def disc_plot_add_data(gen_mode: bool = False):
-      """Evaluates and records the discriminator loss for plotting later.
+      def disc_plot_add_data(gen_mode: bool = False):
+        """Evaluates and records the discriminator loss for plotting later.
 
-      Args:
-          gen_mode: Whether the generator or the discriminator is active.
-              We use this to color the data points.
-      """
-      nonlocal plot_idx
-      mode = "gen" if gen_mode else "dis"
-      X, Y = gen_data if gen_mode else disc_data
-      # Divide by two since we get two data points (gen and disc) per epoch.
-      X.append(plot_idx / 2)
-      Y.append(trainer.eval_disc_loss())
-      tf.logging.info(
-          "plot idx ({}): {} disc loss: {}"
-          .format(mode, plot_idx, Y[-1]))
-      plot_idx += 1
+        Args:
+            gen_mode: Whether the generator or the discriminator is active.
+                We use this to color the data points.
+        """
+        nonlocal plot_idx
+        mode = "gen" if gen_mode else "dis"
+        X, Y = gen_data if gen_mode else disc_data
+        # Divide by two since we get two data points (gen and disc) per epoch.
+        X.append(plot_idx / 2)
+        Y.append(trainer.eval_disc_loss())
+        tf.logging.info(
+            "plot idx ({}): {} disc loss: {}"
+            .format(mode, plot_idx, Y[-1]))
+        plot_idx += 1
 
-    def disc_plot_show():
-      """Render a plot of discriminator loss vs. training epoch number."""
-      plt.scatter(disc_data[0], disc_data[1], c='g', alpha=0.7, s=4,
-                  label="discriminator loss (dis step)")
-      plt.scatter(gen_data[0], gen_data[1], c='r', alpha=0.7, s=4,
-                  label="discriminator loss (gen step)")
-      plt.title("Discriminator loss")
-      plt.legend()
-      _savefig_timestamp("plot_fight_loss_disc", interactive)
-
-    gen_ep_reward = defaultdict(list)
-    rand_ep_reward = defaultdict(list)
-    exp_ep_reward = defaultdict(list)
-
-    def ep_reward_plot_add_data(env, name):
-      """Calculate and record the mean episode reward from rollouts of env."""
-      gen_policy = trainer.gen_policy
-      rand_policy = util.make_blank_policy(trainer.env)
-      exp_policy = trainer.expert_policies[-1]
-
-      gen_ret = util.rollout.mean_return(
-          gen_policy, env, n_episodes=n_episodes_per_reward_data)
-      rand_ret = util.rollout.mean_return(
-          rand_policy, env, n_episodes=n_episodes_per_reward_data)
-      exp_ret = util.rollout.mean_return(
-          exp_policy, env, n_episodes=n_episodes_per_reward_data)
-      gen_ep_reward[name].append(gen_ret)
-      rand_ep_reward[name].append(rand_ret)
-      exp_ep_reward[name].append(exp_ret)
-      tf.logging.info("generator return: {}".format(gen_ret))
-      tf.logging.info("random return: {}".format(rand_ret))
-      tf.logging.info("exp return: {}".format(exp_ret))
-
-    def ep_reward_plot_show():
-      """Render and show average episode reward plots."""
-      for name in gen_ep_reward:
-        plt.title(name + " Performance")
-        plt.xlabel("epochs")
-        plt.ylabel("Average reward per episode (n={})"
-                   .format(n_episodes_per_reward_data))
-        plt.plot(gen_ep_reward[name], label="avg gen ep reward", c="red")
-        plt.plot(rand_ep_reward[name],
-                 label="avg random ep reward", c="black")
-        plt.plot(exp_ep_reward[name], label="avg exp ep reward", c="blue")
+      def disc_plot_show():
+        """Render a plot of discriminator loss vs. training epoch number."""
+        plt.scatter(disc_data[0], disc_data[1], c='g', alpha=0.7, s=4,
+                    label="discriminator loss (dis step)")
+        plt.scatter(gen_data[0], gen_data[1], c='r', alpha=0.7, s=4,
+                    label="discriminator loss (gen step)")
+        plt.title("Discriminator loss")
         plt.legend()
-        _savefig_timestamp("plot_fight_epreward_gen", interactive)
+        _savefig_timestamp("plot_fight_loss_disc", interactive)
 
-    if n_epochs_per_plot is not None:
-      n_plots_per_epoch = 1 / n_epochs_per_plot
-    else:
-      n_plots_per_epoch = None
+      gen_ep_reward = defaultdict(list)
+      rand_ep_reward = defaultdict(list)
+      exp_ep_reward = defaultdict(list)
 
-    def should_plot_now(epoch) -> bool:
-      """For positive epochs, returns True if a plot should be rendered now.
+      def ep_reward_plot_add_data(env, name):
+        """Calculate and record the mean episode reward from rollouts of env."""
+        gen_policy = trainer.gen_policy
+        rand_policy = util.make_blank_policy(trainer.env)
+        exp_policy = trainer.expert_policies[-1]
 
-      This also controls the frequency at which `ep_reward_plot_add_data` is
-      called, because generating those rollouts is too expensive to perform
-      every timestep.
-      """
-      assert epoch >= 1
-      if n_plots_per_epoch is None:
-        return False
-      plot_num = math.floor(n_plots_per_epoch * epoch)
-      prev_plot_num = math.floor(n_plots_per_epoch * (epoch - 1))
-      assert abs(plot_num - prev_plot_num) <= 1
-      return plot_num != prev_plot_num
+        gen_ret = util.rollout.mean_return(
+            gen_policy, env, n_episodes=n_episodes_per_reward_data)
+        rand_ret = util.rollout.mean_return(
+            rand_policy, env, n_episodes=n_episodes_per_reward_data)
+        exp_ret = util.rollout.mean_return(
+            exp_policy, env, n_episodes=n_episodes_per_reward_data)
+        gen_ep_reward[name].append(gen_ret)
+        rand_ep_reward[name].append(rand_ret)
+        exp_ep_reward[name].append(exp_ret)
+        tf.logging.info("generator return: {}".format(gen_ret))
+        tf.logging.info("random return: {}".format(rand_ret))
+        tf.logging.info("exp return: {}".format(exp_ret))
 
-    # Collect data for epoch 0.
-    if n_epochs_per_plot is not None:
-      disc_plot_add_data(False)
-      ep_reward_plot_add_data(trainer.env, "Ground Truth Reward")
-      ep_reward_plot_add_data(trainer.env_train, "Train Reward")
-      ep_reward_plot_add_data(trainer.env_test, "Test Reward")
+      def ep_reward_plot_show():
+        """Render and show average episode reward plots."""
+        for name in gen_ep_reward:
+          plt.title(name + " Performance")
+          plt.xlabel("epochs")
+          plt.ylabel("Average reward per episode (n={})"
+                     .format(n_episodes_per_reward_data))
+          plt.plot(gen_ep_reward[name], label="avg gen ep reward", c="red")
+          plt.plot(rand_ep_reward[name],
+                   label="avg random ep reward", c="black")
+          plt.plot(exp_ep_reward[name], label="avg exp ep reward", c="blue")
+          plt.legend()
+          _savefig_timestamp("plot_fight_epreward_gen", interactive)
 
-    for epoch in tqdm.tqdm(range(1, n_epochs+1), desc="epoch"):
-      trainer.train_disc(n_disc_steps_per_epoch)
-      disc_plot_add_data(False)
-      trainer.train_gen(n_gen_steps_per_epoch)
-      disc_plot_add_data(True)
+      if n_epochs_per_plot is not None:
+        n_plots_per_epoch = 1 / n_epochs_per_plot
+      else:
+        n_plots_per_epoch = None
 
-      if should_plot_now(epoch):
-        disc_plot_show()
+      def should_plot_now(epoch) -> bool:
+        """For positive epochs, returns True if a plot should be rendered now.
+
+        This also controls the frequency at which `ep_reward_plot_add_data` is
+        called, because generating those rollouts is too expensive to perform
+        every timestep.
+        """
+        assert epoch >= 1
+        if n_plots_per_epoch is None:
+          return False
+        plot_num = math.floor(n_plots_per_epoch * epoch)
+        prev_plot_num = math.floor(n_plots_per_epoch * (epoch - 1))
+        assert abs(plot_num - prev_plot_num) <= 1
+        return plot_num != prev_plot_num
+
+      # Collect data for epoch 0.
+      if n_epochs_per_plot is not None:
+        disc_plot_add_data(False)
         ep_reward_plot_add_data(trainer.env, "Ground Truth Reward")
         ep_reward_plot_add_data(trainer.env_train, "Train Reward")
         ep_reward_plot_add_data(trainer.env_test, "Test Reward")
-        ep_reward_plot_show()
 
-      if checkpoint_interval is not None and epoch % checkpoint_interval == 0:
-        save(trainer, os.path.join(log_dir, "checkpoints", f"{epoch:05d}"))
+      for epoch in tqdm.tqdm(range(1, n_epochs+1), desc="epoch"):
+        trainer.train_disc(n_disc_steps_per_epoch)
+        disc_plot_add_data(False)
+        trainer.train_gen(n_gen_steps_per_epoch)
+        disc_plot_add_data(True)
 
-    save(trainer, os.path.join(log_dir, "final"))
+        if should_plot_now(epoch):
+          disc_plot_show()
+          ep_reward_plot_add_data(trainer.env, "Ground Truth Reward")
+          ep_reward_plot_add_data(trainer.env_train, "Train Reward")
+          ep_reward_plot_add_data(trainer.env_test, "Test Reward")
+          ep_reward_plot_show()
 
-    return log_dir, gen_data, disc_data, gen_ep_reward
+        if checkpoint_interval is not None and epoch % checkpoint_interval == 0:
+          save(trainer, os.path.join(log_dir, "checkpoints", f"{epoch:05d}"))
+
+      save(trainer, os.path.join(log_dir, "final"))
+
+      return log_dir, gen_data, disc_data, gen_ep_reward
 
 
 def _savefig_timestamp(prefix="", also_show=True):

--- a/imitation/scripts/train.py
+++ b/imitation/scripts/train.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 from matplotlib import pyplot as plt
 from sacred.observers import FileStorageObserver
+from stable_baselines import logger as sb_logger
 import tensorflow as tf
 import tqdm
 
@@ -83,6 +84,8 @@ def train_and_plot(_seed: int,
 
     tf.logging.info("Logging to %s", log_dir)
     os.makedirs(log_dir, exist_ok=True)
+    sb_logger.configure(folder=osp.join(log_dir, 'generator'),
+                        format_strs=['tensorboard', 'stdout'])
 
     plot_idx = 0
     gen_data = ([], [])

--- a/imitation/trainer.py
+++ b/imitation/trainer.py
@@ -78,9 +78,7 @@ class Trainer:
 
             By default this is equal to `20 * n_disc_samples_per_buffer`.
         init_tensorboard: If True, makes various discriminator
-            TensorBoard summaries. (Generator summaries appear under a
-            different runname than the discriminator summaries because they
-            are configured by initializing the stable_baselines policy).
+            TensorBoard summaries.
         debug_use_ground_truth: If True, use the ground truth reward for
             `self.train_env`.
             This disables the reward wrapping that would normally replace

--- a/imitation/util/__init__.py
+++ b/imitation/util/__init__.py
@@ -4,6 +4,6 @@ import imitation.util.rollout
 from imitation.util.util import (FeedForward32Policy, FeedForward64Policy,
                                  Layers, build_mlp, build_inputs, get_env_id,
                                  is_vec_env, load_policy, make_blank_policy,
-                                 make_save_policy_callback, make_vec_env,
-                                 maybe_load_env, save_trained_policy,
-                                 sequential)
+                                 make_save_policy_callback, make_timestamp,
+                                 make_vec_env, maybe_load_env,
+                                 save_trained_policy, sequential)

--- a/imitation/util/__init__.py
+++ b/imitation/util/__init__.py
@@ -2,7 +2,8 @@
 
 import imitation.util.rollout
 from imitation.util.util import (FeedForward32Policy, FeedForward64Policy,
-                                 apply_ff, build_inputs, get_env_id, is_vec_env,
-                                 load_policy, make_blank_policy,
+                                 Layers, build_mlp, build_inputs, get_env_id,
+                                 is_vec_env, load_policy, make_blank_policy,
                                  make_save_policy_callback, make_vec_env,
-                                 maybe_load_env, save_trained_policy)
+                                 maybe_load_env, save_trained_policy,
+                                 sequential)

--- a/imitation/util/__init__.py
+++ b/imitation/util/__init__.py
@@ -2,7 +2,7 @@
 
 import imitation.util.rollout
 from imitation.util.util import (FeedForward32Policy, FeedForward64Policy,
-                                 Layers, build_mlp, build_inputs, get_env_id,
+                                 LayersDict, build_mlp, build_inputs, get_env_id,
                                  is_vec_env, load_policy, make_blank_policy,
                                  make_save_policy_callback, make_timestamp,
                                  make_vec_env, maybe_load_env,

--- a/imitation/util/rollout.py
+++ b/imitation/util/rollout.py
@@ -4,10 +4,28 @@ from typing import Dict, List, Sequence, Tuple
 
 import gym
 import numpy as np
-from stable_baselines.common import BaseRLModel
+from stable_baselines.common.base_class import BaseRLModel
+from stable_baselines.common.policies import BasePolicy
 import tensorflow as tf
 
 from . import util  # Relative import needed to prevent cycle with __init__.py
+
+
+class RandomPolicy(BasePolicy):
+  """Returns random actions."""
+  def __init__(self, ob_space: gym.Space, ac_space: gym.Space):
+    self.ob_space = ob_space
+    self.ac_space = ac_space
+
+  def step(self, obs, state=None, mask=None, deterministic=False):
+    actions = []
+    for ob in obs:
+      assert self.ob_space.contains(ob)
+      actions.append(self.ac_space.sample())
+    return actions, None, None, None
+
+  def proba_step(self, obs, state=None, mask=None):
+    raise NotImplementedError()
 
 
 def get_action_policy(policy, observation, deterministic=False):

--- a/imitation/util/serialize.py
+++ b/imitation/util/serialize.py
@@ -1,0 +1,77 @@
+"""Helper classes to serialize classes with TensorFlow objects."""
+
+from abc import ABC, abstractmethod
+import os
+import pickle
+
+import tensorflow as tf
+
+from imitation.util import util
+
+
+def make_cls(cls, args, kwargs):
+  return cls(*args, **kwargs)
+
+
+class Serializable(ABC):
+  """Abstract mix-in defining methods to load/save model."""
+  @classmethod
+  @abstractmethod
+  def load(cls, directory):
+    """Load object plus weights from directory."""
+
+  @abstractmethod
+  def save(self, directory):
+    """Save object and weights to directory."""
+
+
+class LayersSerializable(Serializable):
+  """Serialization mix-in based on `__init__` then rehydration.
+
+  Subclsases must call the constructor with all arguments needed by `__init__`,
+  and a dictionary mapping from strings to `tf.layers.Layer` objects.
+  In most cases, you can use the following idiom:
+      ```
+      args = locals()
+      # ... your normal constructor
+      layers = # ... gather your TensorFlow objects
+      LayersSerializable.__init__(**args, layers=layers)
+      ```
+  """
+
+  def __init__(self, *args, layers: util.Layers, **kwargs):
+    self._args = args
+    self._kwargs = kwargs
+    self._checkpoint = tf.train.Checkpoint(**layers)
+
+  def __reduce__(self):
+    return (make_cls, (type(self), self._args, self._kwargs))
+
+  def save_parameters(self, directory: str) -> None:
+    self._checkpoint.save(file_prefix=os.path.join(directory, "weights"))
+
+  def load_parameters(self, directory: str) -> None:
+    restore = self._checkpoint.restore(tf.train.latest_checkpoint(directory))
+    restore.assert_consumed().run_restore_ops()
+
+  @classmethod
+  def load(cls, directory: str) -> None:
+    with open(os.path.join(directory, 'obj'), 'rb') as f:
+      obj = pickle.load(f)
+    obj.load_parameters(directory)
+    return obj
+
+  def save(self, directory: str) -> None:
+    os.makedirs(directory, exist_ok=True)
+
+    obj_path = os.path.join(directory, 'obj')
+    if not os.path.exists(obj_path):
+      # TODO(gleave): it'd be nice to support Python state changing too
+      # obj should be static (since it just consists of _args and _kwargs,
+      # set at construction). So no need to write this file multiple times.
+      # (In fact, best to avoid it -- if we were to die in the middle of this,
+      # it would invalidate previous checkpoints.)
+      with open(obj_path, 'wb') as f:
+        pickle.dump(self, f)
+
+    self._checkpoint.save(file_prefix=os.path.join(directory, "weights"))

--- a/imitation/util/serialize.py
+++ b/imitation/util/serialize.py
@@ -39,7 +39,7 @@ class LayersSerializable(Serializable):
       ```
   """
 
-  def __init__(self, *args, layers: util.Layers, **kwargs):
+  def __init__(self, *args, layers: util.LayersDict, **kwargs):
     self._args = args
     self._kwargs = kwargs
     self._checkpoint = tf.train.Checkpoint(**layers)
@@ -55,7 +55,7 @@ class LayersSerializable(Serializable):
     restore.assert_consumed().run_restore_ops()
 
   @classmethod
-  def load(cls, directory: str) -> None:
+  def load(cls, directory: str) -> "LayersSerializable":
     with open(os.path.join(directory, 'obj'), 'rb') as f:
       obj = pickle.load(f)
     obj.load_parameters(directory)

--- a/imitation/util/trainer.py
+++ b/imitation/util/trainer.py
@@ -11,9 +11,9 @@ from imitation.trainer import Trainer
 import imitation.util as util
 
 
-def init_trainer(env_id, use_gail=False,
+def init_trainer(env_id, seed=0, log_dir=None, use_gail=False,
                  use_random_expert=True,
-                 num_vec=8, discrim_scale=False,
+                 num_vec=8, parallel=True, discrim_scale=False,
                  discrim_kwargs={}, reward_kwargs={}, trainer_kwargs={},
                  make_blank_policy_kwargs={}):
   """Builds a Trainer, ready to be trained on a vectorized environment
@@ -21,6 +21,8 @@ def init_trainer(env_id, use_gail=False,
 
   Args:
     env_id (str): The string id of a gym environment.
+    seed (int): Random seed.
+    log_dir (Optoinal[str]): Directory for logging output.
     use_gail (bool): If True, then train using GAIL. If False, then train
         using AIRL.
     policy_dir (str): The directory containing the pickled experts for
@@ -35,14 +37,15 @@ def init_trainer(env_id, use_gail=False,
     make_blank_policy_kwargs: Keyword arguments passed to `make_blank_policy`,
         used to initialize the trainer.
   """
-  env = util.make_vec_env(env_id, num_vec)
+  env = util.make_vec_env(env_id, num_vec, seed=seed, parallel=parallel,
+                          log_dir=log_dir)
   gen_policy = util.make_blank_policy(env, verbose=1,
                                       **make_blank_policy_kwargs)
 
   if use_random_expert:
     expert_policies = [gen_policy]
   else:
-    expert_policies = util.load_policy(env)
+    expert_policies = util.load_policy(env_id)
     if expert_policies is None:
       raise ValueError(env)
 

--- a/imitation/util/trainer.py
+++ b/imitation/util/trainer.py
@@ -13,7 +13,7 @@ import imitation.util as util
 
 def init_trainer(env_id, seed=0, log_dir=None, use_gail=False,
                  use_random_expert=True,
-                 num_vec=8, parallel=True, discrim_scale=False,
+                 num_vec=8, parallel=False, discrim_scale=False,
                  discrim_kwargs={}, reward_kwargs={}, trainer_kwargs={},
                  make_blank_policy_kwargs={}):
   """Builds a Trainer, ready to be trained on a vectorized environment

--- a/imitation/util/trainer.py
+++ b/imitation/util/trainer.py
@@ -22,15 +22,14 @@ def init_trainer(env_id, seed=0, log_dir=None, use_gail=False,
   Args:
     env_id (str): The string id of a gym environment.
     seed (int): Random seed.
-    log_dir (Optoinal[str]): Directory for logging output.
+    log_dir (Optional[str]): Directory for logging output.
     use_gail (bool): If True, then train using GAIL. If False, then train
         using AIRL.
-    policy_dir (str): The directory containing the pickled experts for
-        generating rollouts. Only applicable if `use_random_expert` is True.
     use_random_expert (bool):
         If True, then use a blank (random) policy to generate rollouts.
         If False, then load an expert policy. Will crash if there is no expert
-        policy in `policy_dir`.
+        policy.
+    parallel (bool): If True, then use SubprocVecEnv; otherwise, DummyVecEnv.
     trainer_kwargs (dict): Aguments for the Trainer constructor.
     reward_kwargs (dict): Arguments for the `*RewardNet` constructor.
     discrim_kwargs (dict): Arguments for the `DiscrimNet*` constructor.

--- a/imitation/util/util.py
+++ b/imitation/util/util.py
@@ -245,13 +245,20 @@ def apply_ff(inputs: tf.Tensor,
              initializer: Optional[Callable] = None,
              ) -> tf.Tensor:
   """Applies a feed forward network on the inputs."""
+
   x = inputs
+  layers = []
   for i, size in enumerate(hid_sizes):
-    x = tf.layers.dense(x, size, activation=activation,
-                        kernel_initializer=initializer, name="dense" + str(i))
-  x = tf.layers.dense(x, 1, kernel_initializer=initializer,
-                      name="dense_final")
-  return tf.squeeze(x, axis=1, name=name)
+    layer = tf.layers.Dense(size, activation=activation,
+                            kernel_initializer=initializer,
+                            name="dense" + str(i))
+    layers.append(layer)
+    x = layer(x)
+  layer = tf.layers.Dense(1, kernel_initializer=initializer, name="dense_final")
+  layers.append(layer)
+  x = layer(x)
+  return x, layers
+  # return tf.squeeze(x, axis=1, name=name)
 
 
 def build_inputs(observation_space: gym.Space,

--- a/imitation/util/util.py
+++ b/imitation/util/util.py
@@ -15,7 +15,7 @@ import tensorflow as tf
 
 # TODO(adam): this should really be OrderedDict but that breaks Python
 # See https://stackoverflow.com/questions/41207128/
-Layers = Dict[str, tf.layers.Layer]
+LayersDict = Dict[str, tf.layers.Layer]
 
 
 def make_timestamp():
@@ -70,7 +70,7 @@ def make_vec_env(env_id: str,
     # Optionally, save to disk
     log_path = None
     if log_dir is not None:
-      log_subdir = os.path.join(log_dir, 'mon')
+      log_subdir = os.path.join(log_dir, 'monitor')
       os.makedirs(log_subdir, exist_ok=True)
       log_path = os.path.join(log_subdir, f'mon{i:03d}')
     return bench.Monitor(env, log_path, allow_early_resets=True)
@@ -249,8 +249,8 @@ def build_mlp(hid_sizes: Iterable[int],
               name: Optional[str] = None,
               activation: Optional[Callable] = tf.nn.relu,
               initializer: Optional[Callable] = None,
-              ) -> Layers:
-  """Constructs an MLP, returning an ordered list of layers."""
+              ) -> LayersDict:
+  """Constructs an MLP, returning an ordered dict of layers."""
   layers = collections.OrderedDict()
 
   # Hidden layers
@@ -269,7 +269,7 @@ def build_mlp(hid_sizes: Iterable[int],
 
 
 def sequential(inputs: tf.Tensor,
-               layers: Layers,
+               layers: LayersDict,
                ) -> tf.Tensor:
   """Applies a sequence of layers to an input."""
   output = inputs

--- a/imitation/util/util.py
+++ b/imitation/util/util.py
@@ -1,7 +1,7 @@
 import functools
 import glob
 import os
-from typing import Iterable, Optional, Tuple
+from typing import Callable, Iterable, Optional, Tuple
 
 import gym
 import stable_baselines
@@ -241,14 +241,15 @@ def _get_tb_log_dir(env, init_tensorboard):
 def apply_ff(inputs: tf.Tensor,
              hid_sizes: Iterable[int],
              name: Optional[str] = None,
+             activation: Optional[Callable] = tf.nn.relu,
+             initializer: Optional[Callable] = None,
              ) -> tf.Tensor:
   """Applies a feed forward network on the inputs."""
-  xavier = tf.contrib.layers.xavier_initializer
   x = inputs
   for i, size in enumerate(hid_sizes):
-    x = tf.layers.dense(x, size, activation='relu',
-                        kernel_initializer=xavier(), name="dense" + str(i))
-  x = tf.layers.dense(x, 1, kernel_initializer=xavier(),
+    x = tf.layers.dense(x, size, activation=activation,
+                        kernel_initializer=initializer, name="dense" + str(i))
+  x = tf.layers.dense(x, 1, kernel_initializer=initializer,
                       name="dense_final")
   return tf.squeeze(x, axis=1, name=name)
 

--- a/imitation/util/util.py
+++ b/imitation/util/util.py
@@ -74,8 +74,12 @@ def make_vec_env(env_id: str,
       os.makedirs(log_subdir, exist_ok=True)
       log_path = os.path.join(log_subdir, f'mon{i:03d}')
     return bench.Monitor(env, log_path, allow_early_resets=True)
-  cls = SubprocVecEnv if parallel else DummyVecEnv
-  return cls([functools.partial(make_env, i) for i in range(n_envs)])
+  env_fns = [functools.partial(make_env, i) for i in range(n_envs)]
+  if parallel:
+    # See GH hill-a/stable-baselines issue #217
+    return SubprocVecEnv(env_fns, start_method='forkserver')
+  else:
+    return DummyVecEnv(env_fns)
 
 
 def is_vec_env(env):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Configuration settings and fixtures for tests."""
+
+import pytest
+import tensorflow as tf
+
+
+@pytest.fixture
+def graph():
+  graph = tf.Graph()
+  with graph.as_default():
+    yield graph
+
+
+@pytest.fixture
+def session(graph):
+  with tf.Session(graph=graph) as sess:
+    with sess.as_default():
+      yield sess

--- a/tests/test_discrim_net.py
+++ b/tests/test_discrim_net.py
@@ -1,0 +1,75 @@
+import tempfile
+
+import gym
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from imitation.discrim_net import DiscrimNetAIRL, DiscrimNetGAIL
+from imitation.reward_net import BasicRewardNet
+from imitation.util import rollout
+
+ENVS = ['FrozenLake-v0', 'CartPole-v1', 'Pendulum-v0']
+DISCRIM_NETS = [DiscrimNetAIRL, DiscrimNetGAIL]
+
+
+def _setup_airl(env):
+  reward_net = BasicRewardNet(env.observation_space, env.action_space)
+  return DiscrimNetAIRL(reward_net)
+
+
+def _setup_gail(env):
+  return DiscrimNetGAIL(env.observation_space, env.action_space)
+
+
+DISCRIM_NET_SETUPS = {
+    DiscrimNetAIRL: _setup_airl,
+    DiscrimNetGAIL: _setup_gail,
+}
+
+
+@pytest.mark.parametrize("env_id", ENVS)
+@pytest.mark.parametrize("discrim_net_cls", DISCRIM_NETS)
+def test_discrim_net_no_crash(session, env_id, discrim_net_cls):
+  env = gym.make(env_id)
+  DISCRIM_NET_SETUPS[discrim_net_cls](env)
+
+
+@pytest.mark.parametrize("env_id", ENVS)
+@pytest.mark.parametrize("discrim_net_cls", DISCRIM_NETS)
+def test_serialize_identity(session, env_id, discrim_net_cls):
+  """Does output of deserialized discriminator match that of original?"""
+  env = gym.make(env_id)
+  original = DISCRIM_NET_SETUPS[discrim_net_cls](env)
+  random = rollout.RandomPolicy(env.observation_space, env.action_space)
+  session.run(tf.global_variables_initializer())
+
+  # TODO(gleave): is it going to break because different variable scope?
+  with tempfile.TemporaryDirectory(prefix='imitation-serialize') as tmpdir:
+    original.save(tmpdir)
+    with tf.variable_scope("loaded"):
+      loaded = discrim_net_cls.load(tmpdir)
+
+  old_obs, act, new_obs, _rew = rollout.generate_transitions(random, env,
+                                                             n_timesteps=100)
+  labels = np.random.randint(2, size=len(old_obs)).astype(np.float32)
+  log_prob = np.random.randn(len(old_obs))
+
+  feed_dict = {}
+  outputs = {'train': [], 'test': []}
+  for net in [original, loaded]:
+    feed_dict.update({
+        net.old_obs_ph: old_obs,
+        net.act_ph: act,
+        net.new_obs_ph: new_obs,
+        net.labels_ph: labels,
+        net.log_policy_act_prob_ph: log_prob,
+    })
+    outputs['train'].append(net.policy_train_reward)
+    outputs['test'].append(net.policy_test_reward)
+
+  rewards = session.run(outputs, feed_dict=feed_dict)
+
+  for key, predictions in rewards.items():
+    assert len(predictions) == 2
+    assert np.allclose(predictions[0], predictions[1])

--- a/tests/test_discrim_net.py
+++ b/tests/test_discrim_net.py
@@ -44,7 +44,6 @@ def test_serialize_identity(session, env_id, discrim_net_cls):
   random = rollout.RandomPolicy(env.observation_space, env.action_space)
   session.run(tf.global_variables_initializer())
 
-  # TODO(gleave): is it going to break because different variable scope?
   with tempfile.TemporaryDirectory(prefix='imitation-serialize') as tmpdir:
     original.save(tmpdir)
     with tf.variable_scope("loaded"):

--- a/tests/test_reward_net.py
+++ b/tests/test_reward_net.py
@@ -40,7 +40,6 @@ def test_serialize_identity(session, env_id, reward_net_cls):
   random = rollout.RandomPolicy(env.observation_space, env.action_space)
   session.run(tf.global_variables_initializer())
 
-  # TODO(gleave): is it going to break because different variable scope?
   with tempfile.TemporaryDirectory(prefix='imitation-serialize') as tmpdir:
     original.save(tmpdir)
     with tf.variable_scope("loaded"):

--- a/tests/test_reward_net.py
+++ b/tests/test_reward_net.py
@@ -1,18 +1,63 @@
+import tempfile
+
 import gym
+import numpy as np
 import pytest
 import tensorflow as tf
 
 from imitation.reward_net import BasicRewardNet, BasicShapedRewardNet
+from imitation.util import rollout
 
 ENVS = ['FrozenLake-v0', 'CartPole-v1', 'Pendulum-v0']
+REWARD_NETS = [BasicRewardNet, BasicShapedRewardNet]
 
 
 @pytest.mark.parametrize("env_id", ENVS)
-def test_init_no_crash(env_id):
+@pytest.mark.parametrize("reward_net_cls", REWARD_NETS)
+def test_init_no_crash(session, env_id, reward_net_cls):
   env = gym.make(env_id)
   for i in range(3):
     with tf.variable_scope(env_id + str(i) + "shaped"):
-      BasicShapedRewardNet(env.observation_space, env.action_space)
-    with tf.variable_scope(env_id + str(i)):
-      BasicRewardNet(env.observation_space, env.action_space)
-  tf.reset_default_graph()
+      reward_net_cls(env.observation_space, env.action_space)
+
+
+def _make_feed_dict(reward_net, rollouts):
+  old_obs, act, new_obs, _rew = rollouts
+  return {
+      reward_net.old_obs_ph: old_obs,
+      reward_net.act_ph: act,
+      reward_net.new_obs_ph: new_obs,
+  }
+
+
+@pytest.mark.parametrize("env_id", ENVS)
+@pytest.mark.parametrize("reward_net_cls", REWARD_NETS)
+def test_serialize_identity(session, env_id, reward_net_cls):
+  env = gym.make(env_id)
+  with tf.variable_scope("original"):
+    original = reward_net_cls(env.observation_space, env.action_space)
+  random = rollout.RandomPolicy(env.observation_space, env.action_space)
+  session.run(tf.global_variables_initializer())
+
+  # TODO(gleave): is it going to break because different variable scope?
+  with tempfile.TemporaryDirectory(prefix='imitation-serialize') as tmpdir:
+    original.save(tmpdir)
+    with tf.variable_scope("loaded"):
+      loaded = reward_net_cls.load(tmpdir)
+
+  assert original.observation_space == loaded.observation_space
+  assert original.action_space == loaded.action_space
+
+  rollouts = rollout.generate_transitions(random, env, n_timesteps=100)
+  feed_dict = {}
+  outputs = {'train': [], 'test': []}
+  for net in [original, loaded]:
+    feed_dict.update(_make_feed_dict(net, rollouts))
+    outputs['train'].append(net.reward_output_train)
+    outputs['test'].append(net.reward_output_test)
+
+  rewards = session.run(outputs, feed_dict=feed_dict)
+
+  for key, predictions in rewards.items():
+    assert len(predictions) == 2
+    assert np.allclose(predictions[0], predictions[1])

--- a/tests/test_reward_net.py
+++ b/tests/test_reward_net.py
@@ -33,6 +33,7 @@ def _make_feed_dict(reward_net, rollouts):
 @pytest.mark.parametrize("env_id", ENVS)
 @pytest.mark.parametrize("reward_net_cls", REWARD_NETS)
 def test_serialize_identity(session, env_id, reward_net_cls):
+  """Does output of deserialized reward network match that of original?"""
   env = gym.make(env_id)
   with tf.variable_scope("original"):
     original = reward_net_cls(env.observation_space, env.action_space)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,5 +1,4 @@
 import pytest
-import tensorflow as tf
 
 from imitation import util
 from imitation.util import rollout
@@ -9,9 +8,9 @@ use_gail_vals = [True, False]
 
 
 @pytest.fixture(autouse=True)
-def setup_and_teardown():
+def setup_and_teardown(session):
+  # Uses conftest.session fixture for everything in this file
   yield
-  tf.reset_default_graph()
 
 
 @pytest.mark.parametrize("use_gail", use_gail_vals)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -148,6 +148,6 @@ def test_wrap_learned_reward_no_crash(use_gail, env="CartPole-v1"):
   trainer.train(n_epochs=1)
 
   learned_reward_env = trainer.wrap_env_test_reward(env)
-  policy = util.make_blank_policy(env, init_tensorboard=False)
+  policy = util.make_blank_policy(env)
   policy.set_env(learned_reward_env)
   policy.learn(10)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,10 +1,18 @@
+"""Tests for imitation.trainer.Trainer and util.trainer.init_trainer."""
+import os
+
 import pytest
 
 from imitation import util
 from imitation.util import rollout
 from imitation.util.trainer import init_trainer
 
-use_gail_vals = [True, False]
+USE_GAIL = [True, False]
+IN_CODECOV = 'COV_CORE_CONFIG' in os.environ
+if IN_CODECOV:  # multiprocessing breaks codecov, disable
+  PARALLEL = [False]
+else:
+  PARALLEL = [True, False]
 
 
 @pytest.fixture(autouse=True)
@@ -13,14 +21,17 @@ def setup_and_teardown(session):
   yield
 
 
-@pytest.mark.parametrize("use_gail", use_gail_vals)
-def test_init_no_crash(use_gail, env='CartPole-v1'):
-  init_trainer(env, use_gail=use_gail)
+@pytest.mark.parametrize("use_gail", USE_GAIL)
+@pytest.mark.parametrize("parallel", PARALLEL)
+def test_init_no_crash(use_gail, parallel, env='CartPole-v1'):
+  init_trainer(env, use_gail=use_gail, parallel=parallel)
 
 
-@pytest.mark.parametrize("use_gail", use_gail_vals)
-def test_train_disc_no_crash(use_gail, env='CartPole-v1', n_timesteps=200):
-  trainer = init_trainer(env, use_gail=use_gail)
+@pytest.mark.parametrize("use_gail", USE_GAIL)
+@pytest.mark.parametrize("parallel", PARALLEL)
+def test_train_disc_no_crash(use_gail, parallel,
+                             env='CartPole-v1', n_timesteps=200):
+  trainer = init_trainer(env, use_gail=use_gail, parallel=parallel)
   trainer.train_disc()
   obs_old, act, obs_new, _ = rollout.generate_transitions(
       trainer.gen_policy, env, n_timesteps=n_timesteps)
@@ -28,14 +39,15 @@ def test_train_disc_no_crash(use_gail, env='CartPole-v1', n_timesteps=200):
                      gen_new_obs=obs_new)
 
 
-@pytest.mark.parametrize("use_gail", use_gail_vals)
-def test_train_gen_no_crash(use_gail, env='CartPole-v1', n_steps=10):
-  trainer = init_trainer(env, use_gail=use_gail)
+@pytest.mark.parametrize("use_gail", USE_GAIL)
+@pytest.mark.parametrize("parallel", PARALLEL)
+def test_train_gen_no_crash(use_gail, parallel, env='CartPole-v1', n_steps=10):
+  trainer = init_trainer(env, use_gail=use_gail, parallel=parallel)
   trainer.train_gen(n_steps)
 
 
 @pytest.mark.expensive
-@pytest.mark.parametrize("use_gail", use_gail_vals)
+@pytest.mark.parametrize("use_gail", USE_GAIL)
 def test_train_disc_improve_D(use_gail, env='CartPole-v1', n_timesteps=200,
                               n_steps=1000):
   trainer = init_trainer(env, use_gail=use_gail)
@@ -92,7 +104,7 @@ def test_train_disc_then_gen(use_gail=False, env='CartPole-v1', n_timesteps=200,
 
 
 @pytest.mark.expensive
-@pytest.mark.parametrize("use_gail", use_gail_vals)
+@pytest.mark.parametrize("use_gail", USE_GAIL)
 def test_train_no_crash(use_gail, env='CartPole-v1'):
   trainer = init_trainer(env, use_gail=use_gail)
   trainer.train(n_epochs=1)
@@ -137,7 +149,7 @@ def test_trained_policy_better_than_random(use_gail, env='CartPole-v1',
 
 
 @pytest.mark.expensive
-@pytest.mark.parametrize("use_gail", use_gail_vals)
+@pytest.mark.parametrize("use_gail", USE_GAIL)
 def test_wrap_learned_reward_no_crash(use_gail, env="CartPole-v1"):
   """
   Briefly train with AIRL, and then used the learned reward to wrap


### PR DESCRIPTION
Currently we can train reward networks but have no way to persist them, which makes them of somewhat limited use. This adds a `save` and `load` method to `RewardNet` and `DiscrimNet`. Additionally, I add logic to `scripts/train.py` to save checkpoints and the final model. This required making some new logging logic, so I also added some logging for Stable Baselines and generally tidied up. This doesn't touch logging of statistics for the *discriminator* (which is still via matplotlib PNGs, and should be amended in another PR).

Concretely, I created a new ABC `Serializable` with abstract `save` and `load` methods, with a concrete implementation `LayersSerializable`. This saves the constructor arguments, needed to reconstruct the graph, and uses `tf.train.Checkpoint` to save/restore the parameter variables.

I'm not that happy with the current implementation. The main bugbears are: (a) mix-in for this is potentially overkill, and (b) has no way of serializing mutable Python state. It really feels like this is something that TensorFlow or a library built on top of it should be taking care of. But I've not been able to find anything. Keras makes this easy, but it's too limited for our purposes.

One alternative would be use `tf.train.Saver` instead of `tf.train.Checkpoint`. This would have the advantage that the user could would not need to keep track of TensorFlow state (instead, we just save all variables within a scope). However, TF 2.x removes the notion of variable collections, and `Saver` is deprecated for this reason. So it gives a cleaner upgrade path.

The other major bugbear is in serializing recursive structures. What I've done for `DiscrimNetAIRL` is really hacky: I save the wrapped reward network in a subdirectory!

If anyone can think of a better way of doing this I'd be very happy to hear it.