### PR TITLE
Downgrade coverage to workaround bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import src.imitation  # pytype:disable=import-error
 
 TF_VERSION = '>=1.15.0,<2.0'
 TESTS_REQUIRE = [
+    # remove pin once https://github.com/nedbat/coveragepy/issues/881 fixed
+    'coverage==4.5.4',
     'codecov',
     'codespell',
     'flake8',


### PR DESCRIPTION
CI tests are triggering bug https://github.com/nedbat/coveragepy/issues/881 see e.g. https://circleci.com/gh/HumanCompatibleAI/imitation/193#queue-placeholder/containers/1 and https://circleci.com/gh/HumanCompatibleAI/imitation/185#tests/containers/1

Downgrade to 4.5.4 which does not suffer from this bug.