### PR TITLE
Single point-of-entry for deserialization

### DIFF
--- a/src/imitation/rewards/discrim_net.py
+++ b/src/imitation/rewards/discrim_net.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 import os
 import pickle
 from typing import Callable, Iterable, Optional
@@ -12,7 +12,7 @@ from imitation.rewards import reward_net
 from imitation.util import serialize
 
 
-class DiscrimNet(serialize.Serializable):
+class DiscrimNet(serialize.Serializable, ABC):
   """Abstract base class for discriminator, used in multiple IRL methods."""
 
   def __init__(self):
@@ -81,6 +81,7 @@ class DiscrimNet(serialize.Serializable):
     Returns:
         The rewards. Its shape is `(batch_size,)`.
     """
+    del steps
     log_act_prob = np.squeeze(
       gen_log_prob_fn(observation=old_obs, actions=act, logp=True))
 
@@ -121,6 +122,7 @@ class DiscrimNet(serialize.Serializable):
     Returns:
         The rewards. Its shape is `(batch_size,)`.
     """
+    del steps
     fd = {
       self.old_obs_ph: old_obs,
       self.act_ph: act,
@@ -252,9 +254,7 @@ class DiscrimNetAIRL(DiscrimNet):
     # Note self._log_D_compl is effectively an entropy term.
     return self._log_D - self.entropy_weight * self._log_D_compl
 
-  def save(self, directory):
-    super().save(directory)
-
+  def _save(self, directory):
     os.makedirs(directory, exist_ok=True)
     params = {
         "entropy_weight": self.entropy_weight,
@@ -265,7 +265,7 @@ class DiscrimNetAIRL(DiscrimNet):
     return self.reward_net.save(os.path.join(directory, "reward_net"))
 
   @classmethod
-  def load(cls, directory):
+  def _load(cls, directory):
     with open(os.path.join(directory, "args"), "rb") as f:
       params = pickle.load(f)
     reward_net_cls = params.pop("reward_net_cls")

--- a/src/imitation/rewards/discrim_net.py
+++ b/src/imitation/rewards/discrim_net.py
@@ -253,6 +253,8 @@ class DiscrimNetAIRL(DiscrimNet):
     return self._log_D - self.entropy_weight * self._log_D_compl
 
   def save(self, directory):
+    super().save(directory)
+
     os.makedirs(directory, exist_ok=True)
     params = {
         "entropy_weight": self.entropy_weight,

--- a/src/imitation/rewards/reward_net.py
+++ b/src/imitation/rewards/reward_net.py
@@ -1,6 +1,6 @@
 """Constructs deep network reward models."""
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Iterable, Optional, Tuple
 
 import gym
@@ -9,7 +9,7 @@ import tensorflow as tf
 from imitation.util import serialize, util
 
 
-class RewardNet(serialize.Serializable):
+class RewardNet(serialize.Serializable, ABC):
   """Abstract reward network.
 
   This class assumes that the caller will set the default TensorFlow Session

--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -13,56 +13,34 @@ from imitation.util.reward_wrapper import RewardFn
 RewardLoaderFn = Callable[[str, VecEnv], ContextManager[RewardFn]]
 RewardNetLoaderFn = Callable[[str, VecEnv], reward_net.RewardNet]
 
-reward_net_registry: registry.Registry[RewardNetLoaderFn] = registry.Registry()
-reward_fn_registry: registry.Registry[RewardLoaderFn] = registry.Registry()
+reward_registry: registry.Registry[RewardLoaderFn] = registry.Registry()
 
 
-def _add_reward_net_loaders(classes):
-  for name, cls in classes.items():
-    loader = registry.build_loader_fn_require_path(cls.load)
-    reward_net_registry.register(key=name, value=loader)
+@registry.sess_context
+def _load_discrim_net(path: str, venv: VecEnv) -> RewardFn:
+  """Load test reward output from discriminator."""
+  del venv
+  discriminator = discrim_net.DiscrimNet.load(path)
+  # TODO(gleave): expose train reward as well? (hard due to action probs?)
+  return discriminator.reward_test
 
 
-REWARD_NETS = {
-    "BasicRewardNet": reward_net.BasicRewardNet,
-    "BasicShapedRewardNet": reward_net.BasicShapedRewardNet,
-}
-_add_reward_net_loaders(REWARD_NETS)
-
-
-def _load_discrim_net(cls):
-  @registry.sess_context
-  def f(path: str, venv: VecEnv):
-      discrim_net = cls.load(path)
-      # TODO(gleave): expose train reward as well? (hard due to action probs?)
-      return discrim_net.reward_test
-  return f
-
-
-def _add_discrim_net_loaders(classes):
-  for name, cls in classes.items():
-    reward_fn_registry.register(key=name, value=_load_discrim_net(cls))
-
-
-_add_discrim_net_loaders({
-    "DiscrimNetAIRL": discrim_net.DiscrimNetAIRL,
-    "DiscrimNetGAIL": discrim_net.DiscrimNetGAIL,
-})
-
-
-def _load_reward_net_as_fn(reward_type: str, shaped: bool) -> RewardLoaderFn:
-  reward_net_loader = reward_net_registry.get(reward_type)
-
+def _load_reward_net_as_fn(shaped: bool) -> RewardLoaderFn:
   @contextlib.contextmanager
-  def loader(path: str, venv: VecEnv) -> Iterator[RewardFn]:
+  def loader(path: str,
+             venv: VecEnv,
+             ) -> Iterator[RewardFn]:
+    """Load train (shaped) or test (not shaped) reward from path."""
+    del venv
     with util.make_session() as (graph, sess):
-      net = reward_net_loader(path, venv)
+      net = reward_net.RewardNet.load(path)
       reward = net.reward_output_train if shaped else net.reward_output_test
 
       def rew_fn(old_obs: np.ndarray,
                  act: np.ndarray,
                  new_obs: np.ndarray,
                  steps: np.ndarray) -> np.ndarray:
+        del steps
         fd = {
             net.old_obs_ph: old_obs,
             net.act_ph: act,
@@ -77,30 +55,28 @@ def _load_reward_net_as_fn(reward_type: str, shaped: bool) -> RewardLoaderFn:
   return loader
 
 
-def _add_reward_net_as_fn_loaders(reward_nets):
-  for k, net_cls in reward_nets.items():
-    reward_fn_registry.register(key=f"{k}_shaped",
-                                value=_load_reward_net_as_fn(k, True))
-    reward_fn_registry.register(key=f"{k}_unshaped",
-                                value=_load_reward_net_as_fn(k, False))
-
-
-_add_reward_net_as_fn_loaders(REWARD_NETS)
-
-
 def load_zero(path: str, venv: VecEnv) -> RewardFn:
+  del path, venv
+
   def f(old_obs: np.ndarray,
         act: np.ndarray,
         new_obs: np.ndarray,
         steps: np.ndarray) -> np.ndarray:
+    del act, new_obs, steps
     return np.zeros(old_obs.shape[0])
+
   return f
 
 
-reward_fn_registry.register(key='zero', value=registry.dummy_context(load_zero))
+reward_registry.register(key="DiscrimNet", value=_load_discrim_net)
+reward_registry.register(key="RewardNet_shaped",
+                         value=_load_reward_net_as_fn(shaped=True))
+reward_registry.register(key="RewardNet_unshaped",
+                         value=_load_reward_net_as_fn(shaped=False))
+reward_registry.register(key='zero', value=registry.dummy_context(load_zero))
 
 
-@util.docstring_parameter(reward_types=", ".join(reward_fn_registry.keys()))
+@util.docstring_parameter(reward_types=", ".join(reward_registry.keys()))
 def load_reward(reward_type: str, reward_path: str,
                 venv: VecEnv) -> ContextManager[RewardFn]:
   """Load serialized policy.
@@ -111,5 +87,5 @@ def load_reward(reward_type: str, reward_path: str,
     reward_path: A path specifying the reward.
     venv: An environment that the policy is to be used with.
   """
-  reward_loader = reward_fn_registry.get(reward_type)
+  reward_loader = reward_registry.get(reward_type)
   return reward_loader(reward_path, venv)

--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -10,10 +10,9 @@ from imitation.rewards import discrim_net, reward_net
 from imitation.util import registry, util
 from imitation.util.reward_wrapper import RewardFn
 
-RewardLoaderFn = Callable[[str, VecEnv], ContextManager[RewardFn]]
-RewardNetLoaderFn = Callable[[str, VecEnv], reward_net.RewardNet]
+RewardFnLoaderFn = Callable[[str, VecEnv], ContextManager[RewardFn]]
 
-reward_registry: registry.Registry[RewardLoaderFn] = registry.Registry()
+reward_registry: registry.Registry[RewardFnLoaderFn] = registry.Registry()
 
 
 @registry.sess_context
@@ -25,7 +24,7 @@ def _load_discrim_net(path: str, venv: VecEnv) -> RewardFn:
   return discriminator.reward_test
 
 
-def _load_reward_net_as_fn(shaped: bool) -> RewardLoaderFn:
+def _load_reward_net_as_fn(shaped: bool) -> RewardFnLoaderFn:
   @contextlib.contextmanager
   def loader(path: str,
              venv: VecEnv,

--- a/src/imitation/util/registry.py
+++ b/src/imitation/util/registry.py
@@ -76,6 +76,7 @@ def build_loader_fn_require_space(fn: Callable[[gym.Space, gym.Space], T],
   """Converts a factory taking observation and action space into a LoaderFn."""
   @functools.wraps(fn)
   def wrapper(path: str, venv: VecEnv) -> T:
+    del path
     return fn(venv.observation_space, venv.action_space, **kwargs)
   return wrapper
 
@@ -85,16 +86,8 @@ def build_loader_fn_require_env(fn: Callable[[VecEnv], T],
   """Converts a factory taking an environment into a LoaderFn."""
   @functools.wraps(fn)
   def wrapper(path: str, venv: VecEnv) -> T:
+    del path
     return fn(venv, **kwargs)
-  return wrapper
-
-
-def build_loader_fn_require_path(fn: Callable[[str], T],
-                                 **kwargs) -> LoaderFn:
-  """Converts a factory taking a path into a LoaderFn."""
-  @functools.wraps(fn)
-  def wrapper(path: str, venv: VecEnv) -> T:
-    return fn(path, **kwargs)
   return wrapper
 
 

--- a/src/imitation/util/serialize.py
+++ b/src/imitation/util/serialize.py
@@ -9,28 +9,21 @@ import tensorflow as tf
 
 from imitation.util import util
 
-T = TypeVar('T')
+T = TypeVar('T', bound='Serializable')
 
 
 class Serializable(ABC):
   """Abstract mix-in defining methods to load/save model."""
-  @classmethod
-  @abstractmethod
-  def load(cls: Type[T], directory: str) -> T:
-    """Load object plus weights from directory.
 
-    Concrete subclasses must override this, and must not call it via super()
-    (this would trigger an infinite loop.)
-    """
+  @classmethod
+  def load(cls: Type[T], directory: str) -> T:
+    """Load object plus weights from directory."""
     with open(os.path.join(directory, 'loader'), 'rb') as f:
       load_cls = pickle.load(f)
-    return load_cls.load(directory)
+    return load_cls._load(directory)
 
-  @abstractmethod
   def save(self, directory: str) -> None:
-    """Save object and weights to directory.
-
-    Concrete subclasses must override this, and must call it via super()."""
+    """Save object and weights to directory."""
     os.makedirs(directory, exist_ok=True)
 
     load_path = os.path.join(directory, 'loader')
@@ -38,6 +31,17 @@ class Serializable(ABC):
       pickle.dump(type(self), f)
     # Ensure atomic write
     os.replace(load_path + '.tmp', load_path)
+
+    self._save(directory)
+
+  @classmethod
+  @abstractmethod
+  def _load(cls: Type[T], directory: str) -> T:
+    """Class-specific loading logic."""
+
+  @abstractmethod
+  def _save(self, directory: str) -> None:
+    """Class-specific saving logic."""
 
 
 def make_cls(cls, args, kwargs):
@@ -47,7 +51,7 @@ def make_cls(cls, args, kwargs):
 class LayersSerializable(Serializable):
   """Serialization mix-in based on `__init__` then rehydration.
 
-  Subclsases must call the constructor with all arguments needed by `__init__`,
+  Subclasses must call the constructor with all arguments needed by `__init__`,
   and a dictionary mapping from strings to `tf.layers.Layer` objects.
   In most cases, you can use the following idiom::
 
@@ -73,16 +77,14 @@ class LayersSerializable(Serializable):
     restore.assert_consumed().run_restore_ops()
 
   @classmethod
-  def load(cls: Type[T], directory: str) -> T:
+  def _load(cls: Type[T], directory: str) -> T:
     with open(os.path.join(directory, 'obj'), 'rb') as f:
       obj = pickle.load(f)
     assert isinstance(obj, cls)
     obj.load_parameters(directory)
     return obj
 
-  def save(self, directory: str) -> None:
-    super().save(directory)
-
+  def _save(self, directory: str) -> None:
     obj_path = os.path.join(directory, 'obj')
     # obj is static, so no need to write them multiple times.
     # (Best to avoid it -- if we were die in the middle of save, it could

--- a/src/imitation/util/serialize.py
+++ b/src/imitation/util/serialize.py
@@ -15,15 +15,22 @@ T = TypeVar('T')
 class Serializable(ABC):
   """Abstract mix-in defining methods to load/save model."""
   @classmethod
+  @abstractmethod
   def load(cls: Type[T], directory: str) -> T:
-    """Load object plus weights from directory."""
+    """Load object plus weights from directory.
+
+    Concrete subclasses must override this, and must not call it via super()
+    (this would trigger an infinite loop.)
+    """
     with open(os.path.join(directory, 'loader'), 'rb') as f:
       load_cls = pickle.load(f)
     return load_cls.load(directory)
 
   @abstractmethod
   def save(self, directory: str) -> None:
-    """Save object and weights to directory."""
+    """Save object and weights to directory.
+
+    Concrete subclasses must override this, and must call it via super()."""
     os.makedirs(directory, exist_ok=True)
 
     load_path = os.path.join(directory, 'loader')

--- a/src/imitation/util/serialize.py
+++ b/src/imitation/util/serialize.py
@@ -17,7 +17,6 @@ def make_cls(cls, args, kwargs):
 class Serializable(ABC):
   """Abstract mix-in defining methods to load/save model."""
   @classmethod
-  @abstractmethod
   def load(cls, directory):
     """Load object plus weights from directory."""
     with open(os.path.join(directory, 'loader'), 'rb') as f:

--- a/tests/test_discrim_net.py
+++ b/tests/test_discrim_net.py
@@ -6,26 +6,26 @@ import pytest
 import tensorflow as tf
 
 from imitation.policies import base
-from imitation.rewards.discrim_net import DiscrimNetAIRL, DiscrimNetGAIL
+from imitation.rewards import discrim_net
 from imitation.rewards.reward_net import BasicRewardNet
 from imitation.util import rollout
 
 ENVS = ['FrozenLake-v0', 'CartPole-v1', 'Pendulum-v0']
-DISCRIM_NETS = [DiscrimNetAIRL, DiscrimNetGAIL]
+DISCRIM_NETS = [discrim_net.DiscrimNetAIRL, discrim_net.DiscrimNetGAIL]
 
 
 def _setup_airl(env):
   reward_net = BasicRewardNet(env.observation_space, env.action_space)
-  return DiscrimNetAIRL(reward_net)
+  return discrim_net.DiscrimNetAIRL(reward_net)
 
 
 def _setup_gail(env):
-  return DiscrimNetGAIL(env.observation_space, env.action_space)
+  return discrim_net.DiscrimNetGAIL(env.observation_space, env.action_space)
 
 
 DISCRIM_NET_SETUPS = {
-    DiscrimNetAIRL: _setup_airl,
-    DiscrimNetGAIL: _setup_gail,
+    discrim_net.DiscrimNetAIRL: _setup_airl,
+    discrim_net.DiscrimNetGAIL: _setup_gail,
 }
 
 
@@ -48,7 +48,7 @@ def test_serialize_identity(session, env_id, discrim_net_cls):
   with tempfile.TemporaryDirectory(prefix='imitation-serialize') as tmpdir:
     original.save(tmpdir)
     with tf.variable_scope("loaded"):
-      loaded = discrim_net_cls.load(tmpdir)
+      loaded = discrim_net.DiscrimNet.load(tmpdir)
 
   old_obs, act, new_obs, _rew = rollout.generate_transitions(random, env,
                                                              n_timesteps=100)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -109,7 +109,7 @@ def test_transfer_learning():
         named_configs=['cartpole', 'fast'],
         config_updates=dict(
           log_dir=log_dir_data,
-          reward_type='DiscrimNetAIRL',
+          reward_type='DiscrimNet',
           reward_path=discrim_path,
         ),
     )


### PR DESCRIPTION
Saves the class of the object, so that `Serializable.load` can always de-serialize. This significantly simplifies `rewards/serialize.py` as no longer need to keep track of different reward types. (I'm still keeping the reward registry since not *everything* is serialized using our method, e.g. hard-coded reward functions or reward models from other codebases.)

This does feel an awful lot like re-inventing `pickle`, however trying to push everything into `pickle` would (a) not play nice with `tf.Checkpoint` and (b) having a hierarchical directory structure for our serialized models is nice and `pickle` can't do this.

Still not quite satisfied with how we're serializing/deserializing things so I'd welcome suggestions on improvements.