### PR TITLE
setup.py: Install SB branch with Runner patch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,11 @@ setup(
         'tqdm',
         'scikit-learn>=0.21.2',
         # TODO(adam): Change to >=2.10.0 once 2.10.0 released
-        'stable-baselines @ git+https://github.com/hill-a/stable-baselines.git',
+        # TODO(shwang): Point to hill-a/stable-baselines master branch once
+        # hill-a/stable-baselines#639 is merged.
+        ('stable-baselines @'
+         'git+https://github.com/shwang/baselines'
+         '@fix_low_timesteps_learn_SAFE'),
         # TODO(shwang): Change to PyPI release once >0.1.55 is released.
         # Needs https://github.com/google/jax/pull/1931
         'jax @ git+https://github.com/google/jax',

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -243,10 +243,6 @@ class AdversarialTrainer:
 
     with logger.accumulate_means("gen"):
       self.gen_policy.set_env(self.venv_train_norm_buffering)
-      # TODO(adam): learn was not intended to be called for each training batch
-      # It should work, but might incur unnecessary overhead: e.g. in PPO2
-      # a new Runner instance is created each time. Also a hotspot for errors:
-      # algorithms not tested for this use case, may reset state accidentally.
       self.gen_policy.learn(total_timesteps=total_timesteps,
                             reset_num_timesteps=False,
                             callback=callback)


### PR DESCRIPTION
We need hill-a/stable-baselines#639 because we call `learn()` repeatedly, sometimes with low timesteps.

Using a fork of `fix_low_timesteps_learn` instead of the real deal in case I break the real deal during merge or code review later.