### PR TITLE
Ensure log directories are unique

### DIFF
--- a/src/imitation/scripts/config/data_collect.py
+++ b/src/imitation/scripts/config/data_collect.py
@@ -31,7 +31,7 @@ def data_collect_defaults():
 @data_collect_ex.config
 def logging(env_name, log_root):
   log_dir = os.path.join(log_root, env_name.replace('/', '_'),
-                         util.make_timestamp())
+                         util.make_unique_timestamp())
 
 
 @data_collect_ex.named_config

--- a/src/imitation/scripts/config/policy_eval.py
+++ b/src/imitation/scripts/config/policy_eval.py
@@ -22,7 +22,7 @@ def replay_defaults():
 @policy_eval_ex.config
 def logging(log_root, env_name):
   log_dir = os.path.join(log_root, env_name.replace("/", "_"),
-                         util.make_timestamp())
+                         util.make_unique_timestamp())
 
 
 @policy_eval_ex.named_config

--- a/src/imitation/scripts/config/train.py
+++ b/src/imitation/scripts/config/train.py
@@ -51,7 +51,7 @@ def train_defaults():
 @train_ex.config
 def logging(env_name, log_root):
     log_dir = os.path.join(log_root, env_name.replace('/', '_'),
-                           util.make_timestamp())
+                           util.make_unique_timestamp())
 
 
 @train_ex.named_config

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -4,6 +4,7 @@ import datetime
 import functools
 import os
 from typing import Callable, Dict, Iterable, Optional, Tuple, Type, Union
+import uuid
 
 import gym
 import stable_baselines
@@ -19,9 +20,12 @@ import tensorflow as tf
 LayersDict = Dict[str, tf.layers.Layer]
 
 
-def make_timestamp():
+def make_unique_timestamp():
+  """Timestamp, with random value added to avoid collisions."""
   ISO_TIMESTAMP = "%Y%m%d_%H%M%S"
-  return datetime.datetime.now().strftime(ISO_TIMESTAMP)
+  timestamp = datetime.datetime.now().strftime(ISO_TIMESTAMP)
+  random_uuid = uuid.uuid4().hex
+  return f"{timestamp}_{random_uuid}"
 
 
 def maybe_load_env(env_or_str, vectorize=True):


### PR DESCRIPTION
Currently log directories are constructed by environment name plus timestamp. When the same script is invoked at almost the same time (as in e.g. `parallel` jobs), the timestamps can be identical. This PR adds a random UUID to the end of each log directory to ensure uniqueness.