### PR TITLE
Time limit

### DIFF
--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -308,6 +308,7 @@ def init_trainer(env_id: str,
                  use_gail: bool = False,
                  num_vec: int = 8,
                  parallel: bool = False,
+                 max_episode_steps: Optional[int] = None,
                  max_n_files: int = 1,
                  scale: bool = True,
                  airl_entropy_weight: float = 1.0,
@@ -335,6 +336,8 @@ def init_trainer(env_id: str,
         using AIRL.
     num_vec: The number of vectorized environments.
     parallel: If True, then use SubprocVecEnv; otherwise, DummyVecEnv.
+    max_episode_steps: If specified, wraps VecEnv in TimeLimit wrapper with
+        this episode length before returning.
     max_n_files: If provided, then only load the most recent `max_n_files`
         files, as sorted by modification times.
     policy_dir: The directory containing the pickled experts for
@@ -349,7 +352,7 @@ def init_trainer(env_id: str,
         used to initialize the trainer.
   """
   env = util.make_vec_env(env_id, num_vec, seed=seed, parallel=parallel,
-                          log_dir=log_dir)
+                          log_dir=log_dir, max_episode_steps=max_episode_steps)
   gen_policy = util.init_rl(env, verbose=1,
                             **make_blank_policy_kwargs)
 

--- a/src/imitation/scripts/config/eval_policy.py
+++ b/src/imitation/scripts/config/eval_policy.py
@@ -13,6 +13,7 @@ def replay_defaults():
   timesteps = int(1e4)  # number of timesteps to evaluate
   num_vec = 1  # number of environments in parallel
   parallel = False  # Use SubprocVecEnv (generally faster if num_vec>1)
+  max_episode_steps = None  # Set to positive int to limit episode horizons
 
   render = True  # render to screen
   render_fps = 60  # -1 to render at full speed

--- a/src/imitation/scripts/config/eval_policy.py
+++ b/src/imitation/scripts/config/eval_policy.py
@@ -35,3 +35,4 @@ def logging(log_root, env_name):
 @eval_policy_ex.named_config
 def fast():
   timesteps = int(1e2)
+  max_episode_steps = int(1e2)

--- a/src/imitation/scripts/config/expert_demos.py
+++ b/src/imitation/scripts/config/expert_demos.py
@@ -15,6 +15,7 @@ def expert_demos_defaults():
   num_vec = 8  # Number of environments in VecEnv
   parallel = True  # Use SubprocVecEnv (generally faster if num_vec>1)
   normalize = True  # Use VecNormalize
+  max_episode_steps = None  # Set to positive int to limit episode horizons
   make_blank_policy_kwargs = dict(DEFAULT_BLANK_POLICY_KWARGS)
 
   # If specified, overrides the ground-truth environment reward

--- a/src/imitation/scripts/config/expert_demos.py
+++ b/src/imitation/scripts/config/expert_demos.py
@@ -39,16 +39,6 @@ def logging(env_name, log_root):
                          util.make_unique_timestamp())
 
 
-# Shared settings
-
-ant_shared_locals = dict(
-    make_blank_policy_kwargs=dict(
-        n_steps=2048,  # batch size of 2048*8=16384 due to num_vec
-    ),
-    total_timesteps=int(5e6),
-)
-
-
 # Standard Gym env configs
 
 @expert_demos_ex.named_config
@@ -140,3 +130,14 @@ def fast():
   """Intended for testing purposes: small # of updates, ends quickly."""
   total_timesteps = int(1e4)
   max_episode_steps = int(1e4)
+
+
+# Shared settings
+
+ant_shared_locals = dict(
+    make_blank_policy_kwargs=dict(
+        n_steps=2048,  # batch size of 2048*8=16384 due to num_vec
+    ),
+    total_timesteps=int(5e6),
+    max_episode_steps=500,  # To match `inverse_rl` settings.
+)

--- a/src/imitation/scripts/config/expert_demos.py
+++ b/src/imitation/scripts/config/expert_demos.py
@@ -139,3 +139,4 @@ def two_d_maze():
 def fast():
   """Intended for testing purposes: small # of updates, ends quickly."""
   total_timesteps = int(1e4)
+  max_episode_steps = int(1e4)

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -184,3 +184,4 @@ def fast():
       n_expert_demos=1,
       parallel=False,  # easier to debug with everything in one process
   )
+  max_episode_steps = int(1e2)

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -183,5 +183,5 @@ def fast():
   init_trainer_kwargs = dict(
       n_expert_demos=1,
       parallel=False,  # easier to debug with everything in one process
+      max_episode_steps=int(1e2),
   )
-  max_episode_steps = int(1e2)

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -14,65 +14,65 @@ train_ex = sacred.Experiment("train_adversarial", interactive=True)
 
 @train_ex.config
 def train_defaults():
-    env_name = "CartPole-v1"  # environment to train on
-    n_epochs = 50
-    n_episodes_eval = 50  # Num of episodes for final mean ground truth return
-    n_disc_steps_per_epoch = 50
-    n_gen_steps_per_epoch = 2048
-    use_gail = True
-    airl_entropy_weight = 1.0
+  env_name = "CartPole-v1"  # environment to train on
+  n_epochs = 50
+  n_episodes_eval = 50  # Num of episodes for final mean ground truth return
+  n_disc_steps_per_epoch = 50
+  n_gen_steps_per_epoch = 2048
+  use_gail = True
+  airl_entropy_weight = 1.0
 
-    init_trainer_kwargs = dict(
-        num_vec=8,  # NOTE: changing this also changes the effective n_steps!
-        parallel=True,  # Use SubprocVecEnv (generally faster if num_vec>1)
-        max_episode_steps=None,  # Set to positive int to limit episode horizons
-        scale=True,
+  init_trainer_kwargs = dict(
+      num_vec=8,  # NOTE: changing this also changes the effective n_steps!
+      parallel=True,  # Use SubprocVecEnv (generally faster if num_vec>1)
+      max_episode_steps=None,  # Set to positive int to limit episode horizons
+      scale=True,
 
-        reward_kwargs=dict(
-            theta_units=[32, 32],
-            phi_units=[32, 32],
-        ),
+      reward_kwargs=dict(
+          theta_units=[32, 32],
+          phi_units=[32, 32],
+      ),
 
-        trainer_kwargs=dict(
-            n_disc_samples_per_buffer=1000,
-            # Setting buffer capacity and disc samples to 1000 effectively
-            # disables the replay buffer. This seems to improve convergence
-            # speed, but may come at a cost of stability.
-            gen_replay_buffer_capacity=1000,
-        ),
+      trainer_kwargs=dict(
+          n_disc_samples_per_buffer=1000,
+          # Setting buffer capacity and disc samples to 1000 effectively
+          # disables the replay buffer. This seems to improve convergence
+          # speed, but may come at a cost of stability.
+          gen_replay_buffer_capacity=1000,
+      ),
 
-        make_blank_policy_kwargs=dict(policy_class=base.FeedForward32Policy,
-                                      **DEFAULT_BLANK_POLICY_KWARGS),
-    )
+      make_blank_policy_kwargs=dict(policy_class=base.FeedForward32Policy,
+                                    **DEFAULT_BLANK_POLICY_KWARGS),
+  )
 
-    log_root = os.path.join("output", "train_adversarial")  # output directory
-    checkpoint_interval = 5  # num epochs between checkpoints (<=0 disables)
+  log_root = os.path.join("output", "train_adversarial")  # output directory
+  checkpoint_interval = 5  # num epochs between checkpoints (<=0 disables)
 
 
 @train_ex.config
 def paths(env_name, log_root):
-    log_dir = os.path.join(log_root, env_name.replace('/', '_'),
-                           util.make_unique_timestamp())
-    # Recommended user sets rollout_glob manually
-    rollout_glob = os.path.join("output", "expert_demos",
-                                env_name.replace('/', '_'),
-                                "*", "rollouts", "final.pkl")
+  log_dir = os.path.join(log_root, env_name.replace('/', '_'),
+                         util.make_unique_timestamp())
+  # Recommended user sets rollout_glob manually
+  rollout_glob = os.path.join("output", "expert_demos",
+                              env_name.replace('/', '_'),
+                              "*", "rollouts", "final.pkl")
 
 
 # Training algorithm configs
 
 @train_ex.named_config
 def gail():
-    init_trainer_kwargs = dict(
-        use_gail=True,
-    )
+  init_trainer_kwargs = dict(
+      use_gail=True,
+  )
 
 
 @train_ex.named_config
 def airl():
-    init_trainer_kwargs = dict(
-        use_gail=False,
-    )
+  init_trainer_kwargs = dict(
+      use_gail=False,
+  )
 
 
 # Standard Gym env configs
@@ -85,26 +85,26 @@ def acrobot():
 
 @train_ex.named_config
 def ant():
-    env_name = "Ant-v2"
-    n_epochs = 2000
+  env_name = "Ant-v2"
+  locals().update(**ant_shared_locals)
 
 
 @train_ex.named_config
 def cartpole():
-    env_name = "CartPole-v1"
-    init_trainer_kwargs = dict(
-        scale=False,
-    )
+  env_name = "CartPole-v1"
+  init_trainer_kwargs = dict(
+      scale=False,
+  )
 
 
 @train_ex.named_config
 def half_cheetah():
-    env_name = "HalfCheetah-v2"
-    n_epochs = 1000
+  env_name = "HalfCheetah-v2"
+  n_epochs = 1000
 
-    init_trainer_kwargs = dict(
-        airl_entropy_weight=0.1,
-    )
+  init_trainer_kwargs = dict(
+      airl_entropy_weight=0.1,
+  )
 
 
 @train_ex.named_config
@@ -126,7 +126,7 @@ def mountain_car():
 
 @train_ex.named_config
 def pendulum():
-    env_name = "Pendulum-v0"
+  env_name = "Pendulum-v0"
 
 
 @train_ex.named_config
@@ -160,13 +160,13 @@ def two_d_maze():
 @train_ex.named_config
 def custom_ant():
   env_name = "imitation/CustomAnt-v0"
-  n_epochs = 2000
+  locals().update(**ant_shared_locals)
 
 
 @train_ex.named_config
 def disabled_ant():
   env_name = "imitation/DisabledAnt-v0"
-  n_epochs = 2000
+  locals().update(**ant_shared_locals)
 
 
 # Debug configs
@@ -185,3 +185,16 @@ def fast():
       parallel=False,  # easier to debug with everything in one process
       max_episode_steps=int(1e2),
   )
+
+
+# Shared settings
+
+ant_shared_locals = dict(
+    n_epochs=2000,
+    init_trainer_kwargs=dict(
+        make_blank_policy_kwargs=dict(
+            n_steps=2048,  # batch size of 2048*8=16384 due to num_vec
+        ),
+        max_episode_steps=500,  # To match `inverse_rl` settings.
+    ),
+)

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -25,7 +25,7 @@ def train_defaults():
     init_trainer_kwargs = dict(
         num_vec=8,  # NOTE: changing this also changes the effective n_steps!
         parallel=True,  # Use SubprocVecEnv (generally faster if num_vec>1)
-        max_episode_steps = None,  # Set to positive int to limit episode horizons
+        max_episode_steps=None,  # Set to positive int to limit episode horizons
         scale=True,
 
         reward_kwargs=dict(

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -25,6 +25,7 @@ def train_defaults():
     init_trainer_kwargs = dict(
         num_vec=8,  # NOTE: changing this also changes the effective n_steps!
         parallel=True,  # Use SubprocVecEnv (generally faster if num_vec>1)
+        max_episode_steps = None,  # Set to positive int to limit episode horizons
         scale=True,
 
         reward_kwargs=dict(

--- a/src/imitation/scripts/eval_policy.py
+++ b/src/imitation/scripts/eval_policy.py
@@ -72,8 +72,7 @@ def eval_policy(_seed: int,
         a reward of this.
     reward_path: If reward_type is specified, the path to a serialized reward
         of `reward_type` to override the environment reward with.
-    log_dir: The directory to log intermediate output to. (As of 2019-07-19
-        this is just episode-by-episode reward from bench.Monitor.)
+
   Returns:
     Statistics returned by `imitation.util.rollout.rollout_stats`.
   """

--- a/src/imitation/scripts/eval_policy.py
+++ b/src/imitation/scripts/eval_policy.py
@@ -47,7 +47,7 @@ def eval_policy(_seed: int,
 
                 reward_type: Optional[str] = None,
                 reward_path: Optional[str] = None,
-                max_episode_steps: Optional[int] = None
+                max_episode_steps: Optional[int] = None,
                 ):
   """Rolls a policy out in an environment, collecting statistics.
 

--- a/src/imitation/scripts/eval_policy.py
+++ b/src/imitation/scripts/eval_policy.py
@@ -47,6 +47,7 @@ def eval_policy(_seed: int,
 
                 reward_type: Optional[str] = None,
                 reward_path: Optional[str] = None,
+                max_episode_steps: Optional[int] = None
                 ):
   """Rolls a policy out in an environment, collecting statistics.
 
@@ -57,6 +58,9 @@ def eval_policy(_seed: int,
     num_vec: Number of environments to run simultaneously.
     parallel: If True, use `SubprocVecEnv` for true parallelism; otherwise,
         uses `DummyVecEnv`.
+    max_episode_steps: If not None, then environments are wrapped by
+        TimeLimit so that they have at most `max_episode_steps` steps per
+        episode.
     render: If True, renders interactively to the screen.
     log_dir: The directory to log intermediate output to. (As of 2019-07-19
         this is just episode-by-episode reward from bench.Monitor.)
@@ -67,7 +71,8 @@ def eval_policy(_seed: int,
         a reward of this.
     reward_path: If reward_type is specified, the path to a serialized reward
         of `reward_type` to override the environment reward with.
-
+    log_dir: The directory to log intermediate output to. (As of 2019-07-19
+        this is just episode-by-episode reward from bench.Monitor.)
   Returns:
     Statistics returned by `imitation.util.rollout.rollout_stats`.
   """
@@ -75,7 +80,8 @@ def eval_policy(_seed: int,
   tf.logging.info('Logging to %s', log_dir)
 
   venv = util.make_vec_env(env_name, num_vec, seed=_seed,
-                           parallel=parallel, log_dir=log_dir)
+                           parallel=parallel, log_dir=log_dir,
+                           max_episode_steps=max_episode_steps)
   if render:
     venv = InteractiveRender(venv, render_fps)
   # TODO(adam): add support for videos using VideoRecorder?

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -67,9 +67,6 @@ def rollouts_and_policy(
       reward_path: A specifier, such as a path to a file on disk, used by
           reward_type to load the reward model. For more information, see
           `imitation.rewards.serialize.load_reward`.
-      discrim_net_airl_path: If provided, then load the serialized
-          DiscrimNetAIRL and wrap the environment in the trainer's test reward.
-          This is useful for AIRL transfer learning.
 
       rollout_save_interval: The number of training updates in between
           intermediate rollout saves. If the argument is nonpositive, then

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -25,6 +25,7 @@ def rollouts_and_policy(
   log_dir: str = None,
   num_vec: int = 8,
   parallel: bool = False,
+  max_episode_steps: Optional[int] = None,
   normalize: bool = True,
   make_blank_policy_kwargs: dict = {},
 
@@ -53,6 +54,9 @@ def rollouts_and_policy(
       log_dir: The root directory to save metrics and checkpoints to.
       num_vec: Number of environments in VecEnv.
       parallel: If True, then use DummyVecEnv. Otherwise use SubprocVecEnv.
+      max_episode_steps: If not None, then environments are wrapped by
+          TimeLimit so that they have at most `max_episode_steps` steps per
+          episode.
       normalize: If True, then rescale observations and reward.
       make_blank_policy_kwargs: Kwargs for `make_blank_policy`.
 
@@ -63,6 +67,9 @@ def rollouts_and_policy(
       reward_path: A specifier, such as a path to a file on disk, used by
           reward_type to load the reward model. For more information, see
           `imitation.rewards.serialize.load_reward`.
+      discrim_net_airl_path: If provided, then load the serialized
+          DiscrimNetAIRL and wrap the environment in the trainer's test reward.
+          This is useful for AIRL transfer learning.
 
       rollout_save_interval: The number of training updates in between
           intermediate rollout saves. If the argument is nonpositive, then
@@ -97,7 +104,8 @@ def rollouts_and_policy(
     os.makedirs(policy_dir, exist_ok=True)
 
     venv = util.make_vec_env(env_name, num_vec, seed=_seed,
-                             parallel=parallel, log_dir=log_dir)
+                             parallel=parallel, log_dir=log_dir,
+                             max_episode_steps=max_episode_steps)
 
     log_callbacks = []
     if reward_type is not None:
@@ -163,6 +171,7 @@ def rollouts_from_policy(
   env_name: str = "CartPole-v1",
   parallel: bool = True,
   rollout_save_dir: Optional[str] = None,
+  max_episode_steps: Optional[int] = None,
 ) -> None:
   """Loads a saved policy and generates rollouts.
 
@@ -178,7 +187,8 @@ def rollouts_from_policy(
           f"{env_name}.pkl".
   """
   venv = util.make_vec_env(env_name, num_vec, seed=_seed,
-                           parallel=parallel, log_dir=log_dir)
+                           parallel=parallel, log_dir=log_dir,
+                           max_episode_steps=max_episode_steps)
   policy = serialize.load_policy(policy_type, policy_path, venv)
 
   if rollout_save_dir is None:

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -76,7 +76,7 @@ def make_vec_env(env_id: str,
     env.seed(seed + i)  # seed each environment separately for diversity
 
     if max_episode_steps is not None:
-      env = TimeLimit(max_episode_steps=max_episode_steps)
+      env = TimeLimit(env, max_episode_steps)
 
     # Use Monitor to record statistics needed for Baselines algorithms logging
     # Optionally, save to disk

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -57,7 +57,8 @@ def make_vec_env(env_id: str,
                  n_envs: int = 8,
                  seed: int = 0,
                  parallel: bool = False,
-                 log_dir: Optional[str] = None) -> VecEnv:
+                 log_dir: Optional[str] = None,
+                 max_episode_steps: Optional[int] = None) -> VecEnv:
   """Returns a VecEnv initialized with `n_envs` Envs.
 
   Args:
@@ -66,10 +67,15 @@ def make_vec_env(env_id: str,
       seed: The environment seed.
       parallel: If True, uses SubprocVecEnv; otherwise, DummyVecEnv.
       log_dir: If specified, saves Monitor output to this directory.
+      max_episode_steps: If specified, wraps VecEnv in TimeLimit wrapper with
+          this episode length before returning.
   """
   def make_env(i):
     env = gym.make(env_id)
     env.seed(seed + i)  # seed each environment separately for diversity
+
+    if time_limit is not None:
+      env = TimeLimit(max_episode_steps=max_episode_steps)
 
     # Use Monitor to record statistics needed for Baselines algorithms logging
     # Optionally, save to disk

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -7,6 +7,7 @@ from typing import Callable, Dict, Iterable, Optional, Tuple, Type, Union
 import uuid
 
 import gym
+from gym.wrappers import TimeLimit
 import stable_baselines
 from stable_baselines import bench
 from stable_baselines.common.base_class import BaseRLModel
@@ -74,7 +75,7 @@ def make_vec_env(env_id: str,
     env = gym.make(env_id)
     env.seed(seed + i)  # seed each environment separately for diversity
 
-    if time_limit is not None:
+    if max_episode_steps is not None:
       env = TimeLimit(max_episode_steps=max_episode_steps)
 
     # Use Monitor to record statistics needed for Baselines algorithms logging


### PR DESCRIPTION
Useful for training experts to compare against `inverse_rl` repo.

In particular, the `inverse_rl` repo uses 500 max episode length for Ant environments, whereas the default episode length is 1000. The shorter time horizon might be important for AIRL training.