### PR TITLE
Support custom arguments to VecNormalize

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'scikit-learn>=0.21.2',
         # FIXME: Use stable release instead of tracking master once
         # commit 9a760542 is released.
-        'stable-baselines @ git+https://github.com/hill-a/stable-baselines.git',
+        'stable-baselines @ git+https://github.com/hill-a/stable-baselines.git@vec-normalize-pickle',
         'jax!=0.1.37',
         'jaxlib~=0.1.20',
         # sacred==0.7.5 build is broken without pymongo

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,8 @@ setup(
         'ray[debug]==0.7.4',
         'tqdm',
         'scikit-learn>=0.21.2',
-        # FIXME: Use stable release instead of tracking master once
-        # commit 9a760542 is released.
-        'stable-baselines @ git+https://github.com/hill-a/stable-baselines.git@vec-normalize-pickle',
+        # TODO(adam): Change to >=2.9.0 once 2.9.0 is released, until then track master
+        'stable-baselines @ git+https://github.com/hill-a/stable-baselines.git',
         'jax!=0.1.37',
         'jaxlib~=0.1.20',
         # sacred==0.7.5 build is broken without pymongo

--- a/src/imitation/envs/examples/airl_envs/point_maze_env.py
+++ b/src/imitation/envs/examples/airl_envs/point_maze_env.py
@@ -56,9 +56,8 @@ class PointMazeEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
   def reset_model(self):
     qpos = self.init_qpos
-    self.episode_length = 0
-    qvel = self.init_qvel + \
-        self.np_random.uniform(size=self.model.nv, low=-0.01, high=0.01)
+    qvel = (self.init_qvel +
+            self.np_random.uniform(size=self.model.nv, low=-0.01, high=0.01))
     self.set_state(qpos, qvel)
     self.episode_length = 0
     return self._get_obs()

--- a/src/imitation/policies/serialize.py
+++ b/src/imitation/policies/serialize.py
@@ -75,6 +75,7 @@ def _load_stable_baselines(cls: Type[BaseRLModel],
           vec_normalize = pickle.load(f)
         vec_normalize.training = False
         vec_normalize.set_venv(venv)
+        policy = NormalizePolicy(policy, vec_normalize)
         tf.logging.info(f"Loaded VecNormalize from '{normalize_path}'")
       except FileNotFoundError:
         # We did not use VecNormalize during training, skip

--- a/src/imitation/policies/serialize.py
+++ b/src/imitation/policies/serialize.py
@@ -4,6 +4,7 @@ import contextlib
 import os
 import pickle
 from typing import Callable, ContextManager, Iterator, Optional, Type
+import warnings
 
 from stable_baselines.common.base_class import BaseRLModel
 from stable_baselines.common.policies import BasePolicy
@@ -83,8 +84,8 @@ def _load_stable_baselines(cls: Type[BaseRLModel],
       try:
         vec_normalize = VecNormalize(venv, training=False)
         vec_normalize.load_running_average(path)
-        warnings.warn("Loading VecNormalize with deprecated way of saving statistics.",
-                      DeprecationWarning)
+        warnings.warn("Loading VecNormalize with deprecated way of "
+                      " saving statistics.", DeprecationWarning)
         policy = NormalizePolicy(policy, vec_normalize)
         tf.logging.info(f"Loaded normalization statistics from '{path}'")
       except FileNotFoundError:

--- a/src/imitation/scripts/config/expert_demos.py
+++ b/src/imitation/scripts/config/expert_demos.py
@@ -15,7 +15,7 @@ def expert_demos_defaults():
   num_vec = 8  # Number of environments in VecEnv
   parallel = True  # Use SubprocVecEnv (generally faster if num_vec>1)
   normalize = True  # Use VecNormalize
-  normalize_kwargs = dict()
+  normalize_kwargs = dict()  # kwargs for `VecNormalize`
   max_episode_steps = None  # Set to positive int to limit episode horizons
   n_episodes_eval = 50  # Num of episodes for final ep reward mean evaluation
 

--- a/src/imitation/scripts/config/expert_demos.py
+++ b/src/imitation/scripts/config/expert_demos.py
@@ -15,6 +15,7 @@ def expert_demos_defaults():
   num_vec = 8  # Number of environments in VecEnv
   parallel = True  # Use SubprocVecEnv (generally faster if num_vec>1)
   normalize = True  # Use VecNormalize
+  normalize_kwargs = dict()
   max_episode_steps = None  # Set to positive int to limit episode horizons
   n_episodes_eval = 50  # Num of episodes for final ep reward mean evaluation
 

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -70,9 +70,6 @@ def rollouts_and_policy(
       n_episodes_eval: The number of episodes to average over when calculating
           the average ground truth reward return of the final policy.
 
-      n_episodes_eval: The number of episodes to average over when calculating
-          the average ground truth reward return of the final policy.
-
       reward_type: If provided, then load the serialized reward of this type,
           wrapping the environment in this reward. This is useful to test
           whether a reward model transfers. For more information, see

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -27,6 +27,7 @@ def rollouts_and_policy(
   parallel: bool,
   max_episode_steps: Optional[int],
   normalize: bool,
+  normalize_kwargs: dict,
   init_rl_kwargs: dict,
 
   n_episodes_eval: int,
@@ -63,6 +64,7 @@ def rollouts_and_policy(
           TimeLimit so that they have at most `max_episode_steps` steps per
           episode.
       normalize: If True, then rescale observations and reward.
+      normalize_kwargs: kwargs for `VecNormalize`.
       init_rl_kwargs: kwargs for `init_rl`.
 
       n_episodes_eval: The number of episodes to average over when calculating
@@ -138,7 +140,7 @@ def rollouts_and_policy(
 
       vec_normalize = None
       if normalize:
-        venv = vec_normalize = VecNormalize(venv)
+        venv = vec_normalize = VecNormalize(venv, **normalize_kwargs)
 
       policy = util.init_rl(venv, verbose=1, **init_rl_kwargs)
 


### PR DESCRIPTION
Use case that prompted this was wanting to normalize reward (since learnt reward models can have arbitrary scale) but not observations of an environment.

Shouldn't merge until https://github.com/hill-a/stable-baselines/pull/525 is merged (or at least looks like it'll be merged).