### PR TITLE
adversarial: Use VecNormalized training reward and update plots

### DIFF
--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -112,9 +112,7 @@ class AdversarialTrainer:
           self.venv, reward_train)
       self.venv_test = reward_wrapper.RewardVecEnvWrapper(
           self.venv, self.discrim.reward_test)
-
-      self.venv_train_norm = VecNormalize(
-          self.venv_train, norm_obs=False, norm_reward=True)
+      self.venv_train_norm = VecNormalize(self.venv_train)
 
     if gen_replay_buffer_capacity is None:
       gen_replay_buffer_capacity = 20 * self._n_disc_samples_per_buffer

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -90,11 +90,6 @@ def airl():
 
 
 @train_ex.named_config
-def plots():
-  plot_interval = 10
-
-
-@train_ex.named_config
 def acrobot():
   env_name = "Acrobot-v1"
   rollout_hint = "acrobot"

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -22,8 +22,11 @@ def train_defaults():
   n_gen_steps_per_epoch = 2048
   airl_entropy_weight = 1.0
 
-  plot_interval = -1  # Number of epochs in between plots (<=0 disables)
+  # Number of epochs in between plots (<0 disables) (=0 means final plot only)
+  plot_interval = -1
   n_plot_episodes = 5  # Number of rollouts for each mean_ep_rew data
+  # Interval for extra episode rew data. (<=0 disables)
+  extra_episode_data_interval = -1
   show_plots = True  # Show plots in addition to saving them
 
   init_trainer_kwargs = dict(

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -280,6 +280,9 @@ class _TrainVisualizer:
 
   def add_data_ep_reward(self, epoch):
     """Calculate and record average episode returns."""
+    if epoch in self.ep_reward_X:
+      # Don't calculate ep reward twice.
+      return
     self.ep_reward_X.append(epoch)
     self._add_data_ep_reward(self.venv_norm_obs, "Ground Truth Reward")
     self._add_data_ep_reward(self.venv_train_norm_obs, "Train Reward")

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -297,8 +297,8 @@ class _TrainVisualizer:
         trajs_gen = [util.rollout.rewrite_rewards_traj(t, reward_fn)
                      for t in trajs_gen_orig_rew]
 
-      gen_ret = util.rollout.rollout_stats(trajs_gen)["mean"]
-      rand_ret = util.rollout.rollout_stats(trajs_rand)["mean"]
+      gen_ret = util.rollout.rollout_stats(trajs_gen)["return_mean"]
+      rand_ret = util.rollout.rollout_stats(trajs_rand)["return_mean"]
       self.gen_ep_reward[reward_name].append(gen_ret)
       self.rand_ep_reward[reward_name].append(rand_ret)
       tf.logging.info(f"{reward_name} generator return: {gen_ret}")

--- a/src/imitation/util/reward_wrapper.py
+++ b/src/imitation/util/reward_wrapper.py
@@ -26,8 +26,9 @@ class RewardVecEnvWrapper(vec_env.VecEnvWrapper):
 
     Args:
         venv: The VecEnv to wrap.
-        reward_fn: A function that wraps takes in an (obs, act, next_obs)
-            triple and returns a vector of rewards.
+        reward_fn: A function that wraps takes in vectorized transitions
+            (obs, act, next_obs) a vector of episode timesteps, and returns a
+            vector of rewards.
         ep_history: The number of episode rewards to retain for computing
             mean reward.
     """

--- a/src/imitation/util/rollout.py
+++ b/src/imitation/util/rollout.py
@@ -52,11 +52,10 @@ def unwrap_traj(traj: Trajectory) -> Trajectory:
   return res
 
 
-def rewrite_rewards_traj(traj: Trajectory, reward_fn: RewardFn) -> Trajectory:
-  """Returns a copy of `traj` with modified rewards."""
+def recalc_rewards_traj(traj: Trajectory, reward_fn: RewardFn) -> np.ndarray:
+  """Returns the rewards of the trajectory calculated under a diff reward fn."""
   steps = np.arange(len(traj.rews))
-  new_rew = reward_fn(traj.obs[:-1], traj.acts, traj.obs[1:], steps)
-  return traj._replace(rews=new_rew)
+  return reward_fn(traj.obs[:-1], traj.acts, traj.obs[1:], steps)
 
 
 class Transitions(NamedTuple):

--- a/src/imitation/util/rollout.py
+++ b/src/imitation/util/rollout.py
@@ -11,6 +11,7 @@ from stable_baselines.common.vec_env import VecEnv
 import tensorflow as tf
 
 from imitation.policies.base import get_action_policy
+from imitation.util.reward_wrapper import RewardFn
 
 
 class Trajectory(NamedTuple):
@@ -49,6 +50,13 @@ def unwrap_traj(traj: Trajectory) -> Trajectory:
   assert len(res.obs) == len(res.acts) + 1
   assert len(res.rews) == len(res.acts)
   return res
+
+
+def rewrite_rewards_traj(traj: Trajectory, reward_fn: RewardFn) -> Trajectory:
+  """Returns a copy of `traj` with modified rewards."""
+  steps = np.arange(len(traj.rews))
+  new_rew = reward_fn(traj.obs[:-1], traj.acts, traj.obs[1:], steps)
+  return traj._replace(rews=new_rew)
 
 
 class Transitions(NamedTuple):

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -103,8 +103,8 @@ def reapply_vec_normalize(venv: VecEnv,
   if disable_norm_reward:
     state['norm_reward'] = False
 
-  result = VecNormalize(venv=None)
-  result.__set_state__(state)
+  result = VecNormalize.__new__(VecNormalize)
+  result.__setstate__(state)
   result.set_venv(venv)
   return result
 

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -71,6 +71,14 @@ def make_vec_env(env_name: str,
     return DummyVecEnv(env_fns)
 
 
+@contextlib.contextmanager
+def vec_norm_disable_training(vec_norm: VecNormalize):
+  """ContextManager that temporarily sets vec_norm.training to False."""
+  prev_training, vec_norm.training = vec_norm.training, False
+  yield
+  vec_norm.training = prev_training
+
+
 def reapply_vec_normalize(venv: VecEnv,
                           src_vec_norm: VecNormalize,
                           *,

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -74,6 +74,7 @@ def make_vec_env(env_name: str,
 @contextlib.contextmanager
 def vec_norm_disable_training(vec_norm: VecNormalize):
   """ContextManager that temporarily sets vec_norm.training to False."""
+  # TODO: Remove once hill-a/stable-baselines#602 is resolved.
   prev_training, vec_norm.training = vec_norm.training, False
   yield
   vec_norm.training = prev_training

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -14,7 +14,8 @@ from stable_baselines import bench
 from stable_baselines.common.base_class import BaseRLModel
 from stable_baselines.common.input import observation_input
 from stable_baselines.common.policies import BasePolicy, MlpPolicy
-from stable_baselines.common.vec_env import DummyVecEnv, SubprocVecEnv, VecEnv
+from stable_baselines.common.vec_env import (DummyVecEnv, SubprocVecEnv, VecEnv,
+                                             VecNormalize)
 import tensorflow as tf
 
 # TODO(adam): this should really be OrderedDict but that breaks Python
@@ -68,6 +69,44 @@ def make_vec_env(env_name: str,
     return SubprocVecEnv(env_fns, start_method='forkserver')
   else:
     return DummyVecEnv(env_fns)
+
+
+def reapply_vec_normalize(venv: VecEnv,
+                          src_vec_norm: VecNormalize,
+                          *,
+                          disable_training: bool = True,
+                          disable_norm_obs: bool = False,
+                          disable_norm_reward: bool = False,
+                          ) -> VecNormalize:
+  """Returns `venv` wrapped in a VecNormalize similar to `src_vec_norm`.
+
+  The new VecNormalize has the same running mean and standard deviation as
+  before, but will disable training, observation normalization, and reward
+  normalization if certain parameters to this function are True.
+
+  Args:
+    venv: A VecEnv.
+    src_vec_norm: A VecNormalize that wraps a VecEnv with the same
+      observation and actions space as `venv`.
+    disable_norm_training: If True, then disable training in the returned
+      VecNormalize.
+    disable_norm_obs: If True, then disable observation normalization
+      in the returned VecNormalize.
+    disable_norm_reward: If False, then disable reward normalization
+      in the returned VecNormalize.
+  """
+  state = src_vec_norm.__getstate__()
+  if disable_training:
+    state['training'] = False
+  if disable_norm_obs:
+    state['norm_obs'] = False
+  if disable_norm_reward:
+    state['norm_reward'] = False
+
+  result = VecNormalize(venv=None)
+  result.__set_state__(state)
+  result.set_venv(venv)
+  return result
 
 
 def init_rl(env: Union[gym.Env, VecEnv],

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -93,7 +93,7 @@ def _check_train_ex_result(result: dict):
 
 def test_train_adversarial(tmpdir):
   """Smoke test for imitation.scripts.train_adversarial"""
-  named_configs = ['cartpole', 'gail', 'fast', 'plots']
+  named_configs = ['cartpole', 'gail', 'fast']
   config_updates = {
       'init_trainer_kwargs': {
           # Rollouts are small, decrease size of buffer to avoid warning
@@ -104,6 +104,8 @@ def test_train_adversarial(tmpdir):
       'log_root': tmpdir,
       'rollout_path': "tests/data/expert_models/cartpole_0/rollouts/final.pkl",
       'init_tensorboard': True,
+      'plot_interval': 1,
+      'extra_episode_data_interval': 1,
   }
   run = train_ex.run(
       named_configs=named_configs,


### PR DESCRIPTION
`imitation.adversarial.trainer` never applied VecNormalize to rewards or observations during PPO2 training. This means that before this patch, PPO2 for the
GAN's generator was training with an unnormalized reward.

As an example of why this is bad, we have a dozen or so runs showing that training an expert in PPO2+MountainCar achieves minimum episode reward when observations are not normalized.

* Adding a new instance variable `AdversarialTrainer.env_train_norm` which has VecNormalized reward. `AdversarialTrainer.env_train` remains even though it isn't used for training GAIL/ARIL because it is useful for plotting training reward in `scripts/train_adversarial.py`.

* Plotting logic in the `train_adversarial` script needed an update after this change because rollouts no longer function properly on the three rollout environments `trainer.{,train_,test_}venv` without reapplying `trainer.train_venv_norm`'s normalization wrapper.
  * I fixed up some tests in plots in the meantime