### PR TITLE
Relative paths in serializing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .#*
 *.html
 output/
-./data/
+/data/
 auto.pkl
 
 # Byte-compiled / optimized / DLL files

--- a/src/imitation/util/sacred.py
+++ b/src/imitation/util/sacred.py
@@ -73,7 +73,9 @@ def build_sacred_symlink(log_dir: str, run: sacred.run.Run) -> None:
     warnings.warn(RuntimeWarning("Couldn't find sacred directory."))
     return
   symlink_path = os.path.join(log_dir, "sacred")
-  os.symlink(os.path.abspath(sacred_dir), symlink_path)
+  # Use relative paths so we can mount the output directory at different paths
+  # (e.g. when copying across machines).
+  os.symlink(os.path.relpath(sacred_dir), symlink_path)
 
 
 def get_sacred_dir_from_run(run: sacred.run.Run) -> Union[str, None]:

--- a/src/imitation/util/sacred.py
+++ b/src/imitation/util/sacred.py
@@ -75,7 +75,8 @@ def build_sacred_symlink(log_dir: str, run: sacred.run.Run) -> None:
   symlink_path = os.path.join(log_dir, "sacred")
   # Use relative paths so we can mount the output directory at different paths
   # (e.g. when copying across machines).
-  os.symlink(os.path.relpath(sacred_dir), symlink_path)
+  os.symlink(os.path.relpath(sacred_dir), symlink_path,
+             target_is_directory=True)
 
 
 def get_sacred_dir_from_run(run: sacred.run.Run) -> Union[str, None]:

--- a/src/imitation/util/sacred.py
+++ b/src/imitation/util/sacred.py
@@ -73,10 +73,10 @@ def build_sacred_symlink(log_dir: str, run: sacred.run.Run) -> None:
     warnings.warn(RuntimeWarning("Couldn't find sacred directory."))
     return
   symlink_path = os.path.join(log_dir, "sacred")
+  target_path = os.path.relpath(sacred_dir, start=log_dir)
   # Use relative paths so we can mount the output directory at different paths
   # (e.g. when copying across machines).
-  os.symlink(os.path.relpath(sacred_dir), symlink_path,
-             target_is_directory=True)
+  os.symlink(target_path, symlink_path, target_is_directory=True)
 
 
 def get_sacred_dir_from_run(run: sacred.run.Run) -> Union[str, None]:

--- a/src/imitation/util/serialize.py
+++ b/src/imitation/util/serialize.py
@@ -70,7 +70,13 @@ class LayersSerializable(Serializable):
     return (make_cls, (type(self), self._args, self._kwargs))
 
   def save_parameters(self, directory: str) -> None:
-    self._checkpoint.save(file_prefix=os.path.join(directory, "weights"))
+    file_prefix = os.path.join(directory, "weights")
+    # TensorFlow stores a path to the latest checkpoint. It will use a relative
+    # path if you give a relative `file_prefix`, otherwise it will use
+    # absolute paths. We want it to use relative paths so saved models are
+    # portable across machines. See TF issue #2973.
+    file_prefix = os.path.relpath(file_prefix)
+    self._checkpoint.save(file_prefix=file_prefix)
 
   def load_parameters(self, directory: str) -> None:
     restore = self._checkpoint.restore(tf.train.latest_checkpoint(directory))

--- a/src/imitation/util/serialize.py
+++ b/src/imitation/util/serialize.py
@@ -100,4 +100,4 @@ class LayersSerializable(Serializable):
       with open(obj_path, 'wb') as f:
         pickle.dump(self, f)
 
-    self._checkpoint.save(file_prefix=os.path.join(directory, "weights"))
+    self.save_parameters(directory)


### PR DESCRIPTION
Use relative paths when serializing, so that the saved models and other outputs are easily portable across machines. (This also often is useful even for local machines, as paths may differ inside/outside Docker.)