### PR TITLE
Downgrade SciPy to fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
             curl -o /root/.mujoco/mjkey.txt ${MUJOCO_KEY}
             md5sum /root/.mujoco/mjkey.txt
             # Only create venv if it's not been restored from cache
-            [[ -d /venv ]] || USE_MPI=True ./ci/build_venv.sh /venv
+            [[ -d /venv ]] || ./ci/build_venv.sh /venv
             python -c "import mujoco_py"
 
       - save_cache:

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ setup(
         # sacred==0.7.5 build is broken without pymongo
         # sacred>0.7.4 have non-picklable config objects (see GH #109)
         'sacred==0.7.4',
+        # Remove this version pin once scipy/#11237 is fixed
+        'scipy==1.3.3',
     ],
     tests_require=TESTS_REQUIRE,
     extras_require={


### PR DESCRIPTION
  - Pin scipy to avoid https://github.com/scipy/scipy/issues/11237
  - Remove dead code in CircleCI config (we no longer use MPI anywhere)

I also saw an error in https://circleci.com/gh/HumanCompatibleAI/imitation/185#tests/containers/1 that seems to be due to https://github.com/nedbat/coveragepy/issues/881 but I've not been able to reproduce. If this reoccurs we should consider pinning coverage to 4.5.4 until the issue is resolved.