### PR TITLE
Allow user to specify termination condition for rollouts

### DIFF
--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -88,7 +88,7 @@ class BCTrainer:
         `imitation.utils.rollout.rollout_stats()`.
     """
     reward_stats = rollout.rollout_stats(
-        self.policy, self.env, n_episodes=n_episodes)
+        self.policy, self.env, sample_until=rollout.n_episodes(n_episodes))
     return reward_stats
 
   def _build_tf_graph(self):

--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -88,7 +88,7 @@ class BCTrainer:
         `imitation.utils.rollout.rollout_stats()`.
     """
     reward_stats = rollout.rollout_stats(
-        self.policy, self.env, sample_until=rollout.n_episodes(n_episodes))
+        self.policy, self.env, sample_until=rollout.min_episodes(n_episodes))
     return reward_stats
 
   def _build_tf_graph(self):

--- a/src/imitation/algorithms/density_baselines.py
+++ b/src/imitation/algorithms/density_baselines.py
@@ -282,5 +282,5 @@ class DensityTrainer:
     reward_stats = rollout.rollout_stats(
         self.imitation_trainer,
         self.venv if true_reward else self.wrapped_env,
-        n_episodes=n_trajectories)
+        sample_until=rollout.n_episodes(n_trajectories))
     return reward_stats

--- a/src/imitation/algorithms/density_baselines.py
+++ b/src/imitation/algorithms/density_baselines.py
@@ -282,5 +282,5 @@ class DensityTrainer:
     reward_stats = rollout.rollout_stats(
         self.imitation_trainer,
         self.venv if true_reward else self.wrapped_env,
-        sample_until=rollout.n_episodes(n_trajectories))
+        sample_until=rollout.min_episodes(n_trajectories))
     return reward_stats

--- a/src/imitation/scripts/eval_policy.py
+++ b/src/imitation/scripts/eval_policy.py
@@ -95,7 +95,8 @@ def eval_policy(_seed: int,
           f"Wrapped env in reward {reward_type} from {reward_path}.")
 
     with serialize.load_policy(policy_type, policy_path, venv) as policy:
-      stats = rollout.rollout_stats(policy, venv, n_timesteps=timesteps)
+      stats = rollout.rollout_stats(policy, venv,
+                                    rollout.min_timesteps(timesteps))
 
   return stats
 

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -39,7 +39,7 @@ def traj_sample_until(n_timesteps: Optional[int],
     return util.rollout.min_timesteps(n_timesteps)
   elif n_episodes is not None:
     assert n_episodes > 0
-    return util.rollout.n_episodes(n_episodes)
+    return util.rollout.min_episodes(n_episodes)
   else:
     raise ValueError("Set at least one of n_timesteps and n_episodes")
 

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -14,7 +14,34 @@ from imitation.rewards.serialize import load_reward
 from imitation.scripts.config.expert_demos import expert_demos_ex
 import imitation.util as util
 from imitation.util.reward_wrapper import RewardVecEnvWrapper
-from imitation.util.rollout import _validate_traj_generate_params
+
+
+def traj_sample_until(n_timesteps: Optional[int],
+                      n_episodes: Optional[int],
+                      ) -> util.rollout.GenTrajTerminationFn:
+  """Returns a termination condition sampling until n_timesteps or n_episodes.
+
+  Arguments:
+    n_timesteps: Minimum number of timesteps to sample.
+    n_episodes: Number of episodes to sample.
+
+  Returns:
+    A termination condition.
+
+  Raises:
+    ValueError if both or neither of n_timesteps and n_episodes are set,
+    or if either are non-positive.
+  """
+  if n_timesteps is not None and n_episodes is not None:
+    raise ValueError("n_timesteps and n_episodes were both set")
+  elif n_timesteps is not None:
+    assert n_timesteps > 0
+    return util.rollout.min_timesteps(n_timesteps)
+  elif n_episodes is not None:
+    assert n_episodes > 0
+    return util.rollout.n_episodes(n_episodes)
+  else:
+    raise ValueError("Set at least one of n_timesteps and n_episodes")
 
 
 @expert_demos_ex.main
@@ -88,8 +115,8 @@ def rollouts_and_policy(
       policy_save_final: If True, then save the policy right after training is
           finished.
   """
-  _validate_traj_generate_params(rollout_save_n_timesteps,
-                                 rollout_save_n_episodes)
+  sample_until = traj_sample_until(rollout_save_n_timesteps,
+                                   rollout_save_n_episodes)
 
   with util.make_session():
     tf.logging.set_verbosity(tf.logging.INFO)
@@ -135,10 +162,7 @@ def rollouts_and_policy(
           callback(sb_logger)
 
         if rollout_save_interval > 0 and step % rollout_save_interval == 0:
-          util.rollout.save(
-            rollout_dir, policy, venv, step,
-            n_timesteps=rollout_save_n_timesteps,
-            n_episodes=rollout_save_n_episodes)
+          util.rollout.save(rollout_dir, policy, venv, sample_until, step)
         if policy_save_interval > 0 and step % policy_save_interval == 0:
           output_dir = os.path.join(policy_dir, f'{step:05d}')
           serialize.save_stable_model(output_dir, policy, vec_normalize)
@@ -148,10 +172,7 @@ def rollouts_and_policy(
 
       # Save final artifacts after training is complete.
       if rollout_save_final:
-        util.rollout.save(
-          rollout_dir, policy, venv, "final",
-          n_timesteps=rollout_save_n_timesteps,
-          n_episodes=rollout_save_n_episodes)
+        util.rollout.save(rollout_dir, policy, venv, sample_until, "final")
       if policy_save_final:
         output_dir = os.path.join(policy_dir, "final")
         serialize.save_stable_model(output_dir, policy, vec_normalize)
@@ -186,6 +207,9 @@ def rollouts_from_policy(
       rollout_save_dir: Rollout pickle is saved in this directory as
           f"{env_name}.pkl".
   """
+  sample_until = traj_sample_until(rollout_save_n_timesteps,
+                                   rollout_save_n_episodes)
+
   if rollout_save_dir is None:
     rollout_save_dir = osp.join(log_dir, "rollouts")
 
@@ -195,11 +219,8 @@ def rollouts_from_policy(
 
   with serialize.load_policy(policy_type, policy_path, venv) as policy:
     os.makedirs(rollout_save_dir, exist_ok=True)
-    util.rollout.save(rollout_save_dir, policy, venv,
-                      basename=env_name,
-                      n_timesteps=rollout_save_n_timesteps,
-                      n_episodes=rollout_save_n_episodes,
-                      )
+    util.rollout.save(rollout_save_dir, policy, venv, sample_until,
+                      basename=env_name)
 
 
 def main_console():

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -153,7 +153,7 @@ def train_and_plot(_seed: int,
     def ep_reward_plot_add_data(env, name):
       """Calculate and record average episode returns."""
       gen_policy = trainer.gen_policy
-      sample_until_data = util.rollout.n_episodes(n_episodes_per_reward_data)
+      sample_until_data = util.rollout.min_episodes(n_episodes_per_reward_data)
       gen_ret = util.rollout.mean_return(
           gen_policy, env, sample_until=sample_until_data)
       gen_ep_reward[name].append(gen_ret)

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -153,20 +153,21 @@ def train_and_plot(_seed: int,
     def ep_reward_plot_add_data(env, name):
       """Calculate and record average episode returns."""
       gen_policy = trainer.gen_policy
+      sample_until_data = util.rollout.n_episodes(n_episodes_per_reward_data)
       gen_ret = util.rollout.mean_return(
-          gen_policy, env, n_episodes=n_episodes_per_reward_data)
+          gen_policy, env, sample_until=sample_until_data)
       gen_ep_reward[name].append(gen_ret)
       tf.logging.info("generator return: {}".format(gen_ret))
 
       rand_policy = util.init_rl(trainer.env)
       rand_ret = util.rollout.mean_return(
-          rand_policy, env, n_episodes=n_episodes_per_reward_data)
+          rand_policy, env, sample_until=sample_until_data)
       rand_ep_reward[name].append(rand_ret)
       tf.logging.info("random return: {}".format(rand_ret))
 
       if expert_policy is not None:
           exp_ret = util.rollout.mean_return(
-              expert_policy, env, n_episodes=n_episodes_per_reward_data)
+              expert_policy, env, sample_until=sample_until_data)
           exp_ep_reward[name].append(exp_ret)
           tf.logging.info("exp return: {}".format(exp_ret))
 
@@ -232,9 +233,10 @@ def train_and_plot(_seed: int,
     save(trainer, os.path.join(log_dir, "checkpoints", "final"))
 
     # Final evaluation of imitation policy.
+    sample_until_eval = util.rollout.min_timesteps(n_episodes_eval)
     stats = util.rollout.rollout_stats(trainer.gen_policy,
                                        trainer.env,
-                                       n_episodes=n_episodes_eval)
+                                       sample_until=sample_until_eval)
     assert stats["n_traj"] >= n_episodes_eval
     mean = stats["return_mean"]
     std_err = stats["return_std"] / math.sqrt(n_episodes_eval)

--- a/src/imitation/util/rollout.py
+++ b/src/imitation/util/rollout.py
@@ -100,7 +100,7 @@ GenTrajTerminationFn = Callable[[Sequence[Trajectory]], bool]
 
 def n_episodes(n: int) -> GenTrajTerminationFn:
   """Terminate after collecting n episodes of data."""
-  def f(trajectories):
+  def f(trajectories: Sequence[Trajectory]):
     return len(trajectories) >= n
   return f
 
@@ -115,7 +115,7 @@ def min_timesteps(n: int) -> GenTrajTerminationFn:
   Returns:
     A function implementing this termination condition.
   """
-  def f(trajectories):
+  def f(trajectories: Sequence[Trajectory]):
     timesteps = sum(len(t.obs) - 1 for t in trajectories)
     return timesteps >= n
   return f

--- a/src/imitation/util/rollout.py
+++ b/src/imitation/util/rollout.py
@@ -302,8 +302,8 @@ def generate_transitions(policy,
         trained on the gym environment.
     env (VecEnv or Env or str): The environment(s) to interact with.
     n_timesteps: The minimum number of timesteps to sample.
-    truncate: If True and `n_timesteps` is not None, then drop any additional
-        samples to ensure that exactly `n_timesteps` samples are returned.
+    truncate: If True, then drop any additional samples to ensure that exactly
+        `n_timesteps` samples are returned.
     **kwargs: Passed-through to generate_trajectories.
 
   Returns:

--- a/src/imitation/util/rollout.py
+++ b/src/imitation/util/rollout.py
@@ -98,8 +98,16 @@ class _TrajectoryAccumulator:
 GenTrajTerminationFn = Callable[[Sequence[Trajectory]], bool]
 
 
-def n_episodes(n: int) -> GenTrajTerminationFn:
-  """Terminate after collecting n episodes of data."""
+def min_episodes(n: int) -> GenTrajTerminationFn:
+  """Terminate after collecting n episodes of data.
+
+  Argument:
+    n: Minimum number of episodes of data to collect.
+        May overshoot if two episodes complete simultaneously (unlikely).
+
+  Returns:
+    A function implementing this termination condition.
+  """
   def f(trajectories: Sequence[Trajectory]):
     return len(trajectories) >= n
   return f
@@ -135,7 +143,7 @@ def generate_trajectories(policy,
     env (VecEnv or Env or str): The environment(s) to interact with.
     sample_until: A function determining the termination condition.
         It takes a sequence of trajectories, and returns a bool.
-        Most users will want to use one of `n_episodes` or `n_timesteps`.
+        Most users will want to use one of `min_episodes` or `min_timesteps`.
     deterministic_policy: If True, asks policy to deterministically return
         action. Note the trajectories might still be non-deterministic if the
         environment has non-determinism!

--- a/src/imitation/util/serialize.py
+++ b/src/imitation/util/serialize.py
@@ -9,7 +9,7 @@ import tensorflow as tf
 
 from imitation.util import util
 
-T = TypeVar('T', bound='Serializable')
+T = TypeVar('T')
 
 
 class Serializable(ABC):

--- a/src/imitation/util/serialize.py
+++ b/src/imitation/util/serialize.py
@@ -9,7 +9,7 @@ import tensorflow as tf
 
 from imitation.util import util
 
-T = TypeVar('T')
+T = TypeVar('T', bound='Serializable')
 
 
 class Serializable(ABC):

--- a/tests/test_density_baselines.py
+++ b/tests/test_density_baselines.py
@@ -58,7 +58,7 @@ def test_density_reward(density_type, is_stationary):
   # check that expert policy does better than a random policy under our reward
   # function
   random_policy = RandomPolicy(env.observation_space, env.action_space)
-  sample_until = rollout.n_episodes(n_experts // 2)
+  sample_until = rollout.min_episodes(n_experts // 2)
   random_trajectories = rollout.generate_trajectories(random_policy,
                                                       env,
                                                       sample_until=sample_until)

--- a/tests/test_density_baselines.py
+++ b/tests/test_density_baselines.py
@@ -58,9 +58,10 @@ def test_density_reward(density_type, is_stationary):
   # check that expert policy does better than a random policy under our reward
   # function
   random_policy = RandomPolicy(env.observation_space, env.action_space)
+  sample_until = rollout.n_episodes(n_experts // 2)
   random_trajectories = rollout.generate_trajectories(random_policy,
                                                       env,
-                                                      n_episodes=n_experts // 2)
+                                                      sample_until=sample_until)
   expert_trajectories_test = expert_trajectories_all[n_experts // 2:]
   random_score = score_trajectories(random_trajectories, reward_fn)
   expert_score = score_trajectories(expert_trajectories_test, reward_fn)

--- a/tests/test_reward_vec_env_wrapper.py
+++ b/tests/test_reward_vec_env_wrapper.py
@@ -18,8 +18,9 @@ def test_reward_overwrite():
   reward_fn = FunkyReward()
   wrapped_env = util.reward_wrapper.RewardVecEnvWrapper(env, reward_fn)
   policy = RandomPolicy(env.observation_space, env.action_space)
-  default_stats = util.rollout.rollout_stats(policy, env, n_episodes=10)
-  wrapped_stats = util.rollout.rollout_stats(policy, wrapped_env, n_episodes=10)
+  sample_until = util.rollout.n_episodes(10)
+  default_stats = util.rollout.rollout_stats(policy, env, sample_until)
+  wrapped_stats = util.rollout.rollout_stats(policy, wrapped_env, sample_until)
   # Pendulum-v0 always has negative rewards
   assert default_stats['return_max'] < 0
   # ours gives between 1 * traj_len and num_envs * traj_len reward

--- a/tests/test_reward_vec_env_wrapper.py
+++ b/tests/test_reward_vec_env_wrapper.py
@@ -18,7 +18,7 @@ def test_reward_overwrite():
   reward_fn = FunkyReward()
   wrapped_env = util.reward_wrapper.RewardVecEnvWrapper(env, reward_fn)
   policy = RandomPolicy(env.observation_space, env.action_space)
-  sample_until = util.rollout.n_episodes(10)
+  sample_until = util.rollout.min_episodes(10)
   default_stats = util.rollout.rollout_stats(policy, env, sample_until)
   wrapped_stats = util.rollout.rollout_stats(policy, wrapped_env, sample_until)
   # Pendulum-v0 always has negative rewards

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -31,16 +31,16 @@ def test_complete_trajectories():
   """Check that complete trajectories are returned by vecenv wrapper,
      including the terminal observation.
   """
-  n_episodes = 13
+  min_episodes = 13
   max_acts = 5
   num_envs = 4
   vec_env = DummyVecEnv([lambda: TerminalSentinelEnv(max_acts)] * num_envs)
   policy = RandomPolicy(vec_env.observation_space, vec_env.action_space)
-  sample_until = rollout.n_episodes(n_episodes)
+  sample_until = rollout.min_episodes(min_episodes)
   trajectories = rollout.generate_trajectories(policy,
                                                vec_env,
                                                sample_until=sample_until)
-  assert len(trajectories) >= n_episodes
+  assert len(trajectories) >= min_episodes
   expected_obs = np.array([[0]] * max_acts + [[1]])
   for trajectory in trajectories:
     obs = trajectory.obs

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -29,15 +29,17 @@ class TerminalSentinelEnv(gym.Env):
 
 def test_complete_trajectories():
   """Check that complete trajectories are returned by vecenv wrapper,
-  including the terminal observation."""
+     including the terminal observation.
+  """
   n_episodes = 13
   max_acts = 5
   num_envs = 4
   vec_env = DummyVecEnv([lambda: TerminalSentinelEnv(max_acts)] * num_envs)
   policy = RandomPolicy(vec_env.observation_space, vec_env.action_space)
+  sample_until = rollout.n_episodes(n_episodes)
   trajectories = rollout.generate_trajectories(policy,
                                                vec_env,
-                                               n_episodes=n_episodes)
+                                               sample_until=sample_until)
   assert len(trajectories) >= n_episodes
   expected_obs = np.array([[0]] * max_acts + [[1]])
   for trajectory in trajectories:

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -38,8 +38,8 @@ def test_train_disc_no_crash(use_gail, parallel,
                              env='CartPole-v1', n_timesteps=200):
   trainer = init_test_trainer(env, use_gail=use_gail, parallel=parallel)
   trainer.train_disc()
-  transitions = rollout.generate_transitions(trainer.gen_policy,
-                                             env, n_timesteps=n_timesteps)
+  transitions = rollout.generate_transitions(trainer.gen_policy, env,
+                                             n_timesteps=n_timesteps)
   trainer.train_disc(gen_obs=transitions.obs, gen_act=transitions.act,
                      gen_next_obs=transitions.next_obs)
 


### PR DESCRIPTION
The codebase currently supports two termination conditions for rollouts: `n_timesteps` and `n_episodes`. This covers typical use cases. However, I recently came across a case not covered by this. In preference comparison, I want to sample a fixed number of segments (smaller than an episode) for a user to compare. So if my segment length is 25, an episode of length 20 would not count at all, and an episode of 51 would count as two. I suspect users will encounter other unusual scenarios that require custom termination conditions.

Fortunately, there's nothing about the sampling logic that really depends on the termination condition, so this PR factors this out. I provide two convenience methods, `min_timesteps` and `n_episodes`, that replicate the previous behavior. I specialize `generate_transitions` to just use `n_timesteps`: the `n_episodes` parameter is never used in the codebase, and I expect it to be used infrequently since if you care about episodes you would normally use `generate_trajectories`.

It might be better to keep `n_episodes` and `n_timesteps` in `generate_trajectories` and add an extra parameter `sample_until`. I decided against this since I find the pick-one-of-N arguments pattern confusing (and abuses won't get caught by the type checker), and in most places in the code only one of them is used. However, it does mean that some of the complexity gets pushed to the CLI scripts: `expert_demos` now has a lengthily `traj_sample_until` method to handle the argument parsing. We may want to move that method to `util.rollout` if/when it gets needed elsewhere.

@qxcv as before tagging you since you wrote a lot of the rollout code, but reviewing this is optional.