### PR TITLE
Support non-PPO2 RL algorithms in `expert_demos`

### DIFF
--- a/src/imitation/scripts/config/expert_demos.py
+++ b/src/imitation/scripts/config/expert_demos.py
@@ -19,7 +19,7 @@ def expert_demos_defaults():
   max_episode_steps = None  # Set to positive int to limit episode horizons
   n_episodes_eval = 50  # Num of episodes for final ep reward mean evaluation
 
-  init_rl_kwargs = dict(DEFAULT_INIT_RL_KWARGS)
+  init_rl_kwargs = dict()
 
   # If specified, overrides the ground-truth environment reward
   reward_type = None  # override reward type
@@ -36,6 +36,13 @@ def expert_demos_defaults():
   init_tensorboard = False  # If True, then write Tensorboard logs.
 
   log_root = os.path.join("output", "expert_demos")  # output directory
+
+
+@expert_demos_ex.config
+def expert_demos_dicts(init_rl_kwargs):
+  # Workaround IDSIA/sacred issue #238
+  if not init_rl_kwargs:
+    init_rl_kwargs = dict(DEFAULT_INIT_RL_KWARGS)
 
 
 @expert_demos_ex.config

--- a/src/imitation/scripts/config/expert_demos.py
+++ b/src/imitation/scripts/config/expert_demos.py
@@ -25,6 +25,7 @@ def expert_demos_defaults():
   reward_type = None  # override reward type
   reward_path = None   # override reward path
 
+  log_interval = 1  # Num updates between custom log callbacks (<=0 disables)
   rollout_save_interval = -1  # Num updates between saves (<=0 disables)
   rollout_save_final = True  # If True, save after training is finished.
   rollout_save_n_timesteps = None  # Min timesteps saved per file, optional.

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -81,6 +81,8 @@ def rollouts_and_policy(
           reward_type to load the reward model. For more information, see
           `imitation.rewards.serialize.load_reward`.
 
+      log_interval: The number of training updates in between custom
+          logging callbacks.
       rollout_save_interval: The number of training updates in between
           intermediate rollout saves. If the argument is nonpositive, then
           don't save intermediate updates.

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -37,6 +37,7 @@ def rollouts_and_policy(
   reward_type: Optional[str],
   reward_path: Optional[str],
 
+  log_interval: int,
   rollout_save_interval: int,
   rollout_save_final: bool,
   rollout_save_n_timesteps: Optional[int],
@@ -154,15 +155,15 @@ def rollouts_and_policy(
         step += 1
         policy = locals_['self']
 
-        # TODO(adam): make logging frequency configurable
-        for callback in log_callbacks:
-          callback(sb_logger)
+        if log_interval > 0 and step % log_interval == 0:
+          for callback in log_callbacks:
+            callback(sb_logger)
 
         if rollout_save_interval > 0 and step % rollout_save_interval == 0:
-          save_path = osp.join(rollout_dir, f"{step}.pkl")
+          save_path = osp.join(rollout_dir, f"{step:09d}.pkl")
           util.rollout.save(save_path, policy, venv, sample_until)
         if policy_save_interval > 0 and step % policy_save_interval == 0:
-          output_dir = os.path.join(policy_dir, f'{step:05d}')
+          output_dir = os.path.join(policy_dir, f'{step:09d}')
           serialize.save_stable_model(output_dir, policy, vec_normalize)
 
       policy.learn(total_timesteps, callback=callback)

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -11,6 +11,7 @@ from imitation.util import registry, rollout, util
 SIMPLE_ENVS = [
     "CartPole-v0",  # Discrete(2) action space
     "MountainCarContinuous-v0",  # Box(1) action space
+    "Pendulum-v0",  # Box(1) action space
 ]
 HARDCODED_TYPES = ["random", "zero"]
 BASELINE_MODELS = [(name, cls_name)

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -13,7 +13,7 @@ SIMPLE_ENVS = [
 ]
 HARDCODED_TYPES = ["random", "zero"]
 BASELINE_MODELS = [(name, cls_name)
-                   for name, (cls_name, attr) in
+                   for name, (cls_name, _attr, _wrapper) in
                    serialize.STABLE_BASELINES_CLASSES.items()]
 
 


### PR DESCRIPTION
It's intended to be able to support arbitrary Stable Baselines algorithms in `expert_demos`. However, there are several issues that make it hard to use off-policy algorithms that this PR resolves:
  - `init_rl_kwargs` has default values that *cannot be deleted* due to https://github.com/IDSIA/sacred/issues/238. This PR worksaround that by only adding the default values if `init_rl_kwargs` is an empty dict.
  - The log callbacks get called each `callback` and the `step` is assumed to be no more than 5 digits long. This is problematic for off-policy algorithms where `callback` is executed every timestep of training. This PR makes the log frequency configurable, and allows up to 9 digit long steps.
  - Added custom loading logic for SAC which has some non-standard policy format.