### PR TITLE
train_adversarial: Change checkpoint default, fix logic

### DIFF
--- a/experiments/imit_benchmark.sh
+++ b/experiments/imit_benchmark.sh
@@ -76,7 +76,7 @@ parallel -j 25% --header : --results ${LOG_ROOT}/parallel/ --colsep , --progress
   log_dir="${LOG_ROOT}/{env_config_name}_{seed}/n_expert_demos_{n_expert_demos}" \
   gen_batch_size={gen_batch_size} \
   rollout_path=${EXPERT_MODELS_DIR}/{env_config_name}_0/rollouts/final.pkl \
-  checkpoint_interval=-1 \
+  checkpoint_interval=0 \
   n_expert_demos={n_expert_demos} \
   seed={seed} \
   :::: $CONFIG_CSV \

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -44,7 +44,7 @@ def train_defaults():
   )
 
   log_root = os.path.join("output", "train_adversarial")  # output directory
-  checkpoint_interval = 5  # num epochs between checkpoints (<=0 disables)
+  checkpoint_interval = 0  # num epochs between checkpoints (<0 disables)
   init_tensorboard = False  # If True, then write Tensorboard logs.
   rollout_hint = None  # Used to generate default rollout_path
   data_dir = "data/"  # Default data directory

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -104,8 +104,9 @@ def train(_run,
     init_tensorboard: If True, then write tensorboard logs to `{log_dir}/sb_tb`.
 
     checkpoint_interval: Save the discriminator and generator models every
-      `checkpoint_interval` epochs and after training is complete. If <=0,
-      then only save weights after training is complete.
+      `checkpoint_interval` epochs and after training is complete. If 0,
+      then only save weights after training is complete. If <0, then don't
+      save weights at all.
 
   Returns:
     A dictionary with two keys. "imit_stats" gives the return value of
@@ -183,7 +184,8 @@ def train(_run,
         save(trainer, os.path.join(log_dir, "checkpoints", f"{epoch:05d}"))
 
     # Save final artifacts.
-    save(trainer, os.path.join(log_dir, "checkpoints", "final"))
+    if checkpoint_interval >= 0:
+      save(trainer, os.path.join(log_dir, "checkpoints", "final"))
 
     if visualizer:
       visualizer.plot_disc_loss()


### PR DESCRIPTION
Now by default only save the final checkpoint. (per 5 epochs was too often, and I've only used the final epoch ever).

Also modifies meaning of <0 to allow disabling any checkpointing.