### PR TITLE
pytype: specify version and sources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,3 +52,11 @@ omit =
 source =
     src/imitation
     *venv/lib/python*/site-packages/imitation
+
+[pytype]
+inputs =
+	src/
+	tests/
+	experiments/
+	setup.py
+python_version = 3.7


### PR DESCRIPTION
Version is important since otherwise it will default to whatever is in the environment, which could give different results on different systems.

Specifying inputs is just a convenience: you can just run `pytype` with no arguments to type check everything.