### PR TITLE
Create a registry for policies

### DIFF
--- a/src/imitation/policies/serialize.py
+++ b/src/imitation/policies/serialize.py
@@ -79,8 +79,12 @@ def _load_stable_baselines(cls: Type[BaseRLModel],
   return f
 
 
-policy_registry.register('random', value=registry.env_to_space(RandomPolicy))
-policy_registry.register('zero', value=registry.env_to_space(ZeroPolicy))
+policy_registry.register(
+    'random',
+    value=registry.build_loader_fn_require_space(RandomPolicy))
+policy_registry.register(
+    'zero',
+    value=registry.build_loader_fn_require_space(ZeroPolicy))
 
 STABLE_BASELINES_CLASSES = {
     'ppo1': (stable_baselines.PPO1, 'policy_pi'),

--- a/src/imitation/policies/serialize.py
+++ b/src/imitation/policies/serialize.py
@@ -1,7 +1,7 @@
 """Load serialized policies of different types."""
 
 import os
-from typing import Callable, Dict, Optional, Type, Union
+from typing import Callable, Optional, Type, Union
 
 import gym
 import stable_baselines
@@ -11,8 +11,11 @@ from stable_baselines.common.vec_env import VecEnv, VecNormalize
 import tensorflow as tf
 
 from imitation.policies.base import RandomPolicy, ZeroPolicy
+from imitation.util import registry
 
 PolicyLoaderFn = Callable[[str, Union[gym.Env, VecEnv]], BasePolicy]
+
+policy_registry: registry.Registry[PolicyLoaderFn] = registry.Registry()
 
 
 class NormalizePolicy(BasePolicy):
@@ -76,26 +79,17 @@ def _load_stable_baselines(cls: Type[BaseRLModel],
   return f
 
 
-def _load_random(path: str, env: gym.Env) -> RandomPolicy:
-  return RandomPolicy(env.observation_space, env.action_space)
-
-
-def _load_zero(path: str, env: gym.Env) -> ZeroPolicy:
-  return ZeroPolicy(env.observation_space, env.action_space)
-
+policy_registry.register('random', value=registry.env_to_space(RandomPolicy))
+policy_registry.register('zero', value=registry.env_to_space(ZeroPolicy))
 
 STABLE_BASELINES_CLASSES = {
     'ppo1': (stable_baselines.PPO1, 'policy_pi'),
     'ppo2': (stable_baselines.PPO2, 'act_model'),
 }
 
-
-AGENT_LOADERS: Dict[str, PolicyLoaderFn] = {
-    'random': _load_random,
-    'zero': _load_zero,
-}
 for k, (cls, attr) in STABLE_BASELINES_CLASSES.items():
-  AGENT_LOADERS[k] = _load_stable_baselines(cls, attr)
+  fn = _load_stable_baselines(cls, attr)
+  policy_registry.register(k, value=fn)
 
 
 def load_policy(policy_type: str, policy_path: str,
@@ -103,13 +97,11 @@ def load_policy(policy_type: str, policy_path: str,
   """Load serialized policy.
 
   Args:
-    policy_type: A key in `AGENT_LOADERS`, e.g. `ppo2`.
+    policy_type: A key in `policy_registry`, e.g. `ppo2`.
     policy_path: A path on disk where the policy is stored.
     env: An environment that the policy is to be used with.
   """
-  agent_loader = AGENT_LOADERS.get(policy_type)
-  if agent_loader is None:
-    raise ValueError(f"Unrecognized agent type '{policy_type}'")
+  agent_loader = policy_registry.get(policy_type)
   return agent_loader(policy_path, env)
 
 

--- a/src/imitation/policies/serialize.py
+++ b/src/imitation/policies/serialize.py
@@ -1,7 +1,7 @@
 """Load serialized policies of different types."""
 
 import os
-from typing import Callable, Optional, Type, Union
+from typing import Callable, Optional, Type
 
 import gym
 import stable_baselines
@@ -13,7 +13,7 @@ import tensorflow as tf
 from imitation.policies.base import RandomPolicy, ZeroPolicy
 from imitation.util import registry
 
-PolicyLoaderFn = Callable[[str, Union[gym.Env, VecEnv]], BasePolicy]
+PolicyLoaderFn = Callable[[str, VecEnv], BasePolicy]
 
 policy_registry: registry.Registry[PolicyLoaderFn] = registry.Registry()
 
@@ -93,16 +93,16 @@ for k, (cls, attr) in STABLE_BASELINES_CLASSES.items():
 
 
 def load_policy(policy_type: str, policy_path: str,
-                env: Union[gym.Env, VecEnv]) -> BasePolicy:
+                venv: VecEnv) -> BasePolicy:
   """Load serialized policy.
 
   Args:
     policy_type: A key in `policy_registry`, e.g. `ppo2`.
     policy_path: A path on disk where the policy is stored.
-    env: An environment that the policy is to be used with.
+    venv: An environment that the policy is to be used with.
   """
   agent_loader = policy_registry.get(policy_type)
-  return agent_loader(policy_path, env)
+  return agent_loader(policy_path, venv)
 
 
 def save_stable_model(output_dir: str,

--- a/src/imitation/util/registry.py
+++ b/src/imitation/util/registry.py
@@ -45,7 +45,7 @@ class Registry(Generic[T]):
       self._values[key] = load(self._indirect[key])
     return self._values[key]
 
-  def register(self, key: str,
+  def register(self, key: str, *,
                value: Optional[T] = None,
                indirect: Optional[str] = None):
     if key in self._values or key in self._indirect:
@@ -62,15 +62,15 @@ class Registry(Generic[T]):
       self._indirect[key] = indirect
 
 
-def env_to_space(cls: Type[T], **kwargs) -> LoaderFn:
+def build_loader_fn_require_space(cls: Type[T], **kwargs) -> LoaderFn:
   """Converts a factory taking observation and action space into a LoaderFn."""
   def f(path: str, venv: VecEnv) -> T:
     return cls(venv.observation_space, venv.action_space, **kwargs)
   return f
 
 
-def env_only(policy_cls: Type[T], **kwargs) -> LoaderFn:
+def build_loader_fn_require_env(cls: Type[T], **kwargs) -> LoaderFn:
   """Converts a factory taking an environment into a LoaderFn."""
   def f(path: str, venv: VecEnv) -> T:
-    return policy_cls(venv, **kwargs)
+    return cls(venv, **kwargs)
   return f

--- a/src/imitation/util/registry.py
+++ b/src/imitation/util/registry.py
@@ -1,0 +1,77 @@
+import importlib
+from typing import Callable, Generic, Optional, Type, TypeVar, Union
+
+import gym
+from stable_baselines.common.vec_env import VecEnv
+
+T = TypeVar("T")
+LoaderFn = Callable[[str, Union[gym.Env, VecEnv]], T]
+"""The type stored in Registry is commonly an instance of LoaderFn."""
+
+
+def load(name):
+  """Load an attribute in format path.to.module:attribute."""
+  module_name, attr_name = name.split(":")
+  module = importlib.import_module(module_name)
+  attr = getattr(module, attr_name)
+  return attr
+
+
+class Registry(Generic[T]):
+  """A registry mapping IDs to type T objects, with support for lazy loading.
+
+  The registry allows for insertion and retrieval. Modification of existing
+  elements is not allowed.
+
+  If the registered item is a string, it is assumed to be a path to an attribute
+  in the form path.to.module:attribute. In this case, the module is loaded
+  only if and when the registered item is retrieved.
+
+  This is helpful both to reduce overhead from importing unused modules,
+  and when some modules may have additional dependencies that are not installed
+  in all deployments.
+
+  Note: This is a similar idea to gym.EnvRegistry.
+  """
+
+  def __init__(self):
+    self._values = {}
+    self._indirect = {}
+
+  def get(self, key: str) -> T:
+    if key not in self._values and key not in self._indirect:
+      raise KeyError(f"Key '{key}' is not registered.")
+
+    if key not in self._values:
+      self._values[key] = load(self._indirect[key])
+    return self._values[key]
+
+  def register(self, key: str,
+               value: Optional[T] = None,
+               indirect: Optional[str] = None):
+    if key in self._values or key in self._indirect:
+      raise KeyError(f"Duplicate registration for '{key}'")
+
+    provided_args = sum([value is not None, indirect is not None])
+    if provided_args != 1:
+      raise ValueError("Must provide exactly one of 'value' and 'indirect',"
+                       f"{provided_args} have been provided.")
+
+    if value is not None:
+      self._values[key] = value
+    else:
+      self._indirect[key] = indirect
+
+
+def env_to_space(cls: Type[T], **kwargs) -> LoaderFn:
+  """Converts a factory taking observation and action space into a LoaderFn."""
+  def f(path: str, env: Union[gym.Env, VecEnv]) -> T:
+    return cls(env.observation_space, env.action_space, **kwargs)
+  return f
+
+
+def env_only(policy_cls: Type[T], **kwargs) -> LoaderFn:
+  """Converts a factory taking an environment into a LoaderFn."""
+  def f(path: str, env: gym.Env) -> T:
+    return policy_cls(env, **kwargs)
+  return f

--- a/src/imitation/util/registry.py
+++ b/src/imitation/util/registry.py
@@ -1,11 +1,10 @@
 import importlib
-from typing import Callable, Generic, Optional, Type, TypeVar, Union
+from typing import Callable, Generic, Optional, Type, TypeVar
 
-import gym
 from stable_baselines.common.vec_env import VecEnv
 
 T = TypeVar("T")
-LoaderFn = Callable[[str, Union[gym.Env, VecEnv]], T]
+LoaderFn = Callable[[str, VecEnv], T]
 """The type stored in Registry is commonly an instance of LoaderFn."""
 
 
@@ -65,13 +64,13 @@ class Registry(Generic[T]):
 
 def env_to_space(cls: Type[T], **kwargs) -> LoaderFn:
   """Converts a factory taking observation and action space into a LoaderFn."""
-  def f(path: str, env: Union[gym.Env, VecEnv]) -> T:
-    return cls(env.observation_space, env.action_space, **kwargs)
+  def f(path: str, venv: VecEnv) -> T:
+    return cls(venv.observation_space, venv.action_space, **kwargs)
   return f
 
 
 def env_only(policy_cls: Type[T], **kwargs) -> LoaderFn:
   """Converts a factory taking an environment into a LoaderFn."""
-  def f(path: str, env: gym.Env) -> T:
-    return policy_cls(env, **kwargs)
+  def f(path: str, venv: VecEnv) -> T:
+    return policy_cls(venv, **kwargs)
   return f

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -52,6 +52,7 @@ def assert_equal_rollout(rollout_a, rollout_b):
 
 @pytest.mark.parametrize("env_name", ENV_NAMES)
 def test_seed(env, env_name):
+  env.action_space.seed(0)
   actions = [env.action_space.sample() for _ in range(10)]
 
   # With the same seed, should always get the same result
@@ -69,7 +70,7 @@ def test_seed(env, env_name):
   # eventually get a different result. For deterministic environments, all
   # seeds will produce the same starting state.
   same_obs = True
-  for i in range(10):
+  for i in range(20):
     env.seed(i)
     new_rollout = rollout(env, actions)
     for step_a, step_new in zip(rollout_a, new_rollout):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,36 @@
+"""Tests for util.registry."""
+
+import pytest
+
+from imitation.util import registry
+
+
+def test_lazy():
+  """Test indirect/lazy loading of registered values."""
+  reg = registry.Registry()
+
+  reg.register('nomodule', indirect='this.module.does.not.exist:foobar')
+  with pytest.raises(ImportError):
+    reg.get('nomodule')
+
+  reg.register('noattribute', indirect='imitation:attr_does_not_exist')
+  with pytest.raises(AttributeError):
+    reg.get('noattribute')
+
+  reg.register('exists', indirect='math:pi')
+  val = reg.get('exists')
+  import math
+  assert val == math.pi
+
+
+def test_keys():
+  reg = registry.Registry()
+
+  with pytest.raises(KeyError, match="not registered"):
+    reg.get('foobar')
+
+  reg.register(key='foobar', value='fizzbuzz')
+  assert reg.get('foobar') == 'fizzbuzz'
+
+  with pytest.raises(KeyError, match="Duplicate registration"):
+    reg.register(key='foobar', value='fizzbuzz')

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -17,6 +17,9 @@ def test_lazy():
   with pytest.raises(AttributeError):
     reg.get('noattribute')
 
+  with pytest.raises(ValueError, match="exactly one of"):
+    reg.register(key='wrongargs', value=3.14, indirect='math:pi')
+
   reg.register('exists', indirect='math:pi')
   val = reg.get('exists')
   import math


### PR DESCRIPTION
Currently we are using a dict to map policy types (e.g. `'ppo2'`, `'random'`) to loader functions. This is a little awkward as if you want to add a policy, you have two options: modify `policies/serialize.py` directly (not an option for external code) or monkey-patch the dictionary.

This PR creates a registry object, which is like a insertion and retrieval only dictionary with support for lazy loading. This is inspired by Gym's `EnvRegistry`, although quite a bit simpler. User code creating new policies can call `imitation.policies.serialize.policy_registry.register`.

I've written the registry class to be generic. I expect it could also be useful for storing loaders for reward models.