### PR TITLE
Bypass out-of-sync Gym registry in SubprocVecEnv by resolving EnvSpec

### DIFF
--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -46,8 +46,12 @@ def make_vec_env(env_name: str,
       seed: The environment seed.
       parallel: If True, uses SubprocVecEnv; otherwise, DummyVecEnv.
       log_dir: If specified, saves Monitor output to this directory.
-      max_episode_steps: If specified, wraps VecEnv in TimeLimit wrapper with
-          this episode length before returning.
+      max_episode_steps: If specified, wraps each env in a TimeLimit wrapper
+          with this episode length. If not specified and `max_episode_steps`
+          exists for this VecEnv in the Gym registry, uses the registry value
+          for every TimeLimit wrapper (this is the default behavior when calling
+          `gym.make`). Otherwise the environments are passed into the VecEnv
+          unwrapped.
   """
   # Resolve the spec outside of the subprocess first, so that it is available to
   # subprocesses running `make_env` via automatic pickling.

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -47,10 +47,10 @@ def make_vec_env(env_name: str,
       log_dir: If specified, saves Monitor output to this directory.
       max_episode_steps: If specified, wraps each env in a TimeLimit wrapper
           with this episode length. If not specified and `max_episode_steps`
-          exists for this VecEnv in the Gym registry, uses the registry value
-          for every TimeLimit wrapper (this is the default behavior when calling
-          `gym.make`). Otherwise the environments are passed into the VecEnv
-          unwrapped.
+          exists for this `env_name` in the Gym registry, uses the registry
+          `max_episode_steps` for every TimeLimit wrapper (this automatic
+          wrapper is the default behavior when calling `gym.make`). Otherwise
+          the environments are passed into the VecEnv unwrapped.
   """
   # Resolve the spec outside of the subprocess first, so that it is available to
   # subprocesses running `make_env` via automatic pickling.

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -70,6 +70,8 @@ def make_vec_env(env_name: str,
 
     if max_episode_steps is not None:
       env = TimeLimit(env, max_episode_steps)
+    elif (spec.max_episode_steps is not None) and not spec.tags.get('vnc'):
+      env = TimeLimit(env, max_episode_steps=spec.max_episode_steps)
 
     # Use Monitor to record statistics needed for Baselines algorithms logging
     # Optionally, save to disk

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -71,7 +71,7 @@ def make_vec_env(env_name: str,
 
     if max_episode_steps is not None:
       env = TimeLimit(env, max_episode_steps)
-    elif (spec.max_episode_steps is not None) and not spec.tags.get('vnc'):
+    elif spec.max_episode_steps is not None:
       env = TimeLimit(env, max_episode_steps=spec.max_episode_steps)
 
     # Use Monitor to record statistics needed for Baselines algorithms logging

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -193,7 +193,7 @@ def test_parallel(config_updates):
   assert run.status == 'COMPLETED'
 
 
-def _generate_custom_data(tmpdir: str, env_named_config: str) -> str:
+def _generate_test_rollouts(tmpdir: str, env_named_config: str) -> str:
   expert_demos_ex.run(
     named_configs=[env_named_config, "fast"],
     config_updates=dict(
@@ -206,7 +206,7 @@ def _generate_custom_data(tmpdir: str, env_named_config: str) -> str:
 
 def test_parallel_train_adversarial_custom_env(tmpdir):
   env_named_config = "custom_ant"
-  rollout_path = _generate_custom_data(tmpdir, env_named_config)
+  rollout_path = _generate_test_rollouts(tmpdir, env_named_config)
 
   config_updates = dict(
     sacred_ex_name="train_adversarial",

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -144,9 +144,9 @@ PARALLEL_CONFIG_UPDATES = [
   dict(
     sacred_ex_name="expert_demos",
     base_named_configs=["cartpole", "fast"],
+    n_seeds=2,
     search_space={
       "config_updates": {
-        "seed": tune.grid_search([0, 1]),
         "init_rl_kwargs": {
           "learning_rate": tune.grid_search([3e-4, 1e-4]),
         },
@@ -169,8 +169,17 @@ PARALLEL_CONFIG_UPDATES = [
         },
       }},
   ),
+  # Test that custom environments are passed to SubprocVecEnv in Ray workers.
+  dict(
+    sacred_ex_name="train_adversarial",
+    base_named_configs=["custom_ant", "fast"],
+    base_config_updates=dict(
+      init_trainer_kwargs=dict(
+        parallel=True,
+        num_vec=2,
+      )),
+  ),
 ]
-
 
 PARALLEL_CONFIG_LOW_RESOURCE = {
     # CI server only has 2 cores.


### PR DESCRIPTION
We ran into an unusual problem when using `imitation.scripts.parallel` to parallelize training of our custom ant environment. The subprocesses created by `imitation.util.make_vec_env` reported that all our custom environments weren't registered, but when we ran `imitation.scripts.parallel`. During debuggins, we found that it didn't help to forcibly reregister the environments in scope of the stack trace before the inner worker function to SubprocVecEnv. (Even forcibly reregistering environments inside `make_vec_env` itself did not suffice)

The most likely explanation is that the Python forkserver used by `SubprocVecEnv` was somehow prematurely initialized by `ray` so that new processes forked from the forkserver didn't include our custom environments inside the Gym registry. (edit: We are actually quite unsure if this is actually the cause of the bug. THis is just a hypothesis)

h/t: @AdamGleave for the idea to resolve the custom environment's `EnvSpec` before initializing the `SubprocVecEnv`.