### PR TITLE
Minor docstring and type annotation fixes

### DIFF
--- a/src/imitation/rewards/reward_net.py
+++ b/src/imitation/rewards/reward_net.py
@@ -225,7 +225,7 @@ def build_basic_theta_network(hid_sizes: Optional[Iterable[int]],
     old_obs_input: Previous observation.
     new_obs_input: Next observation.
     act_input: Action.
-    kwargs: Passed through to `util.apply_ff`.
+    **kwargs: Passed through to `util.build_mlp`.
 
   Returns:
     tf.Tensor: Predicted reward.
@@ -303,7 +303,7 @@ def build_basic_phi_network(hid_sizes: Optional[Iterable[int]],
     hid_sizes: Number of units at each hidden layer. Default is (32, 32).
     old_obs_input: Previous observation.
     new_obs_input: Next observation.
-    kwargs: Passed through to `util.apply_ff`.
+    **kwargs: Passed through to `util.build_mlp`.
 
   Returns:
     Tuple[tf.Tensor, tf.Tensor]: potential for the old and new observations.

--- a/src/imitation/util/serialize.py
+++ b/src/imitation/util/serialize.py
@@ -9,24 +9,23 @@ import tensorflow as tf
 
 from imitation.util import util
 
-
-def make_cls(cls, args, kwargs):
-  return cls(*args, **kwargs)
+T = TypeVar('T')
 
 
 class Serializable(ABC):
   """Abstract mix-in defining methods to load/save model."""
   @classmethod
   @abstractmethod
-  def load(cls, directory):
+  def load(cls: Type[T], directory: str) -> T:
     """Load object plus weights from directory."""
 
   @abstractmethod
-  def save(self, directory):
+  def save(self, directory: str) -> None:
     """Save object and weights to directory."""
 
 
-T = TypeVar('T')
+def make_cls(cls, args, kwargs):
+  return cls(*args, **kwargs)
 
 
 class LayersSerializable(Serializable):


### PR DESCRIPTION
We renamed `apply_ff` to `build_mlp` a while ago. Add type annotations to `Serializable` (already present in `LayersSerializable`).