### PR TITLE
rewards.serialize: Load training rewards

### DIFF
--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -1,10 +1,14 @@
 """Load serialized reward functions of different types."""
 
 import contextlib
-from typing import Callable, ContextManager, Iterator
+from functools import partial
+from typing import Callable, ContextManager, Iterator, Optional
+from pathlib import Path
+import pickle
 
 import numpy as np
 from stable_baselines.common.vec_env import VecEnv
+from stable_baselines.common import BaseRLModel
 
 from imitation.rewards import discrim_net, reward_net
 from imitation.util import registry, util
@@ -16,7 +20,26 @@ reward_registry: registry.Registry[RewardFnLoaderFn] = registry.Registry()
 
 
 @registry.sess_context
-def _load_discrim_net(path: str, venv: VecEnv) -> RewardFn:
+def _load_discrim_net_train(path: str,
+                            venv: VecEnv,
+                            gen_path: Optional[str] = None) -> RewardFn:
+  """Load train reward output from discriminator."""
+  del venv
+  discriminator = discrim_net.DiscrimNet.load(path)
+  if gen_path is None:
+    gen_path = Path(path, "..", "gen_policy")
+
+  gen_model_path = gen_path / "model.pkl"
+  assert gen_model_path.exists()
+  with open(gen_model_path, "rb") as f:
+    gen_policy = pickle.load(f)  # type: BaseRLModel
+
+  return partial(discriminator.reward_train,
+                 gen_log_prob_fn=gen_policy.action_probability)
+
+
+@registry.sess_context
+def _load_discrim_net_test(path: str, venv: VecEnv) -> RewardFn:
   """Load test reward output from discriminator."""
   del venv
   discriminator = discrim_net.DiscrimNet.load(path)
@@ -67,7 +90,9 @@ def load_zero(path: str, venv: VecEnv) -> RewardFn:
   return f
 
 
-reward_registry.register(key="DiscrimNet", value=_load_discrim_net)
+reward_registry.register(key="DiscrimNet", value=_load_discrim_net_train)
+reward_registry.register(key="DiscrimNet_train", value=_load_discrim_net_train)
+reward_registry.register(key="DiscrimNet_test", value=_load_discrim_net_test)
 reward_registry.register(key="RewardNet_shaped",
                          value=_load_reward_net_as_fn(shaped=True))
 reward_registry.register(key="RewardNet_unshaped",
@@ -77,7 +102,7 @@ reward_registry.register(key='zero', value=registry.dummy_context(load_zero))
 
 @util.docstring_parameter(reward_types=", ".join(reward_registry.keys()))
 def load_reward(reward_type: str, reward_path: str,
-                venv: VecEnv) -> ContextManager[RewardFn]:
+                venv: VecEnv, **kwargs) -> ContextManager[RewardFn]:
   """Load serialized policy.
 
   Args:
@@ -85,6 +110,10 @@ def load_reward(reward_type: str, reward_path: str,
         include {reward_types}.
     reward_path: A path specifying the reward.
     venv: An environment that the policy is to be used with.
+    **kwargs: Optional additional arguments associated with a particular reward
+      type. `DiscrimNet_train` takes an optional keyword argument `gen_path`,
+      the path to the generator policy directory.
+      (default is `{path}/../gen_policy`).
   """
   reward_loader = reward_registry.get(reward_type)
-  return reward_loader(reward_path, venv)
+  return reward_loader(reward_path, venv, **kwargs)


### PR DESCRIPTION
Adds two new reward type keys to the reward serialize registry: "DiscrimNet_train" and "DiscrimNet_test".

"DiscrimNet_test" is an alias for "DiscrimNet". "DiscrimNet_train" loads the train reward, and this requires a path to the generator directory. The caller can use the 