### PR TITLE
PointMaze: add velocity to observations

### DIFF
--- a/src/imitation/envs/examples/airl_envs/__init__.py
+++ b/src/imitation/envs/examples/airl_envs/__init__.py
@@ -10,23 +10,24 @@ def _register(env_name: str, entry_point: str, kwargs: Optional[dict] = None):
     gym_register(id=env_name, entry_point=entry_point, kwargs=kwargs)
 
 
+def _point_maze_register():
+  for dname, dval in {'Left': 0, 'Right': 1}.items():
+    for vname, vval in {'': False, 'Vel': True}.items():
+      _register(f'imitation/PointMaze{dname}{vname}-v0',
+                entry_point='point_maze_env:PointMazeEnv',
+                kwargs={
+                  'direction': dval,
+                  'include_vel': vval,
+                })
+
+
 _register('imitation/ObjPusher-v0',
           entry_point=f'pusher_env:PusherEnv',
           kwargs={'sparse_reward': False})
 _register('imitation/TwoDMaze-v0',
           entry_point='twod_maze:TwoDMaze')
-_register('imitation/PointMazeRight-v0',
-          entry_point='point_maze_env:PointMazeEnv',
-          kwargs={
-              'sparse_reward': False,
-              'direction': 1,
-          })
-_register('imitation/PointMazeLeft-v0',
-          entry_point='point_maze_env:PointMazeEnv',
-          kwargs={
-              'sparse_reward': False,
-              'direction': 0,
-          })
+
+_point_maze_register()
 
 # A modified ant which flips over less and learns faster via TRPO
 _register('imitation/CustomAnt-v0',

--- a/src/imitation/envs/examples/airl_envs/point_maze_env.py
+++ b/src/imitation/envs/examples/airl_envs/point_maze_env.py
@@ -12,10 +12,12 @@ class PointMazeEnv(mujoco_env.MujocoEnv, utils.EzPickle):
                maze_length=0.6,
                sparse_reward=False,
                no_reward=False,
+               include_vel=False,
                episode_length=100):
     utils.EzPickle.__init__(self)
     self.sparse_reward = sparse_reward
     self.no_reward = no_reward
+    self.include_vel = include_vel
     self.max_episode_length = episode_length
     self.direction = direction
     self.length = maze_length
@@ -62,10 +64,10 @@ class PointMazeEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     return self._get_obs()
 
   def _get_obs(self):
-    return np.concatenate([
-        self.get_body_com("particle"),
-        # self.get_body_com("target"),
-    ])
+    obs = [self.get_body_com("particle")]
+    if self.include_vel:
+      obs.append(self.sim.data.get_body_xvelp("particle"))
+    return np.concatenate(obs)
 
   def plot_trajs(self, *args, **kwargs):
     pass

--- a/src/imitation/policies/base.py
+++ b/src/imitation/policies/base.py
@@ -13,6 +13,9 @@ class HardCodedPolicy(BasePolicy, abc.ABC):
   def __init__(self, ob_space: gym.Space, ac_space: gym.Space):
     self.ob_space = ob_space
     self.ac_space = ac_space
+    self.n_env = None
+    self.n_steps = None
+    self.n_batch = None
 
   def step(self, obs, state=None, mask=None, deterministic=False):
     actions = []


### PR DESCRIPTION
Currently PointMaze observations is just the position of the particle (in Cartesian coordinates).

This makes the environment highly non-Markovian, and leads to even expert policies looking rather jagged: they keep accelerating towards the particle, overshooting, and correcting winding up in SHM-like motion.

This PR optionally adds velocity to the observations. I'd recommend the version with velocity for any tests not designed to directly replicate the original AIRL paper.

Minor nit: `get_body_com` returns `(x,y,z)` coordinates but it's a 2D plane, so the `z`-coordinate is always zero. We should probably just use `qpos` and `qvel` directly, but that'd break backward compatibility.