### PR TITLE
Add "rollouts_from_policy" command to `data_collect`

### DIFF
--- a/src/imitation/scripts/config/data_collect.py
+++ b/src/imitation/scripts/config/data_collect.py
@@ -19,7 +19,7 @@ def data_collect_defaults():
 
   rollout_save_interval = 100  # Num updates between saves (<=0 disables)
   rollout_save_final = True  # If True, save after training is finished.
-  rollout_save_n_samples = 2000  # Min timesteps saved per file, optional.
+  rollout_save_n_timesteps = 2000  # Min timesteps saved per file, optional.
   rollout_save_n_episodes = None  # Num episodes saved per file, optional.
 
   policy_save_interval = -1  # Num updates between saves (<=0 disables)

--- a/src/imitation/scripts/config/data_collect.py
+++ b/src/imitation/scripts/config/data_collect.py
@@ -19,7 +19,8 @@ def data_collect_defaults():
 
   rollout_save_interval = 100  # Num updates between saves (<=0 disables)
   rollout_save_final = True  # If True, save after training is finished.
-  rollout_save_n_samples = 2000  # Minimum number of timesteps saved per file.
+  rollout_save_n_samples = 2000  # Min timesteps saved per file, optional.
+  rollout_save_n_episodes = None  # Num episodes saved per file, optional.
 
   policy_save_interval = -1  # Num updates between saves (<=0 disables)
   policy_save_final = True  # If True, save after training is finished.

--- a/src/imitation/scripts/data_collect.py
+++ b/src/imitation/scripts/data_collect.py
@@ -25,7 +25,7 @@ def data_collect(_seed: int,
 
                  rollout_save_interval: int = 0,
                  rollout_save_final: bool = False,
-                 rollout_save_n_samples: Optional[int] = None,
+                 rollout_save_n_timesteps: Optional[int] = None,
                  rollout_save_n_episodes: Optional[int] = None,
 
                  policy_save_interval: int = -1,
@@ -53,12 +53,12 @@ def data_collect(_seed: int,
           don't save intermediate updates.
       rollout_save_final: If True, then save rollouts right after training is
           finished.
-      rollout_save_n_samples: The minimum number of timesteps saved in every
-          file. Could be more than `rollout_save_n_samples` because trajectories
+      rollout_save_n_timesteps: The minimum number of timesteps saved in every
+          file. Could be more than `rollout_save_n_timesteps` because trajectories
           are saved by episode rather than by transition. Must set exactly one
-          of `rollout_save_n_samples` and `rollout_save_n_episodes`.
+          of `rollout_save_n_timesteps` and `rollout_save_n_episodes`.
       rollout_save_n_episodes: The number of episodes saved in every
-          file. Must set exactly one of `rollout_save_n_samples` and
+          file. Must set exactly one of `rollout_save_n_timesteps` and
           `rollout_save_n_episodes`.
       policy_save_interval: The number of training updates between saves. Has
           the same semantics are `rollout_save_interval`.
@@ -88,7 +88,7 @@ def data_collect(_seed: int,
     callback = _make_callback(
       vec_normalize,
       rollout_save_interval,
-      rollout_save_n_samples,
+      rollout_save_n_timesteps,
       rollout_save_n_episodes,
       rollout_dir, policy_save_interval, policy_dir)
 
@@ -98,7 +98,7 @@ def data_collect(_seed: int,
     if rollout_save_final:
       util.rollout.save(
         rollout_dir, policy, "final",
-        n_timesteps=rollout_save_n_samples,
+        n_timesteps=rollout_save_n_timesteps,
         n_episodes=rollout_save_n_episodes)
     if policy_save_final:
       output_dir = os.path.join(policy_dir, "final")
@@ -108,7 +108,7 @@ def data_collect(_seed: int,
 def _make_callback(vec_normalize: Optional[VecNormalize] = None,
 
                    rollout_save_interval: Optional[int] = None,
-                   rollout_save_n_samples: Optional[int] = None,
+                   rollout_save_n_timesteps: Optional[int] = None,
                    rollout_save_n_episodes: Optional[int] = None,
                    rollout_dir: Optional[str] = None,
 
@@ -131,7 +131,7 @@ def _make_callback(vec_normalize: Optional[VecNormalize] = None,
     if rollout_ok and step % rollout_save_interval == 0:
       util.rollout.save(
         rollout_dir, policy, step,
-        n_timesteps=rollout_save_n_samples,
+        n_timesteps=rollout_save_n_timesteps,
         n_episodes=rollout_save_n_episodes)
     if policy_ok and step % policy_save_interval == 0:
       output_dir = os.path.join(policy_dir, f'{step:5d}')

--- a/src/imitation/scripts/data_collect.py
+++ b/src/imitation/scripts/data_collect.py
@@ -130,28 +130,37 @@ def rollouts_from_policy(
   rollout_save_n_timesteps: int,
   rollout_save_n_episodes: int,
   log_dir: str,
-  policy_path: str,
+  policy_path: Optional[str] = None,
   policy_type: str = "ppo2",
   env_name: str = "CartPole-v1",
   parallel: bool = True,
+  rollout_save_dir: Optional[str] = None,
 ) -> None:
   """Loads a saved policy and generates rollouts.
 
-  Save path is f"{log_dir}/rollouts/{env_name}.pkl". Unlisted arguments are the
-  same as in `data_collect()`.
+  Default save path is f"{log_dir}/rollouts/{env_name}.pkl". Change to
+  f"{rollout_save_dir}/{env_name}.pkl" by setting the `rollout_save_dir` param.
+  Unlisted arguments are the same as in `data_collect()`.
 
   Args:
       policy_type: Argument to `imitation.policies.serialize.load_policy`.
-      policy_path: Argument to `imitation.policies.serialize.load_policy`.
+      policy_path: Argument to `imitation.policies.serialize.load_policy`. If
+          not provided, then defaults to f"expert_models/{env_name}".
+      rollout_save_dir: Rollout pickle is saved in this directory as
+          f"{env_name}.pkl".
   """
   venv = util.make_vec_env(env_name, num_vec, seed=_seed,
                            parallel=parallel, log_dir=log_dir)
+
+  if policy_path is None:
+    policy_path = f"expert_models/{env_name}"
   policy = serialize.load_policy(policy_type, policy_path, venv)
 
-  rollout_dir = osp.join(log_dir, "rollouts")
-  os.makedirs(rollout_dir, exist_ok=True)
+  if rollout_save_dir is None:
+    rollout_save_dir = osp.join(log_dir, "rollouts")
+  os.makedirs(rollout_save_dir, exist_ok=True)
 
-  util.rollout.save(rollout_dir, policy, venv,
+  util.rollout.save(rollout_save_dir, policy, venv,
                     basename=env_name,
                     n_timesteps=rollout_save_n_timesteps,
                     n_episodes=rollout_save_n_episodes,

--- a/src/imitation/scripts/data_collect.py
+++ b/src/imitation/scripts/data_collect.py
@@ -10,6 +10,7 @@ import tensorflow as tf
 from imitation.policies import serialize
 from imitation.scripts.config.data_collect import data_collect_ex
 import imitation.util as util
+from imitation.util.rollout import _validate_generate_params
 
 
 @data_collect_ex.main
@@ -66,6 +67,8 @@ def rollouts_and_policy(
       policy_save_final: If True, then save the policy right after training is
           finished.
   """
+  _validate_generate_params(rollout_save_n_timesteps, rollout_save_n_episodes)
+
   with util.make_session():
     tf.logging.set_verbosity(tf.logging.INFO)
     sb_logger.configure(folder=osp.join(log_dir, 'rl'),

--- a/src/imitation/scripts/data_collect.py
+++ b/src/imitation/scripts/data_collect.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 from imitation.policies import serialize
 from imitation.scripts.config.data_collect import data_collect_ex
 import imitation.util as util
-from imitation.util.rollout import _validate_generate_params
+from imitation.util.rollout import _validate_traj_generate_params
 
 
 @data_collect_ex.main
@@ -67,7 +67,8 @@ def rollouts_and_policy(
       policy_save_final: If True, then save the policy right after training is
           finished.
   """
-  _validate_generate_params(rollout_save_n_timesteps, rollout_save_n_episodes)
+  _validate_traj_generate_params(rollout_save_n_timesteps,
+                                 rollout_save_n_episodes)
 
   with util.make_session():
     tf.logging.set_verbosity(tf.logging.INFO)

--- a/src/imitation/util/rollout.py
+++ b/src/imitation/util/rollout.py
@@ -116,24 +116,18 @@ def generate_trajectories(policy, env, *, n_timesteps=None, n_episodes=None,
   else:
     get_action = functools.partial(get_action_policy, policy)
 
-  # Validate end condition arguments and initialize end conditions.
+  # Validate end condition arguments.
   _validate_generate_params(n_timesteps, n_episodes)
-  if n_timesteps is not None:
-    end_cond = "timesteps"
-  elif n_episodes is not None:
-    end_cond = "episodes"
-  else:
-    raise RuntimeError  # Should never reach this statement after validation.
 
   # Implements end-condition logic.
   def rollout_done():
-    if end_cond == "timesteps":
+    if n_timesteps is not None:
+      assert n_episodes is None
       # accidentallyquadratic.tumblr.com
       return sum(len(t["obs"]) - 1 for t in trajectories) >= n_timesteps
-    elif end_cond == "episodes":
-      return len(trajectories) >= n_episodes
     else:
-      raise RuntimeError(end_cond)
+      assert n_episodes is not None
+      return len(trajectories) >= n_episodes
 
   # Collect rollout tuples.
   trajectories = []

--- a/src/imitation/util/rollout.py
+++ b/src/imitation/util/rollout.py
@@ -66,6 +66,17 @@ class _TrajectoryAccumulator:
     self.partial_trajectories[idx].append(step_dict)
 
 
+def _validate_generate_params(n_timesteps, n_episodes):
+  if n_timesteps is not None and n_episodes is not None:
+    raise ValueError("n_timesteps and n_episodes were both set")
+  elif n_timesteps is not None:
+    assert n_timesteps > 0
+  elif n_episodes is not None:
+    assert n_episodes > 0
+  else:
+    raise ValueError("Set at least one of n_timesteps and n_episodes")
+
+
 def generate_trajectories(policy, env, *, n_timesteps=None, n_episodes=None,
                           deterministic_policy=False,
                           ) -> TrajectoryList:
@@ -106,17 +117,14 @@ def generate_trajectories(policy, env, *, n_timesteps=None, n_episodes=None,
     get_action = functools.partial(get_action_policy, policy)
 
   # Validate end condition arguments and initialize end conditions.
-  if n_timesteps is not None and n_episodes is not None:
-    raise ValueError("n_timesteps and n_episodes were both set")
-  elif n_timesteps is not None:
-    assert n_timesteps > 0
+  _validate_generate_params(n_timesteps, n_episodes)
+  if n_timesteps is not None:
     end_cond = "timesteps"
   elif n_episodes is not None:
-    assert n_episodes > 0
     end_cond = "episodes"
     episodes_elapsed = 0
   else:
-    raise ValueError("Set at least one of n_timesteps and n_episodes")
+    raise RuntimeError  # Should never reach this statement after validation.
 
   # Implements end-condition logic.
   def rollout_done():

--- a/src/imitation/util/rollout.py
+++ b/src/imitation/util/rollout.py
@@ -404,7 +404,7 @@ def generate_transitions_multiple(policies, env, n_timesteps, *, truncate=True,
 
 def save(rollout_dir: str,
          policy: BaseRLModel,
-         step: Union[str, int],
+         basename: Union[str, int],
          **kwargs,
          ) -> None:
     """Generate policy rollouts and save them to a pickled TrajectoryList.
@@ -412,15 +412,15 @@ def save(rollout_dir: str,
     Args:
         rollout_dir: Path to the save directory.
         policy: The stable baselines policy.
-        step: Either the integer training step or "final" to mark that training
-            is finished. Used as a suffix in the save file's basename.
+        basename: The file is saved as `f"{basename}.pkl"`. Usually this is
+            the step number, or "final".
         n_timesteps (Optional[int]): `n_timesteps` argument from
             `generate_trajectories`.
         n_episodes (Optional[int]): `n_episodes` argument from
             `generate_trajectories`.
         truncate (bool): `truncate` argument from `generate_trajectories`.
     """
-    path = os.path.join(rollout_dir, f'{step}.pkl')
+    path = os.path.join(rollout_dir, f'{basename}.pkl')
     traj_list = generate_trajectories(policy, policy.get_env(), **kwargs)
     with open(path, "wb") as f:
       pickle.dump(traj_list, f)

--- a/src/imitation/util/rollout.py
+++ b/src/imitation/util/rollout.py
@@ -122,7 +122,6 @@ def generate_trajectories(policy, env, *, n_timesteps=None, n_episodes=None,
     end_cond = "timesteps"
   elif n_episodes is not None:
     end_cond = "episodes"
-    episodes_elapsed = 0
   else:
     raise RuntimeError  # Should never reach this statement after validation.
 
@@ -152,10 +151,6 @@ def generate_trajectories(policy, env, *, n_timesteps=None, n_episodes=None,
     obs_old_batch = obs_batch
     act_batch, _ = get_action(obs_old_batch, deterministic=deterministic_policy)
     obs_batch, rew_batch, done_batch, _ = env.step(act_batch)
-
-    # Track episode count.
-    if end_cond == "episodes":
-      episodes_elapsed += np.sum(done_batch)
 
     # Don't save tuples if there is a done. The new_obs for any environment
     # is incorrect for any timestep where there is an episode end.

--- a/src/imitation/util/rollout.py
+++ b/src/imitation/util/rollout.py
@@ -66,7 +66,7 @@ class _TrajectoryAccumulator:
     self.partial_trajectories[idx].append(step_dict)
 
 
-def _validate_generate_params(n_timesteps, n_episodes):
+def _validate_traj_generate_params(n_timesteps, n_episodes):
   if n_timesteps is not None and n_episodes is not None:
     raise ValueError("n_timesteps and n_episodes were both set")
   elif n_timesteps is not None:
@@ -117,7 +117,7 @@ def generate_trajectories(policy, env, *, n_timesteps=None, n_episodes=None,
     get_action = functools.partial(get_action_policy, policy)
 
   # Validate end condition arguments.
-  _validate_generate_params(n_timesteps, n_episodes)
+  _validate_traj_generate_params(n_timesteps, n_episodes)
 
   # Implements end-condition logic.
   def rollout_done():

--- a/src/imitation/util/rollout.py
+++ b/src/imitation/util/rollout.py
@@ -5,8 +5,11 @@ import os
 import pickle
 from typing import Dict, List, Optional, Tuple, Union
 
+import gym
 import numpy as np
 from stable_baselines.common.base_class import BaseRLModel
+from stable_baselines.common.policies import BasePolicy
+from stable_baselines.common.vec_env import VecEnv
 import tensorflow as tf
 
 from imitation.policies.base import get_action_policy
@@ -403,7 +406,8 @@ def generate_transitions_multiple(policies, env, n_timesteps, *, truncate=True,
 
 
 def save(rollout_dir: str,
-         policy: BaseRLModel,
+         policy: Union[BaseRLModel, BasePolicy],
+         env: Union[gym.Env, VecEnv],
          basename: Union[str, int],
          **kwargs,
          ) -> None:
@@ -412,6 +416,7 @@ def save(rollout_dir: str,
     Args:
         rollout_dir: Path to the save directory.
         policy: The stable baselines policy.
+        env: The environment.
         basename: The file is saved as `f"{basename}.pkl"`. Usually this is
             the step number, or "final".
         n_timesteps (Optional[int]): `n_timesteps` argument from
@@ -421,7 +426,7 @@ def save(rollout_dir: str,
         truncate (bool): `truncate` argument from `generate_trajectories`.
     """
     path = os.path.join(rollout_dir, f'{basename}.pkl')
-    traj_list = generate_trajectories(policy, policy.get_env(), **kwargs)
+    traj_list = generate_trajectories(policy, env, **kwargs)
     with open(path, "wb") as f:
       pickle.dump(traj_list, f)
     tf.logging.info("Dumped demonstrations to {}.".format(path))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -8,7 +8,7 @@ from imitation.scripts.train import train_ex
 
 
 def test_data_collect_main():
-  """Smoke test for imitation.scripts.data_collect"""
+  """Smoke test for imitation.scripts.data_collect.rollouts_and_policy"""
   run = data_collect_ex.run(
       named_configs=['cartpole', 'fast'],
       # codecov does not like parallel
@@ -18,8 +18,9 @@ def test_data_collect_main():
 
 
 def test_data_collect_rollouts_from_policy():
-  """Smoke test for imitation.scripts.data_collect"""
-  with tempfile.TemporaryDirectory(prefix='imitation-serialize') as tmpdir:
+  """Smoke test for imitation.scripts.data_collect.rollouts_from_policy"""
+  with tempfile.TemporaryDirectory(prefix='imitation-data_collect-policy',
+                                   ) as tmpdir:
     run = data_collect_ex.run(
         command_name="rollouts_from_policy",
         named_configs=['cartpole', 'fast'],

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,17 +1,33 @@
 """Smoke tests for CLI programs in imitation.scripts.*"""
 
+import tempfile
+
 from imitation.scripts.data_collect import data_collect_ex
 from imitation.scripts.policy_eval import policy_eval_ex
 from imitation.scripts.train import train_ex
 
 
-def test_data_collect():
+def test_data_collect_main():
   """Smoke test for imitation.scripts.data_collect"""
   run = data_collect_ex.run(
       named_configs=['cartpole', 'fast'],
       # codecov does not like parallel
       config_updates={'parallel': False},
   )
+  assert run.status == 'COMPLETED'
+
+
+def test_data_collect_rollouts_from_policy():
+  """Smoke test for imitation.scripts.data_collect"""
+  with tempfile.TemporaryDirectory(prefix='imitation-serialize') as tmpdir:
+    run = data_collect_ex.run(
+        command_name="rollouts_from_policy",
+        named_configs=['cartpole', 'fast'],
+        config_updates=dict(
+          parallel=False,  # codecov does not like parallel
+          rollout_save_dir=tmpdir,
+          policy_path="expert_models/PPO2_CartPole-v1_0",
+        ))
   assert run.status == 'COMPLETED'
 
 


### PR DESCRIPTION
The new command takes a `policy_path` and loads the pickled policy to generate `rollouts/{env_name}.pkl`.

I used this to [generate demonstrations](https://gist.github.com/shwang/010da07b8d0a1232f3f5f00ac18bfa5b) from Adam's trained expert models in #57.