### PR TITLE
train_experts: Save results.txt and build zip file

### DIFF
--- a/experiments/train_experts.sh
+++ b/experiments/train_experts.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 
+# This script trains experts for AIRL and GAIL benchmark scripts.
+# When training is finished, it reports the mean episode reward of each
+# expert and builds a zip file of expert models that can be used for
+# `experiments/gail_benchmark.sh`.
+
 ENVS+="acrobot cartpole mountain_car "
 ENVS+="reacher half_cheetah hopper ant humanoid swimmer walker "
 ENVS+="two_d_maze custom_ant disabled_ant "
+
 SEEDS="0 1 2"
 
 if $(command -v gdate > /dev/null); then
@@ -12,10 +18,11 @@ else
 fi
 
 TIMESTAMP=$(${DATE_CMD} --iso-8601=seconds)
-OUTPUT_DIR=output/train_experts/${TIMESTAMP}/
+OUTPUT_DIR="output/train_experts/${TIMESTAMP}"
+RESULTS_FILE="results.txt"
 
 echo "Writing logs in ${OUTPUT_DIR}"
-
+# Train experts.
 parallel -j 25% --header : --progress --results ${OUTPUT_DIR}/parallel/ \
   python -m imitation.scripts.expert_demos \
   with \
@@ -23,3 +30,39 @@ parallel -j 25% --header : --progress --results ${OUTPUT_DIR}/parallel/ \
   seed={seed} \
   log_root=${OUTPUT_DIR} \
   ::: env ${ENVS} ::: seed ${SEEDS}
+
+pushd $OUTPUT_DIR
+shopt -s failglob  # Catch obvious errors by reporting glob match fails.
+
+# Display and save mean episode reward to ${RESULTS_FILE}.
+find . -name stdout | xargs tail -n 15 | grep -E '(==|ep_reward_mean)' | tee ${RESULTS_FILE}
+
+# For easy zip archiving into the correct format, build symlinks to the
+# first experts corresponding to each ${env_name}.
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/train_experts.XXX")
+
+for env_name in */; do
+  env_name=${env_name::-1}  # Remove trailing "/"
+  if [ $env_name == "parallel" ]; then
+    # Not actually an env name; this is a log dir for the parallel command.
+    continue
+  fi
+
+  for policy_dir in ${env_name}/*/policies/final; do
+    ln -s "$(pwd)/${policy_dir}" "${tmp_dir}/${env_name}"
+    break  # Only use the first expert.
+  done
+done
+
+# Build zipfile using the directory structure corresponding to the symlinks
+# from before.
+ZIP_FILE=$(pwd)/experts.zip
+zip -v ${ZIP_FILE} ${RESULTS_FILE}
+
+pushd ${tmp_dir}
+zip -rv ${ZIP_FILE} */
+popd
+echo "Expert zip saved to ${ZIP_FILE}"
+
+shopt -u failglob
+popd

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -144,7 +144,7 @@ def rollouts_from_policy(
   rollout_save_n_timesteps: int,
   rollout_save_n_episodes: int,
   log_dir: str,
-  policy_path: Optional[str] = None,
+  policy_path: str,
   policy_type: str = "ppo2",
   env_name: str = "CartPole-v1",
   parallel: bool = True,
@@ -165,9 +165,6 @@ def rollouts_from_policy(
   """
   venv = util.make_vec_env(env_name, num_vec, seed=_seed,
                            parallel=parallel, log_dir=log_dir)
-
-  if policy_path is None:
-    policy_path = f"expert_models/{env_name}"
   policy = serialize.load_policy(policy_type, policy_path, venv)
 
   if rollout_save_dir is None:


### PR DESCRIPTION
Modifies the script to automatically build the zip file that I previously was building manually. Also archives a `results.txt` file into the zip file, containing:
```
...
==> ./parallel/env/half_cheetah/seed/2/stdout <==                                                                                                                                                           
| ep_reward_mean     | 2.41e+03     |                                                                                                                                                                       
==> ./parallel/env/half_cheetah/seed/1/stdout <==                                                                                                                                                           
| ep_reward_mean     | 3.82e+03     |                                       
==> ./parallel/env/custom_ant/seed/0/stdout <==                                              
| ep_reward_mean     | 1.83e+03     |                                    
==> ./parallel/env/custom_ant/seed/2/stdout <==    
...
```

Note that the zip file only saves one expert model for each environment. This is because `gail_benchmark.sh` expects to find a single model at `{env_name}/`.