### PR TITLE
adversarial: Fix AIRL ent_bonus, buffer unnormalized gen samples

### DIFF
--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -282,7 +282,7 @@ class AdversarialTrainer:
                             reset_num_timesteps=False,
                             **learn_kwargs)
 
-    gen_samples = self.venv_train_norm_buffering.pop_transitions()
+    gen_samples = self.venv_train_norm.pop_transitions()
     self._gen_replay_buffer.store(gen_samples)
 
   def train(self,

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -125,9 +125,9 @@ class AdversarialTrainer:
       self.reward_train = partial(
           self.discrim.reward_train,
           # The generator policy uses normalized observations
-          # but the reward function and discriminator receive unnormalized
-          # observations. Therefore to get the right log action probs
-          # for AIRL's ent bonus, we need to normalize.
+          # but the reward function (self.reward_train) and discriminator use
+          # and receive unnormalized observations. Therefore to get the right
+          # log action probs for AIRL's ent bonus, we need to normalize obs.
           gen_log_prob_fn=self._gen_log_action_prob_from_unnormalized)
       self.reward_test = self.discrim.reward_test
       self.venv_train = reward_wrapper.RewardVecEnvWrapper(

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -28,7 +28,8 @@ def save(trainer, save_path):
   # TODO(gleave): unify this with the saving logic in data_collect?
   # (Needs #43 to be merged before attempting.)
   serialize.save_stable_model(os.path.join(save_path, "gen_policy"),
-                              trainer.gen_policy)
+                              trainer.gen_policy,
+                              trainer.venv_train_norm)
 
 
 @train_ex.main


### PR DESCRIPTION
Ent bonus for AIRL was wrong because the observation input to `gen_policy.action_probability()` needed to be normalized but was not.

Looking at before/after plots for cartpole and mountain car it's not clear that we are doing better than before in cartpole AIRL (maybe worse). Mountain car ARIL seems to be doing better.

Here are the [before plots](https://www.notion.so/chaiberkeley/Before-PRs-156-161-2c7970b81de242e8a8859169245c2782).


Cartpole training curve before/after (before is first image)
![image](https://user-images.githubusercontent.com/1750835/73901211-f5626b80-4846-11ea-9caf-a8e61a6c1d94.png)



![image](https://user-images.githubusercontent.com/1750835/73900874-e62eee00-4845-11ea-9a18-58fdc6b22d30.png)

Mountain car training curve before/after:
(No longer has any flatlining -200 policies. Performance seems to improve more steadily?)

![image](https://user-images.githubusercontent.com/1750835/73901159-d368e900-4846-11ea-9804-3c41de2932f1.png)
![image](https://user-images.githubusercontent.com/1750835/73901315-483c2300-4847-11ea-8b88-78d43cb7da51.png)
(An "after" mountain training curve with more timesteps coming soon)


EDIT: Adding more after plots for both envs.

Cart Pole
![image](https://user-images.githubusercontent.com/1750835/73989744-bb9f6c80-48fb-11ea-88a7-b4d3fa4f6e93.png)

Mountain Car
![image](https://user-images.githubusercontent.com/1750835/73989753-c9ed8880-48fb-11ea-96ac-97b12e6b7628.png)

