### PR TITLE
AdvTrainer: Minimum default gen buffer size

### DIFF
--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -77,7 +77,8 @@ class AdversarialTrainer:
           generator replay buffer (the number of obs-action-obs samples from
           the generator that can be stored).
 
-          By default this is equal to `20 * self.gen_batch_size`.
+          By default this is equal to `self.gen_batch_size`, meaning that we
+          sample only from the most recent batch of generator samples.
         init_tensorboard: If True, makes various discriminator
           TensorBoard summaries.
         init_tensorboard_graph: If both this and `init_tensorboard` are True,
@@ -136,7 +137,7 @@ class AdversarialTrainer:
     self.gen_policy.set_env(self.venv_train_norm_buffering)
 
     if gen_replay_buffer_capacity is None:
-      gen_replay_buffer_capacity = 20 * self.gen_batch_size
+      gen_replay_buffer_capacity = self.gen_batch_size
     self._gen_replay_buffer = buffer.ReplayBuffer(gen_replay_buffer_capacity,
                                                   self.venv)
     self._exp_replay_buffer = buffer.ReplayBuffer.from_data(expert_demos)

--- a/src/imitation/util/buffer.py
+++ b/src/imitation/util/buffer.py
@@ -299,7 +299,6 @@ class ReplayBuffer:
     trans_dict = transitions._asdict()
     if lengths[0] > self.capacity and truncate_ok:
       trans_dict = {k: v[-self.capacity:] for k, v in trans_dict.items()}
-        trans_dict[k] = v[-self.capacity:]
 
     self._buffer.store(trans_dict)
 

--- a/src/imitation/util/buffer.py
+++ b/src/imitation/util/buffer.py
@@ -298,7 +298,7 @@ class ReplayBuffer:
 
     trans_dict = transitions._asdict()
     if lengths[0] > self.capacity and truncate_ok:
-      for k, v in trans_dict.items():
+      trans_dict = {k: v[-self.capacity:] for k, v in trans_dict.items()}
         trans_dict[k] = v[-self.capacity:]
 
     self._buffer.store(trans_dict)


### PR DESCRIPTION
Change the default generator buffer size to be `self.gen_batch_size` for consistency with Sacred script. (Used to be `20 * self.gen_batch_size`).

Also fixes a bug that disallows training generator alone for more than `len(replay_buffer)` timesteps, because this would put more samples into the buffer than the buffer has capacity.