### PR TITLE
Model-based environment ABC for non-tabular environments

### DIFF
--- a/docs/imitation.rst
+++ b/docs/imitation.rst
@@ -21,10 +21,10 @@ imitation.discrim\_net module
    :undoc-members:
    :show-inheritance:
 
-imitation.model\_env module
----------------------------
+imitation.resettable\_env module
+--------------------------------
 
-.. automodule:: imitation.model_env
+.. automodule:: imitation.resettable_env
    :members:
    :undoc-members:
    :show-inheritance:

--- a/src/imitation/examples/model_envs.py
+++ b/src/imitation/examples/model_envs.py
@@ -3,7 +3,7 @@
 import gym
 import numpy as np
 
-from imitation.model_env import TabularModelEnv
+from imitation.resettable_env import TabularModelEnv
 
 
 def make_random_trans_mat(

--- a/src/imitation/examples/model_envs.py
+++ b/src/imitation/examples/model_envs.py
@@ -282,3 +282,17 @@ for width, height, horizon in [(7, 4, 9), (15, 6, 18), (100, 20, 110)]:
         'use_xy_obs': use_xy,
         'horizon': horizon,
     })
+
+# These parameter choices are somewhat arbitrary.
+# We anticipate most users will want to construct RandomMDP directly.
+gym.register('imitation/Random-v0',
+             entry_point='imitation.examples.model_envs:RandomMDP',
+             kwargs={
+                 'n_states': 16,
+                 'n_actions': 3,
+                 'branch_factor': 2,
+                 'horizon': 20,
+                 'random_obs': True,
+                 'obs_dim': 5,
+                 'generator_seed': 42,
+             })

--- a/src/imitation/examples/model_envs.py
+++ b/src/imitation/examples/model_envs.py
@@ -3,7 +3,7 @@
 import gym
 import numpy as np
 
-from imitation.model_env import ModelBasedEnv
+from imitation.model_env import TabularModelEnv
 
 
 def make_random_trans_mat(
@@ -79,7 +79,7 @@ def make_obs_mat(
   return obs_mat
 
 
-class RandomMDP(ModelBasedEnv):
+class RandomMDP(TabularModelEnv):
   """AN MDP with a random transition matrix.
 
   Random matrix is created by `make_random_trans_mat`."""
@@ -142,7 +142,7 @@ class RandomMDP(ModelBasedEnv):
     return self._horizon
 
 
-class CliffWorld(ModelBasedEnv):
+class CliffWorld(TabularModelEnv):
   """A grid world like this::
 
        0 1 2 3 4 5 6 7 8 9

--- a/src/imitation/model_env.py
+++ b/src/imitation/model_env.py
@@ -15,6 +15,7 @@ class ModelBasedEnv(gym.Env, abc.ABC):
     self._state_space = None
     self._observation_space = None
     self._action_space = None
+    self.cur_state = None
     self._n_actions_taken = None
     self.seed()
 
@@ -98,8 +99,6 @@ class TabularModelEnv(ModelBasedEnv, abc.ABC):
     so that error can be thrown if reset() is not called), attributes for
     cached observation/action space, and random seed for rollouts."""
     super().__init__()
-    self.cur_state = None
-    self._n_actions_taken = None
 
   @property
   def state_space(self) -> gym.Space:

--- a/src/imitation/model_env.py
+++ b/src/imitation/model_env.py
@@ -16,7 +16,6 @@ class ModelBasedEnv(gym.Env, abc.ABC):
   """Number of steps taken so far"""
 
   def __init__(self):
-    # TODO(gleave): anything needed here?
     self.n_actions_taken = None
 
   def seed(self, seed=None):

--- a/src/imitation/model_env.py
+++ b/src/imitation/model_env.py
@@ -17,6 +17,7 @@ class ModelBasedEnv(gym.Env, abc.ABC):
 
   def __init__(self):
     self.n_actions_taken = None
+    self.seed()
 
   def seed(self, seed=None):
     if seed is None:
@@ -86,7 +87,6 @@ class TabularModelEnv(ModelBasedEnv, abc.ABC):
     # succeed.
     self._action_space = None
     self._observation_space = None
-    self.seed()
 
   @property
   def action_space(self):

--- a/src/imitation/model_env.py
+++ b/src/imitation/model_env.py
@@ -19,24 +19,6 @@ class ModelBasedEnv(gym.Env, abc.ABC):
     self._n_actions_taken = None
     self.seed()
 
-  @property
-  @abc.abstractmethod
-  def state_space(self) -> gym.Space:
-    """State space. Often same as observation_space, but differs in POMDPs."""
-    return self._state_space
-
-  @property
-  @abc.abstractmethod
-  def observation_space(self) -> gym.Space:
-    """Observation space. Return value of reset() and component of step()."""
-    return self._observation_space
-
-  @property
-  @abc.abstractmethod
-  def action_space(self) -> gym.Space:
-    """Action space. Parameter type of step()."""
-    return self._action_space
-
   @abc.abstractmethod
   def initial_state(self):
     """Samples from the initial state distribution."""
@@ -56,6 +38,21 @@ class ModelBasedEnv(gym.Env, abc.ABC):
   @abc.abstractmethod
   def obs_from_state(self, state):
     """Returns observation produced by a given state."""
+
+  @property
+  def state_space(self) -> gym.Space:
+    """State space. Often same as observation_space, but differs in POMDPs."""
+    return self._state_space
+
+  @property
+  def observation_space(self) -> gym.Space:
+    """Observation space. Return value of reset() and component of step()."""
+    return self._observation_space
+
+  @property
+  def action_space(self) -> gym.Space:
+    """Action space. Parameter type of step()."""
+    return self._action_space
 
   @property
   def n_actions_taken(self) -> int:

--- a/src/imitation/resettable_env.py
+++ b/src/imitation/resettable_env.py
@@ -8,8 +8,13 @@ from gym import spaces
 import numpy as np
 
 
-class ModelBasedEnv(gym.Env, abc.ABC):
-  """ABC for environments with known dynamics."""
+class ResettableEnv(gym.Env, abc.ABC):
+  """ABC for environments that are resettable.
+
+  Specifically, these environments provide oracle access to sample from
+  the initial state distribution and transition dynamics, and compute the
+  reward and termination condition. Almost all simulated environments can
+  meet these criteria."""
 
   def __init__(self):
     self._state_space = None
@@ -46,7 +51,7 @@ class ModelBasedEnv(gym.Env, abc.ABC):
 
   @property
   def observation_space(self) -> gym.Space:
-    """Observation space. Return value of reset() and component of step()."""
+    """Observation space. Return type of reset() and component of step()."""
     return self._observation_space
 
   @property
@@ -87,7 +92,7 @@ class ModelBasedEnv(gym.Env, abc.ABC):
     return obs, rew, done, infos
 
 
-class TabularModelEnv(ModelBasedEnv, abc.ABC):
+class TabularModelEnv(ResettableEnv, abc.ABC):
   """ABC for tabular environments with known dynamics."""
 
   def __init__(self):

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -7,7 +7,6 @@ import pytest
 # Unused imports are for side-effect of registering environments
 import imitation.examples.airl_envs  # noqa: F401
 import imitation.examples.model_envs  # noqa: F401
-import imitation.model_env
 
 ENV_NAMES = [env_spec.id for env_spec in gym.envs.registration.registry.all()
              if env_spec.id.startswith('imitation/')]
@@ -79,7 +78,7 @@ def test_premature_step(env):
 @pytest.mark.parametrize("env_name", ENV_NAMES)
 def test_model_based(env):
   """Smoke test for each of the ModelBasedEnv methods with basic type checks."""
-  if not isinstance(env, imitation.model_env.ModelBasedEnv):
+  if not hasattr(env, 'state_space'):  # pragma: no cover
     pytest.skip("This test is only for subclasses of ModelBasedEnv.")
 
   old_state = env.initial_state()

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -15,7 +15,7 @@ DETERMINISTIC_ENVS = []
 
 
 def matches_list(env_name, patterns):
-  for pattern in patterns:
+  for pattern in patterns:  # pragma: no cover
     if re.match(pattern, env_name):
       return True
   return False

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,4 +1,7 @@
+import re
+
 import gym
+import numpy as np
 import pytest
 
 # Import for side-effect of registering environment
@@ -8,10 +11,22 @@ import imitation.examples.model_envs  # noqa: F401
 ENV_NAMES = [env_spec.id for env_spec in gym.envs.registration.registry.all()
              if env_spec.id.startswith('imitation/')]
 
+DETERMINISTIC_ENVS = [
+    r"imitation/CliffWorld.*-v0",
+    r"imitation/PointMaze.*-v0",
+]
 
-@pytest.mark.parametrize("env_name", ENV_NAMES)
-def test_envs(env_name):
-  """Check that our custom environments don't crash on `step`, and `reset`."""
+
+@pytest.fixture
+def is_deterministic(env_name):
+  for pattern in DETERMINISTIC_ENVS:
+    if re.compile(pattern).match(env_name):
+      return True
+  return False
+
+
+@pytest.fixture
+def env(env_name):
   try:
     env = gym.make(env_name)
   except gym.error.DependencyNotInstalled as e:  # pragma: no cover
@@ -19,9 +34,51 @@ def test_envs(env_name):
       pytest.skip("Requires `mujoco_py`, which isn't installed.")
     else:
       raise
-  env.reset()
+  return env
+
+
+@pytest.mark.parametrize("env_name", ENV_NAMES)
+def test_seed(env, is_deterministic):
+  # With the same seed, should always give the same result
+  seeds = env.seed(42)
+  assert isinstance(seeds, list)
+  assert len(seeds) > 0
+
+  first_obs = env.reset()
+  env.seed(42)
+  second_obs = env.reset()
+  assert np.all(first_obs == second_obs)
+
+  # For non-deterministic environments, if we try enough seeds we should
+  # eventually get a different result. For deterministic environments, all
+  # seeds will produce the same starting state.
+  same_obs = True
+  for i in range(10):
+    env.seed(i)
+    obs = env.reset()
+    if not np.all(obs == first_obs):
+      same_obs = False
+      break
+
+  assert same_obs == is_deterministic
+
+
+@pytest.mark.parametrize("env_name", ENV_NAMES)
+def test_rollout(env):
+  """Check custom environments have correct types on `step` and `reset`."""
   obs_space = env.observation_space
+
+  seeds = env.seed()
+  assert isinstance(seeds, list)
+  assert len(seeds) > 0
+
+  obs = env.reset()
+  assert obs in obs_space
+
   for _ in range(4):
     act = env.action_space.sample()
     obs, rew, done, info = env.step(act)
     assert obs in obs_space
+    assert isinstance(rew, float)
+    assert isinstance(done, bool)
+    assert isinstance(info, dict)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -79,11 +79,6 @@ def test_premature_step(env):
 def test_rollout(env):
   """Check custom environments have correct types on `step` and `reset`."""
   obs_space = env.observation_space
-
-  seeds = env.seed()
-  assert isinstance(seeds, list)
-  assert len(seeds) > 0
-
   obs = env.reset()
   assert obs in obs_space
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,7 +1,6 @@
 import re
 
 import gym
-from gym.envs.mujoco import mujoco_env
 import numpy as np
 import pytest
 
@@ -66,7 +65,9 @@ def test_seed(env, env_name):
 
 @pytest.mark.parametrize("env_name", ENV_NAMES)
 def test_premature_step(env):
-  if isinstance(env, mujoco_env.MujocoEnv):
+  if hasattr(env, 'sim') and hasattr(env, 'model'):  # pragma: no cover
+    # We can't use isinstance since importing mujoco_py will fail on
+    # machines without MuJoCo installed
     pytest.skip("MuJoCo environments cannot perform this check.")
 
   act = env.action_space.sample()

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -77,6 +77,9 @@ def test_seed(env, env_name):
       obs_new = step_new[0]
       if np.any(obs_a != obs_new):
         same_obs = False
+        break
+    if not same_obs:
+      break
 
   is_deterministic = matches_list(env_name, DETERMINISTIC_ENVS)
   assert same_obs == is_deterministic

--- a/tests/test_tabular.py
+++ b/tests/test_tabular.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from imitation.examples.model_envs import RandomMDP
-from imitation.model_env import ModelBasedEnv
+from imitation.model_env import TabularModelEnv
 from imitation.tabular_irl import (LinearRewardModel, MLPRewardModel, mce_irl,
                                    mce_occupancy_measures, mce_partition_fh)
 
@@ -97,7 +97,7 @@ def test_policy_om_random_mdp():
   assert np.allclose(np.sum(D), mdp.horizon)
 
 
-class ReasonableMDP(ModelBasedEnv):
+class ReasonableMDP(TabularModelEnv):
   observation_matrix = np.array([
       [3, -5, -1, -1, -4, 5, 3, 0],
       # state 1 (top)

--- a/tests/test_tabular.py
+++ b/tests/test_tabular.py
@@ -1,5 +1,6 @@
 """Test tabular environments and tabular MCE IRL."""
 
+import gym
 import jax.experimental.optimizers as jaxopt
 import numpy as np
 import pytest
@@ -74,6 +75,7 @@ def test_random_mdp():
 def test_policy_om_random_mdp():
   """Test that optimal policy occupancy measure ("om") for a random MDP makes
   sense."""
+  mdp = gym.make('imitation/Random-v0')
   mdp = RandomMDP(n_states=16,
                   n_actions=3,
                   branch_factor=2,

--- a/tests/test_tabular.py
+++ b/tests/test_tabular.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from imitation.examples.model_envs import RandomMDP
-from imitation.model_env import TabularModelEnv
+from imitation.resettable_env import TabularModelEnv
 from imitation.tabular_irl import (LinearRewardModel, MLPRewardModel, mce_irl,
                                    mce_occupancy_measures, mce_partition_fh)
 
@@ -76,13 +76,6 @@ def test_policy_om_random_mdp():
   """Test that optimal policy occupancy measure ("om") for a random MDP makes
   sense."""
   mdp = gym.make('imitation/Random-v0')
-  mdp = RandomMDP(n_states=16,
-                  n_actions=3,
-                  branch_factor=2,
-                  horizon=20,
-                  random_obs=True,
-                  obs_dim=5,
-                  generator_seed=42)
   V, Q, pi = mce_partition_fh(mdp)
   assert np.all(np.isfinite(V))
   assert np.all(np.isfinite(Q))


### PR DESCRIPTION
This PR introduces a new abstract class for model-based environments that does not make any assumption about the observation/action space. The current `ModelBasedEnv` is renamed to `TabularModelEnv` and subclasses this.

There are a very broad class of environments in common use that are model-based but not tabular. Any MuJoCo environment, for example -- although exposing the dynamics of MuJoCo environments is a little involved due to internal state in the optimizer (see e.g. https://github.com/HumanCompatibleAI/adversarial-policies/blob/master/src/aprl/agents/monte_carlo.py#L12)

Although we don't currently have algorithms that can benefit from model-based but non-tabular environments, this seems like a plausible category: there've been various discussions of trying model-based RL and IRL. Additionally, it's useful for post-hoc analysis of reward models. For example, it lets you compute a variety of state-action-next state distributions, e.g. you can randomly sample an observation and action and then compute the next state. Having a state distribution is essential for knowing what areas of the reward model to evaluate and which can be safely ignored (unreachable states, physically impossible transitions, etc).
