### PR TITLE
train_adversarial: Remove custom plotting

### DIFF
--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -229,12 +229,6 @@ class AdversarialTrainer:
   def eval_disc_loss(self, **kwargs) -> float:
     """Evaluates the discriminator loss.
 
-    The generator rollout parameters of the form "gen_*" are optional,
-    but if one is given, then all such parameters must be filled (otherwise
-    this method will error). If none of the generator rollout parameters are
-    given, then a rollout with the same length as the expert rollout
-    is generated on the fly.
-
     Args:
       gen_samples (Optional[rollout.Transitions]): Same as in `train_disc_step`.
       expert_samples (Optional[rollout.Transitions]): Same as in
@@ -272,7 +266,7 @@ class AdversarialTrainer:
 
   def train(self,
             total_timesteps: int,
-            callback: Optional[Callable[[bool], None]] = None,
+            callback: Optional[Callable[[int], None]] = None,
             ) -> None:
     """Alternates between training the generator and discriminator.
 

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -1,12 +1,13 @@
 from functools import partial
 import os
-from typing import Optional, Sequence
+from typing import Callable, Optional, Sequence
 from warnings import warn
 
 import numpy as np
 from stable_baselines.common.base_class import BaseRLModel
 from stable_baselines.common.vec_env import VecEnv, VecNormalize
 import tensorflow as tf
+import tqdm
 
 import imitation.rewards.discrim_net as discrim_net
 from imitation.rewards.reward_net import BasicShapedRewardNet
@@ -225,34 +226,6 @@ class AdversarialTrainer:
         logger.logkv(k, v)
       logger.dumpkvs()
 
-  def train_gen(self, total_timesteps: Optional[int] = None, callback=None):
-    """Trains the generator to maximize the discriminator loss.
-
-    After the end of training populates the generator replay buffer (used in
-    discriminator training) with `self.disc_batch_size` transitions.
-
-    Args:
-      total_timesteps: The number of transitions to sample from
-        `self.venv_train_norm` during training. By default,
-        `self.gen_batch_size`.
-      callback: Callback argument to the Stable Baselines `RLModel.learn()`
-        method.
-    """
-    if total_timesteps is None:
-      total_timesteps = self.gen_batch_size
-
-    with logger.accumulate_means("gen"):
-      self.gen_policy.set_env(self.venv_train_norm_buffering)
-      # TODO(adam): learn was not intended to be called for each training batch
-      # It should work, but might incur unnecessary overhead: e.g. in PPO2
-      # a new Runner instance is created each time. Also a hotspot for errors:
-      # algorithms not tested for this use case, may reset state accidentally.
-      self.gen_policy.learn(total_timesteps=total_timesteps,
-                            reset_num_timesteps=False,
-                            callback=callback)
-      gen_samples = self.venv_train_norm_buffering.pop_transitions()
-      self._gen_replay_buffer.store(gen_samples)
-
   def eval_disc_loss(self, **kwargs) -> float:
     """Evaluates the discriminator loss.
 
@@ -272,6 +245,60 @@ class AdversarialTrainer:
     """
     fd = self._build_disc_feed_dict(**kwargs)
     return np.mean(self._sess.run(self.discrim.disc_loss, feed_dict=fd))
+
+  def train_gen(self, total_timesteps: Optional[int] = None, callback=None):
+    """Trains the generator to maximize the discriminator loss.
+
+    After the end of training populates the generator replay buffer (used in
+    discriminator training) with `self.disc_batch_size` transitions.
+
+    Args:
+      total_timesteps: The number of transitions to sample from
+        `self.venv_train_norm` during training. By default,
+        `self.gen_batch_size`.
+      callback: Callback argument to the Stable Baselines `RLModel.learn()`
+        method.
+    """
+    if total_timesteps is None:
+      total_timesteps = self.gen_batch_size
+
+    with logger.accumulate_means("gen"):
+      self.gen_policy.set_env(self.venv_train_norm_buffering)
+      self.gen_policy.learn(total_timesteps=total_timesteps,
+                            reset_num_timesteps=False,
+                            callback=callback)
+      gen_samples = self.venv_train_norm_buffering.pop_transitions()
+      self._gen_replay_buffer.store(gen_samples)
+
+  def train(self,
+            total_timesteps: int,
+            callback: Optional[Callable[[bool], None]] = None,
+            ) -> None:
+    """Alternates between training the generator and discriminator.
+
+    Every epoch consists of a call to `train_gen(self.gen_batch_size)`,
+    a call to `train_disc(self.disc_batch_size)`, and
+    finally a call to `callback(epoch)`.
+
+    Training ends once an additional epoch would cause the number of transitions
+    sampled from the environment to exceed `total_timesteps`.
+
+    Params:
+      total_timesteps: An upper bound on the number of transitions to sample
+        from the environment during training.
+      callback: A function called at the end of every epoch which takes in a
+        single argument, the epoch number. Epoch numbers are in
+        `range(total_timesteps // self.gen_batch_size)`.
+    """
+    n_epochs = total_timesteps // self.gen_batch_size
+    assert n_epochs >= 1, ("No updates (need at least "
+                           f"{self.gen_batch_size} timesteps, have only "
+                           f"total_timesteps={total_timesteps})!")
+    for epoch in tqdm.tqdm(range(0, n_epochs), desc="epoch"):
+      self.train_gen(self.gen_batch_size)
+      self.train_disc(self.disc_batch_size)
+      callback(epoch)
+      util.logger.dumpkvs()
 
   def _build_graph(self):
     # Build necessary parts of the TF graph. Most of the real action happens in

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -251,7 +251,7 @@ class AdversarialTrainer:
       total_timesteps: The number of transitions to sample from
         `self.venv_train_norm` during training. By default,
         `self.gen_batch_size`.
-      learn_kwargs: **kwargs for the Stable Baselines `RLModel.learn()`
+      learn_kwargs: kwargs for the Stable Baselines `RLModel.learn()`
         method.
     """
     if total_timesteps is None:

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -240,7 +240,8 @@ class AdversarialTrainer:
     fd = self._build_disc_feed_dict(**kwargs)
     return np.mean(self._sess.run(self.discrim.disc_loss, feed_dict=fd))
 
-  def train_gen(self, total_timesteps: Optional[int] = None, callback=None):
+  def train_gen(self, total_timesteps: Optional[int] = None,
+                learn_kwargs: dict = None):
     """Trains the generator to maximize the discriminator loss.
 
     After the end of training populates the generator replay buffer (used in
@@ -260,7 +261,7 @@ class AdversarialTrainer:
       self.gen_policy.set_env(self.venv_train_norm_buffering)
       self.gen_policy.learn(total_timesteps=total_timesteps,
                             reset_num_timesteps=False,
-                            callback=callback)
+                            **learn_kwargs)
       gen_samples = self.venv_train_norm_buffering.pop_transitions()
       self._gen_replay_buffer.store(gen_samples)
 
@@ -291,7 +292,8 @@ class AdversarialTrainer:
     for epoch in tqdm.tqdm(range(0, n_epochs), desc="epoch"):
       self.train_gen(self.gen_batch_size)
       self.train_disc(self.disc_batch_size)
-      callback(epoch)
+      if callback:
+        callback(epoch)
       util.logger.dumpkvs()
 
   def _build_graph(self):

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -241,7 +241,7 @@ class AdversarialTrainer:
     return np.mean(self._sess.run(self.discrim.disc_loss, feed_dict=fd))
 
   def train_gen(self, total_timesteps: Optional[int] = None,
-                learn_kwargs: dict = None):
+                learn_kwargs: Optional[dict] = None):
     """Trains the generator to maximize the discriminator loss.
 
     After the end of training populates the generator replay buffer (used in
@@ -251,11 +251,13 @@ class AdversarialTrainer:
       total_timesteps: The number of transitions to sample from
         `self.venv_train_norm` during training. By default,
         `self.gen_batch_size`.
-      callback: Callback argument to the Stable Baselines `RLModel.learn()`
+      learn_kwargs: **kwargs for the Stable Baselines `RLModel.learn()`
         method.
     """
     if total_timesteps is None:
       total_timesteps = self.gen_batch_size
+    if learn_kwargs is None:
+      learn_kwargs = {}
 
     with logger.accumulate_means("gen"):
       self.gen_policy.set_env(self.venv_train_norm_buffering)

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -4,19 +4,15 @@ Can be used as a CLI script, or the `train_and_plot` function can be called
 directly.
 """
 
-from collections import defaultdict
 import os
 import os.path as osp
 import pickle
 from typing import Optional
 
-from matplotlib import pyplot as plt
-import numpy as np
 from sacred.observers import FileStorageObserver
 import tensorflow as tf
-import tqdm
 
-from imitation.algorithms.adversarial import AdversarialTrainer, init_trainer
+from imitation.algorithms.adversarial import init_trainer
 import imitation.envs.examples  # noqa: F401
 from imitation.policies import serialize
 from imitation.scripts.config.train_adversarial import train_ex
@@ -45,13 +41,7 @@ def train(_run,
           init_trainer_kwargs: dict,
           total_timesteps: int,
           n_episodes_eval: int,
-
-          plot_interval: int,
-          n_plot_episodes: int,
-          extra_episode_data_interval: int,
-          show_plots: bool,
           init_tensorboard: bool,
-
           checkpoint_interval: int,
           ) -> dict:
   """Train an adversarial-network-based imitation learning algorithm.
@@ -142,53 +132,14 @@ def train(_run,
                            seed=_seed, log_dir=log_dir,
                            **init_trainer_kwargs)
 
-    if plot_interval >= 0:
-      visualizer = _TrainVisualizer(
-        trainer=trainer,
-        show_plots=show_plots,
-        n_episodes_per_reward_data=n_plot_episodes,
-        log_dir=log_dir,
-        expert_mean_ep_reward=expert_stats["return_mean"])
-    else:
-      visualizer = None
-
-    # Main training loop.
-    n_epochs = total_timesteps // trainer.gen_batch_size
-    assert n_epochs >= 1, ("No updates (need at least "
-                           f"{trainer.gen_batch_size} timesteps, have only "
-                           f"total_timesteps={total_timesteps})!")
-
-    for epoch in tqdm.tqdm(range(1, n_epochs+1), desc="epoch"):
-      trainer.train_gen(trainer.gen_batch_size)
-      if visualizer:
-        visualizer.add_data_disc_loss(True, epoch)
-      trainer.train_disc(trainer.disc_batch_size)
-
-      util.logger.dumpkvs()
-
-      if visualizer:
-        visualizer.add_data_disc_loss(False, epoch)
-
-        if (extra_episode_data_interval > 0
-            and epoch % extra_episode_data_interval == 0):  # noqa: E129
-          visualizer.add_data_ep_reward(epoch)
-
-        if plot_interval > 0 and epoch % plot_interval == 0:
-          visualizer.plot_disc_loss()
-          visualizer.add_data_ep_reward(epoch)
-          # Add episode mean rewards only at plot time because it is expensive.
-          visualizer.plot_ep_reward()
-
+    def callback(epoch):
       if checkpoint_interval > 0 and epoch % checkpoint_interval == 0:
         save(trainer, os.path.join(log_dir, "checkpoints", f"{epoch:05d}"))
 
+    trainer.train(total_timesteps, callback)
+
     # Save final artifacts.
     save(trainer, os.path.join(log_dir, "checkpoints", "final"))
-
-    if visualizer:
-      visualizer.plot_disc_loss()
-      visualizer.add_data_ep_reward(epoch)
-      visualizer.plot_ep_reward()
 
     # Final evaluation of imitation policy.
     results = {}
@@ -198,148 +149,7 @@ def train(_run,
                                                sample_until=sample_until_eval)
     results["imit_stats"] = util.rollout.rollout_stats(trajs)
     results["expert_stats"] = expert_stats
-
     return results
-
-
-class _TrainVisualizer:
-  def __init__(self,
-               trainer: AdversarialTrainer,
-               show_plots: bool,
-               n_episodes_per_reward_data: int,
-               log_dir: str,
-               expert_mean_ep_reward: Optional[float] = None):
-    """
-    Args:
-      trainer: AdversarialTrainer used to perform rollouts.
-      show_plots: If True, then `plt.show()` plot in addition to saving them.
-      n_episodes_per_reward_data: The number of episodes to rollout out when
-        determining the mean episode reward.
-      n_epochs_per_plot: An optional number, greater than or equal to 1. The
-        (possibly fractional) number of epochs between each plot. The first
-        plot is at epoch 0, after the first discrim and generator steps.
-        If `n_epochs_per_plot is None`, then don't make any plots.
-      expert_mean_ep_reward: If provided, then also plot the performance of
-        the expert policy.
-    """
-    self.trainer = trainer
-    self.show_plots = show_plots
-    self.n_episodes_per_reward_data = n_episodes_per_reward_data
-    self.log_dir = log_dir
-    self.expert_mean_ep_reward = expert_mean_ep_reward
-
-    self.venv_norm_obs = util.reapply_vec_normalize(
-      trainer.venv, trainer.venv_train_norm, disable_norm_reward=True)
-    self.plot_idx = 0
-    self.gen_data = ([], [])
-    self.disc_data = ([], [])
-
-    self.ep_reward_X = []
-    self.gen_ep_reward = defaultdict(list)
-    self.rand_ep_reward = defaultdict(list)
-
-    # Collect data for epoch 0.
-    self.add_data_disc_loss(False, 0)
-    self.add_data_ep_reward(0)
-
-  def add_data_disc_loss(self, generator_active: bool, epoch: int):
-    """Evaluates and records the discriminator loss for plotting later.
-
-    Args:
-        generator_active: True if the generator is being trained. Otherwise, the
-            discriminator is being trained.  We use this to color the data
-            points.
-    """
-    if not generator_active and len(self.gen_data[0]) == 0:
-      # Skip because `eval_disc_loss()` doesn't have generator samples
-      # available. (`trainer.train_gen()` hasn't been called yet)
-      return
-    mode = "gen" if generator_active else "dis"
-    X, Y = self.gen_data if generator_active else self.disc_data
-    if not generator_active:
-      X.append(epoch)
-    else:
-      X.append(epoch + 0.5)
-    Y.append(self.trainer.eval_disc_loss())
-    tf.logging.info("epoch ({}): {} disc loss: {}".format(mode, epoch, Y[-1]))
-
-  def plot_disc_loss(self):
-    """Render a plot of discriminator loss vs. training epoch number."""
-    plt.scatter(self.disc_data[0], self.disc_data[1], c='g', alpha=0.7, s=4,
-                label="discriminator loss (dis step)")
-    plt.scatter(self.gen_data[0], self.gen_data[1], c='r', alpha=0.7, s=4,
-                label="discriminator loss (gen step)")
-    plt.title("Discriminator loss")
-    plt.legend()
-    self._savefig("plot_fight_loss_disc", self.show_plots)
-
-  def add_data_ep_reward(self, epoch):
-    """Calculate and record average episode returns."""
-    if epoch in self.ep_reward_X:
-      # Don't calculate ep reward twice.
-      return
-    self.ep_reward_X.append(epoch)
-
-    gen_policy = self.trainer.gen_policy
-    rand_policy = util.init_rl(self.trainer.venv)
-    sample_until = util.rollout.min_episodes(self.n_episodes_per_reward_data)
-    trajs_rand = util.rollout.generate_trajectories(
-      rand_policy, self.venv_norm_obs, sample_until)
-    trajs_gen = util.rollout.generate_trajectories(
-      gen_policy, self.venv_norm_obs, sample_until)
-
-    for reward_fn, reward_name in [(None, "Ground Truth Reward"),
-                                   (self.trainer.reward_train, "Train Reward"),
-                                   (self.trainer.reward_test, "Test Reward")]:
-      if reward_fn is None:
-        trajs_rand_rets = [np.sum(traj.rews) for traj in trajs_rand]
-        trajs_gen_rets = [np.sum(traj.rews) for traj in trajs_gen]
-      else:
-        trajs_rand_rets = [
-            np.sum(util.rollout.recalc_rewards_traj(traj, reward_fn))
-            for traj in trajs_rand]
-        trajs_gen_rets = [
-            np.sum(util.rollout.recalc_rewards_traj(traj, reward_fn))
-            for traj in trajs_gen]
-
-      gen_ret = np.mean(trajs_gen_rets)
-      rand_ret = np.mean(trajs_rand_rets)
-      self.gen_ep_reward[reward_name].append(gen_ret)
-      self.rand_ep_reward[reward_name].append(rand_ret)
-      tf.logging.info(f"{reward_name} generator return: {gen_ret}")
-      tf.logging.info(f"{reward_name} random return: {rand_ret}")
-
-  def plot_ep_reward(self):
-    """Render and show average episode reward plots."""
-    for name in self.gen_ep_reward:
-      plt.title(name + " Performance")
-      plt.xlabel("epochs")
-      plt.ylabel("Average reward per episode (n={})"
-                 .format(self.n_episodes_per_reward_data))
-      X = self.ep_reward_X
-      plt.plot(X, self.gen_ep_reward[name], label="avg gen ep reward", c="red")
-      plt.plot(X, self.rand_ep_reward[name],
-               label="avg random ep reward", c="black")
-
-      name = name.lower().replace(' ', '-')
-      if (self.expert_mean_ep_reward is not None and
-              name == "ground-truth-reward"):
-          plt.axhline(y=self.expert_mean_ep_reward,
-                      linestyle='dashed',
-                      label=f"expert (return={self.expert_mean_ep_reward:.2g})",
-                      color="black")
-      plt.legend()
-      self._savefig(f"plot_fight_epreward_gen_{name}", self.show_plots)
-
-  def _savefig(self, prefix="", also_show=True):
-    plot_dir = osp.join(self.log_dir, "plots")
-    os.makedirs(plot_dir, exist_ok=True)
-    path = osp.join(plot_dir, f"{prefix}_{self.plot_idx}")
-    plt.savefig(path)
-    tf.logging.info("plot saved to {}".format(path))
-    if also_show:
-      plt.show()
-    plt.clf()
 
 
 def main_console():

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -14,8 +14,7 @@ from stable_baselines import bench
 from stable_baselines.common.base_class import BaseRLModel
 from stable_baselines.common.input import observation_input
 from stable_baselines.common.policies import BasePolicy, MlpPolicy
-from stable_baselines.common.vec_env import (DummyVecEnv, SubprocVecEnv, VecEnv,
-                                             VecNormalize)
+from stable_baselines.common.vec_env import DummyVecEnv, SubprocVecEnv, VecEnv
 import tensorflow as tf
 
 # TODO(adam): this should really be OrderedDict but that breaks Python
@@ -76,44 +75,6 @@ def make_vec_env(env_name: str,
     return SubprocVecEnv(env_fns, start_method='forkserver')
   else:
     return DummyVecEnv(env_fns)
-
-
-def reapply_vec_normalize(venv: VecEnv,
-                          src_vec_norm: VecNormalize,
-                          *,
-                          disable_training: bool = True,
-                          disable_norm_obs: bool = False,
-                          disable_norm_reward: bool = False,
-                          ) -> VecNormalize:
-  """Returns `venv` wrapped in a VecNormalize similar to `src_vec_norm`.
-
-  The new VecNormalize has the same running mean and standard deviation as
-  before, but will disable training, observation normalization, and reward
-  normalization if certain parameters to this function are True.
-
-  Args:
-    venv: A VecEnv.
-    src_vec_norm: A VecNormalize that wraps a VecEnv with the same
-      observation and actions space as `venv`.
-    disable_norm_training: If True, then disable training in the returned
-      VecNormalize.
-    disable_norm_obs: If True, then disable observation normalization
-      in the returned VecNormalize.
-    disable_norm_reward: If False, then disable reward normalization
-      in the returned VecNormalize.
-  """
-  state = src_vec_norm.__getstate__()
-  if disable_training:
-    state['training'] = False
-  if disable_norm_obs:
-    state['norm_obs'] = False
-  if disable_norm_reward:
-    state['norm_reward'] = False
-
-  result = VecNormalize.__new__(VecNormalize)
-  result.__setstate__(state)
-  result.set_venv(venv)
-  return result
 
 
 def init_rl(env: Union[gym.Env, VecEnv],


### PR DESCRIPTION
I decided to remove custom plotting because:
(1) Now that we plot disc loss and other things in Tensorboard, the custom plotter is almost entirely redundant.
(2) Also there seems to be a bug in master (maybe related to our complicated reward/observation normalization copying scheme) that is under-reporting episode rewards in our custom plots. EG: TensorBoard shows Cartpole reaching 500, but our custom plots have reward less than 200.



Also moves the training loop to AdversarialTrainer.train() since we only need a simple callback after this simplification.