### PR TITLE
Serialize: Add abstract methods `_load` and `_save`

### DIFF
--- a/src/imitation/rewards/discrim_net.py
+++ b/src/imitation/rewards/discrim_net.py
@@ -81,6 +81,7 @@ class DiscrimNet(serialize.Serializable, ABC):
     Returns:
         The rewards. Its shape is `(batch_size,)`.
     """
+    del steps
     log_act_prob = np.squeeze(
       gen_log_prob_fn(observation=old_obs, actions=act, logp=True))
 
@@ -121,6 +122,7 @@ class DiscrimNet(serialize.Serializable, ABC):
     Returns:
         The rewards. Its shape is `(batch_size,)`.
     """
+    del steps
     fd = {
       self.old_obs_ph: old_obs,
       self.act_ph: act,
@@ -252,9 +254,7 @@ class DiscrimNetAIRL(DiscrimNet):
     # Note self._log_D_compl is effectively an entropy term.
     return self._log_D - self.entropy_weight * self._log_D_compl
 
-  def save(self, directory):
-    super().save(directory)
-
+  def _save(self, directory):
     os.makedirs(directory, exist_ok=True)
     params = {
         "entropy_weight": self.entropy_weight,

--- a/src/imitation/rewards/discrim_net.py
+++ b/src/imitation/rewards/discrim_net.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 import os
 import pickle
 from typing import Callable, Iterable, Optional
@@ -12,7 +12,7 @@ from imitation.rewards import reward_net
 from imitation.util import serialize
 
 
-class DiscrimNet(serialize.Serializable):
+class DiscrimNet(serialize.Serializable, ABC):
   """Abstract base class for discriminator, used in multiple IRL methods."""
 
   def __init__(self):
@@ -265,7 +265,7 @@ class DiscrimNetAIRL(DiscrimNet):
     return self.reward_net.save(os.path.join(directory, "reward_net"))
 
   @classmethod
-  def load(cls, directory):
+  def _load(cls, directory):
     with open(os.path.join(directory, "args"), "rb") as f:
       params = pickle.load(f)
     reward_net_cls = params.pop("reward_net_cls")

--- a/src/imitation/rewards/reward_net.py
+++ b/src/imitation/rewards/reward_net.py
@@ -1,6 +1,6 @@
 """Constructs deep network reward models."""
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Iterable, Optional, Tuple
 
 import gym
@@ -9,7 +9,7 @@ import tensorflow as tf
 from imitation.util import serialize, util
 
 
-class RewardNet(serialize.Serializable):
+class RewardNet(serialize.Serializable, ABC):
   """Abstract reward network.
 
   This class assumes that the caller will set the default TensorFlow Session

--- a/src/imitation/util/serialize.py
+++ b/src/imitation/util/serialize.py
@@ -27,7 +27,6 @@ class Serializable(ABC):
   def _load(cls: Type[T], directory: str) -> T:
     pass
 
-  @classmethod
   @abstractmethod
   def save(self, directory: str) -> None:
     """Save object and weights to directory.

--- a/src/imitation/util/serialize.py
+++ b/src/imitation/util/serialize.py
@@ -38,7 +38,6 @@ class Serializable(ABC):
   @abstractmethod
   def _load(cls: Type[T], directory: str) -> T:
     """Class-specific loading logic."""
-    pass
 
   @abstractmethod
   def _save(self, directory: str) -> None:

--- a/src/imitation/util/serialize.py
+++ b/src/imitation/util/serialize.py
@@ -22,16 +22,8 @@ class Serializable(ABC):
       load_cls = pickle.load(f)
     return load_cls._load(directory)
 
-  @classmethod
-  @abstractmethod
-  def _load(cls: Type[T], directory: str) -> T:
-    pass
-
-  @abstractmethod
   def save(self, directory: str) -> None:
-    """Save object and weights to directory.
-
-    Concrete subclasses must override this, and must call it via super()."""
+    """Save object and weights to directory."""
     os.makedirs(directory, exist_ok=True)
 
     load_path = os.path.join(directory, 'loader')
@@ -39,6 +31,18 @@ class Serializable(ABC):
       pickle.dump(type(self), f)
     # Ensure atomic write
     os.replace(load_path + '.tmp', load_path)
+
+    self._save(directory)
+
+  @classmethod
+  @abstractmethod
+  def _load(cls: Type[T], directory: str) -> T:
+    """Class-specific loading logic."""
+    pass
+
+  @abstractmethod
+  def _save(self, directory: str) -> None:
+    """Class-specific saving logic."""
 
 
 def make_cls(cls, args, kwargs):
@@ -81,9 +85,7 @@ class LayersSerializable(Serializable):
     obj.load_parameters(directory)
     return obj
 
-  def save(self, directory: str) -> None:
-    super().save(directory)
-
+  def _save(self, directory: str) -> None:
     obj_path = os.path.join(directory, 'obj')
     # obj is static, so no need to write them multiple times.
     # (Best to avoid it -- if we were die in the middle of save, it could


### PR DESCRIPTION
`Serializable.load` is no longer abstract. Instead, it depends on abstract `Serializable._load`.

Also added `ABC` mixin to abstract classes `DiscrimNet` and `RewardNet`. Somehow `pytype` started calling out their unimplemented `build_policy_train_reward` after some changes to serializable.py.