### PR TITLE
Smoke test for fast version of experiments

### DIFF
--- a/experiments/transfer_learn_benchmark.sh
+++ b/experiments/transfer_learn_benchmark.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e
+
 # Train PPO2 experts using reward models from experiments/imit_benchmark.sh
 
 TIMESTAMP=$(date --iso-8601=seconds)
@@ -25,6 +27,7 @@ while true; do
     # Fast mode (debug)
     -f | --fast)
       ENVS="cartpole mountain_car"
+      REWARD_MODELS_DIR="tests/data/reward_models"
       SEEDS="0"
       extra_configs+="fast "
       shift

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,0 +1,12 @@
+"""Smoke tests for bash scripts in experiments/"""
+import pytest
+import subprocess
+
+
+@pytest.mark.parametrize("script_name", ["imit_benchmark.sh",
+                                         "train_experts.sh",
+                                         "transfer_learn_benchmark.sh"])
+def test_experiments_fast(script_name: str):
+  """Quickly check that experiments run successfully on fast mode."""
+  exit_code = subprocess.call([f'./experiments/{script_name}', '--fast'])
+  assert exit_code == 0

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,6 +1,7 @@
 """Smoke tests for bash scripts in experiments/"""
-import pytest
 import subprocess
+
+import pytest
 
 
 @pytest.mark.parametrize("script_name", ["imit_benchmark.sh",


### PR DESCRIPTION
Resolves #62.

- [ ] Fix `No such file or directory: 'tests/data/reward_models/gail/cartpole_0/checkpoints/final/discrim/loader'` by adding cartpole/pendulum reward model regeneration to `generate_test_data.sh`.
  - Wait until the new reward models for #116 are uploaded (after this PR there will be a new directory hierachy).