### PR TITLE
Migrate unit test code to benchmark_environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import src.imitation  # pytype: disable=import-error
 
 TF_VERSION = '>=1.15.0,<2.0'
 TESTS_REQUIRE = [
-    # TODO(adam): change to PyPi once we make first release
+    # TODO(adam): use PyPi rather than Git once we make first release
     ('benchmark-environments @ '
      'git+https://github.com/HumanCompatibleAI/benchmark-environments.git'),
     # remove pin once https://github.com/nedbat/coveragepy/issues/881 fixed

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@ import src.imitation  # pytype: disable=import-error
 
 TF_VERSION = '>=1.15.0,<2.0'
 TESTS_REQUIRE = [
+    # TODO(adam): change to PyPi once we make first release
+    ('benchmark-environments @ '
+     'git+https://github.com/HumanCompatibleAI/benchmark-environments.git'),
     # remove pin once https://github.com/nedbat/coveragepy/issues/881 fixed
     'coverage==4.5.4',
     'codecov',

--- a/src/imitation/testing/envs.py
+++ b/src/imitation/testing/envs.py
@@ -4,95 +4,15 @@ This is used in the imitation test suite and may also be useful for users
 of this library.
 """
 
-import re
-
 import gym
-import numpy as np
 
 
-def make_env_fixture(skip_fn):
-  def f(env_name):
-    env = None
-    try:
-      env = gym.make(env_name)
-      yield env
-    except gym.error.DependencyNotInstalled as e:  # pragma: no cover
-      if e.args[0].find('mujoco_py') != -1:
-        skip_fn("Requires `mujoco_py`, which isn't installed.")
-      else:
-        raise
-    finally:
-      if env is not None:
-        env.close()
-  return f
+def test_model_based(env: gym.Env) -> None:
+  """Smoke test for each of the ModelBasedEnv methods with type checks.
 
-
-def matches_list(env_name, patterns):
-  for pattern in patterns:  # pragma: no cover
-    if re.match(pattern, env_name):
-      return True
-  return False
-
-
-def rollout(env, actions):
-  ret = [(env.reset(), None, None, None)]
-  for act in actions:
-    ret.append(env.step(act))
-  return ret
-
-
-def assert_equal_rollout(rollout_a, rollout_b):
-  for step_a, step_b in zip(rollout_a, rollout_b):
-    ob_a, rew_a, done_a, info_a = step_a
-    ob_b, rew_b, done_b, info_b = step_b
-    np.testing.assert_equal(ob_a, ob_b)
-    assert rew_a == rew_b
-    assert done_a == done_b
-    np.testing.assert_equal(info_a, info_b)
-
-
-def test_seed(env, env_name, deterministic_envs):
-  """Tests environment seeding.
-
-  If non-deterministic, different seeds should produce different transitions.
-  If deterministic, should be invariant to seed.
+  Raises:
+      AssertionError if test fails.
   """
-  env.action_space.seed(0)
-  actions = [env.action_space.sample() for _ in range(10)]
-
-  # With the same seed, should always get the same result
-  seeds = env.seed(42)
-  assert isinstance(seeds, list)
-  assert len(seeds) > 0
-  rollout_a = rollout(env, actions)
-
-  env.seed(42)
-  rollout_b = rollout(env, actions)
-
-  assert_equal_rollout(rollout_a, rollout_b)
-
-  # For non-deterministic environments, if we try enough seeds we should
-  # eventually get a different result. For deterministic environments, all
-  # seeds will produce the same starting state.
-  same_obs = True
-  for i in range(20):
-    env.seed(i)
-    new_rollout = rollout(env, actions)
-    for step_a, step_new in zip(rollout_a, new_rollout):
-      obs_a = step_a[0]
-      obs_new = step_new[0]
-      if np.any(obs_a != obs_new):
-        same_obs = False
-        break
-    if not same_obs:
-      break
-
-  is_deterministic = matches_list(env_name, deterministic_envs)
-  assert same_obs == is_deterministic
-
-
-def test_model_based(env):
-  """Smoke test for each of the ModelBasedEnv methods with type checks."""
   state = env.initial_state()
   assert env.state_space.contains(state)
 
@@ -110,18 +30,3 @@ def test_model_based(env):
   assert env.observation_space.contains(obs)
   next_obs = env.obs_from_state(new_state)
   assert env.observation_space.contains(next_obs)
-
-
-def test_rollout(env):
-  """Check custom environments have correct types on `step` and `reset`."""
-  obs_space = env.observation_space
-  obs = env.reset()
-  assert obs in obs_space
-
-  for _ in range(4):
-    act = env.action_space.sample()
-    obs, rew, done, info = env.step(act)
-    assert obs in obs_space
-    assert isinstance(rew, float)
-    assert isinstance(done, bool)
-    assert isinstance(info, dict)


### PR DESCRIPTION
  - Remove code that has been migrated to `benchmark-environments`.
  - Add `benchmark-environments` as a test-only dependency.

Unit tests are expected to fail until https://github.com/HumanCompatibleAI/benchmark-environments/pull/6 is merged.