### PR TITLE
Bugfixes in imitation.train script

### DIFF
--- a/src/imitation/scripts/config/train.py
+++ b/src/imitation/scripts/config/train.py
@@ -49,9 +49,13 @@ def train_defaults():
 
 
 @train_ex.config
-def logging(env_name, log_root):
+def paths(env_name, log_root):
     log_dir = os.path.join(log_root, env_name.replace('/', '_'),
                            util.make_timestamp())
+    # Recommended user sets rollout_glob manually
+    rollout_glob = os.path.join("output", "data_collect",
+                                env_name.replace('/', '_'),
+                                "*", "rollouts", "final.pkl")
 
 
 @train_ex.named_config

--- a/src/imitation/scripts/train.py
+++ b/src/imitation/scripts/train.py
@@ -35,6 +35,7 @@ def save(trainer, save_path):
 @train_ex.main
 def train_and_plot(_seed: int,
                    env_name: str,
+                   rollout_glob: str,
                    log_dir: str,
                    *,
                    n_epochs: int = 100,
@@ -95,7 +96,8 @@ def train_and_plot(_seed: int,
   assert n_epochs_per_plot is None or n_epochs_per_plot >= 1
 
   with util.make_session():
-    trainer = init_trainer(env_name, seed=_seed, log_dir=log_dir,
+    trainer = init_trainer(env_name, rollout_glob=rollout_glob,
+                           seed=_seed, log_dir=log_dir,
                            **init_trainer_kwargs)
 
     tf.logging.info("Logging to %s", log_dir)

--- a/src/imitation/scripts/train.py
+++ b/src/imitation/scripts/train.py
@@ -17,6 +17,7 @@ from stable_baselines import logger as sb_logger
 import tensorflow as tf
 import tqdm
 
+from imitation.policies import serialize
 from imitation.scripts.config.train import train_ex
 import imitation.util as util
 from imitation.util.trainer import init_trainer
@@ -29,7 +30,8 @@ def save(trainer, save_path):
   trainer.discrim.save(os.path.join(save_path, "discrim"))
   # TODO(gleave): unify this with the saving logic in data_collect?
   # (Needs #43 to be merged before attempting.)
-  trainer._gen_policy.save(os.path.join(save_path, "gen_policy"))
+  serialize.save_stable_model(os.path.join(save_path, "gen_policy"),
+                              trainer._gen_policy)
 
 
 @train_ex.main

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -50,6 +50,10 @@ def test_train():
       'init_trainer_kwargs': {
           # codecov does not like parallel
           'parallel': False,
+          # Rollouts are small, decrease size of buffer to avoid warning
+          'trainer_kwargs': {
+              'n_disc_samples_per_buffer': 50,
+          },
       },
       'log_root': 'output/tests/train',
       'rollout_glob': "tests/data/rollouts/CartPole*.pkl",

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -50,9 +50,9 @@ def test_train():
       'init_trainer_kwargs': {
           # codecov does not like parallel
           'parallel': False,
-          'rollout_glob': "tests/data/rollouts/CartPole*.pkl",
       },
       'log_root': 'output/tests/train',
+      'rollout_glob': "tests/data/rollouts/CartPole*.pkl",
   }
   run = train_ex.run(
       named_configs=['cartpole', 'gail', 'fast'],


### PR DESCRIPTION
In `master`, running `python -m imitation.scripts.train` fails since `init_trainer` expects a `rollout_glob` argument but this is not passed by `imitation.scripts.train`. You have to set it explicitly via `init_trainer_kwargs.rollout_glob`.

An additional problem is that you cannot load with e.g. `policy_eval` the policies saved, since they are using a slightly different directory layout to `data_collect`.

This PR adds a top-level config parameter `rollout_glob` and sets it to a reasonable default value, and uses the same directory structure as `data_collect`.