### PR TITLE
Replace squeeze by flatten to fix (1,) shape case in DiscrimNet.reward_train

### DIFF
--- a/src/imitation/rewards/discrim_net.py
+++ b/src/imitation/rewards/discrim_net.py
@@ -200,7 +200,8 @@ class DiscrimNet(serialize.Serializable, ABC):
         The rewards. Its shape is `(batch_size,)`.
     """
     del steps
-    log_act_prob = gen_log_prob_fn(observation=obs, actions=act, logp=True).reshape(-1)
+    log_act_prob = np.reshape(
+      gen_log_prob_fn(observation=obs, actions=act, logp=True), (-1,))
 
     n_gen = len(obs)
     assert obs.shape == next_obs.shape

--- a/src/imitation/rewards/discrim_net.py
+++ b/src/imitation/rewards/discrim_net.py
@@ -196,13 +196,11 @@ class DiscrimNet(serialize.Serializable, ABC):
         returns `log_act_prob`, the generator's log action probabilities.
         `log_act_prob[i]` is equal to the generator's log probability of
         choosing `act[i]` given `obs[i]`.
-        `np.squeeze(log_act_prob)` has shape `(batch_size,)`.
     Returns:
         The rewards. Its shape is `(batch_size,)`.
     """
     del steps
-    log_act_prob = np.squeeze(
-      gen_log_prob_fn(observation=obs, actions=act, logp=True))
+    log_act_prob = gen_log_prob_fn(observation=obs, actions=act, logp=True).reshape(-1)
 
     n_gen = len(obs)
     assert obs.shape == next_obs.shape

--- a/src/imitation/rewards/discrim_net.py
+++ b/src/imitation/rewards/discrim_net.py
@@ -200,8 +200,8 @@ class DiscrimNet(serialize.Serializable, ABC):
         The rewards. Its shape is `(batch_size,)`.
     """
     del steps
-    log_act_prob = np.reshape(
-      gen_log_prob_fn(observation=obs, actions=act, logp=True), (-1,))
+    log_act_prob = gen_log_prob_fn(observation=obs,
+                                   actions=act, logp=True).flatten()
 
     n_gen = len(obs)
     assert obs.shape == next_obs.shape


### PR DESCRIPTION
If your `batch_size == 1` (e.g. if your `VecEnv` has only one copy of the environment during training), then
`log_act_prob.shape == () != (1,) == (batch_size,)`, since squeeze will transform a `(1,)`
shape into a `()` shape - and thus the shape assert will fail.
AFAIK, replacing it by `.reshape(-1)` should fix the problem while maintaining same behavior in other cases.