### PR TITLE
Use Stable Baselines 2.7.0 PyPi release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,7 @@ setup(
         'gym',
         'numpy>=1.15',
         'tqdm',
-        # FIXME: replace this with PyPI link once commit 2bc3c8722b9eb5 appears
-        # in a release (will probably happen in version 2.6.1 or 2.7, when they
-        # come out)
-        'stable-baselines @ git+https://github.com/hill-a/stable-baselines.git',
+        'stable-baselines>=2.7.0',
         'jax!=0.1.37',
         'jaxlib~=0.1.20',
         # sacred==0.7.5 build is broken without pymongo


### PR DESCRIPTION
Stable Baselines just made a release, we can stop tracking their master branch