### PR TITLE
Baselines GAIL traj conversion utility

### DIFF
--- a/experiments/convert_traj.py
+++ b/experiments/convert_traj.py
@@ -27,24 +27,24 @@ def convert_trajs_to_sb(trajs: List[rollout.Trajectory]) -> dict:
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("src_path", type=str)
-    parser.add_argument("dst_path", type=str)
-    args = parser.parse_args()
+  parser = argparse.ArgumentParser()
+  parser.add_argument("src_path", type=str)
+  parser.add_argument("dst_path", type=str)
+  args = parser.parse_args()
 
-    src_path = Path(args.src_path)
-    dst_path = Path(args.dst_path)
+  src_path = Path(args.src_path)
+  dst_path = Path(args.dst_path)
 
-    assert src_path.is_file()
-    with open(src_path, "rb") as f:
-      src_trajs = pickle.load(f)  # type: List[rollout.Trajectory]
+  assert src_path.is_file()
+  with open(src_path, "rb") as f:
+    src_trajs = pickle.load(f)  # type: List[rollout.Trajectory]
 
-    dst_trajs = convert_trajs_to_sb(src_trajs)
-    os.makedirs(dst_path.parent, exist_ok=True)
-    with open(dst_path, "wb") as f:
-      np.savez_compressed(f, **dst_trajs)
+  dst_trajs = convert_trajs_to_sb(src_trajs)
+  os.makedirs(dst_path.parent, exist_ok=True)
+  with open(dst_path, "wb") as f:
+    np.savez_compressed(f, **dst_trajs)
 
-    print(f"Dumped rollouts to {dst_path}")
+  print(f"Dumped rollouts to {dst_path}")
 
 
 if __name__ == "__main__":

--- a/experiments/convert_traj.py
+++ b/experiments/convert_traj.py
@@ -44,7 +44,7 @@ def main():
     with open(dst_path, "wb") as f:
       np.savez_compressed(f, **dst_trajs)
 
-    print(f"Dumped files to {dst_path}")
+    print(f"Dumped rollouts to {dst_path}")
 
 
 if __name__ == "__main__":

--- a/experiments/convert_traj.py
+++ b/experiments/convert_traj.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+"""
+Convert trajectories from imitation List[Trajectory] format to transitions.
+
+Then save as npz in the correct format.
+"""
+
+from typing import List
+
+import numpy as np
+
+from imitation.util import rollout as ro_util
+
+
+def convert_trajs_to_sb(trajs: List[ro_util.Trajectory]) -> dict:
+  """Converts Trajectories into the dict format used by Stable Baselines GAIL.
+  """
+  trans = ro_util.flatten_trajectories(trajs)
+  return dict(
+    acs=trans.acts,
+    rews=trans.rews,
+    obs=trans.obs,
+    ep_rets=np.array([np.sum(t.rews) for t in trajs]),
+  )
+
+
+if __name__ == "__main__":
+    import argparse
+    import os
+    from pathlib import Path
+    import pickle
+    parser = argparse.ArgumentParser()
+    parser.add_argument("src_path", type=str)
+    parser.add_argument("dst_path", type=str)
+    args = parser.parse_args()
+
+    src_path = Path(args.src_path)
+    dst_path = Path(args.dst_path)
+
+    assert src_path.is_file()
+    with open(src_path, "rb") as f:
+      src_trajs = pickle.load(f)
+
+    dst_trajs = convert_trajs_to_sb(src_trajs)  # type: ro_util.Trajectory
+    os.makedirs(dst_path.parent, exist_ok=True)
+    with open(dst_path, "wb") as f:
+      np.savez_compressed(f, **dst_trajs)
+
+    print(f"Dumped files to {dst_path}")

--- a/experiments/convert_traj.py
+++ b/experiments/convert_traj.py
@@ -3,17 +3,21 @@
 Convert trajectories from `imitation` format to openai/baselines GAIL format.
 """
 
+import argparse
+import os
+from pathlib import Path
+import pickle
 from typing import List
 
 import numpy as np
 
-from imitation.util import rollout as ro_util
+from imitation.util import rollout
 
 
-def convert_trajs_to_sb(trajs: List[ro_util.Trajectory]) -> dict:
+def convert_trajs_to_sb(trajs: List[rollout.Trajectory]) -> dict:
   """Converts Trajectories into the dict format used by Stable Baselines GAIL.
   """
-  trans = ro_util.flatten_trajectories(trajs)
+  trans = rollout.flatten_trajectories(trajs)
   return dict(
     acs=trans.acts,
     rews=trans.rews,
@@ -22,11 +26,7 @@ def convert_trajs_to_sb(trajs: List[ro_util.Trajectory]) -> dict:
   )
 
 
-if __name__ == "__main__":
-    import argparse
-    import os
-    from pathlib import Path
-    import pickle
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("src_path", type=str)
     parser.add_argument("dst_path", type=str)
@@ -37,11 +37,15 @@ if __name__ == "__main__":
 
     assert src_path.is_file()
     with open(src_path, "rb") as f:
-      src_trajs = pickle.load(f)
+      src_trajs = pickle.load(f)  # type: List[rollout.Trajectory]
 
-    dst_trajs = convert_trajs_to_sb(src_trajs)  # type: ro_util.Trajectory
+    dst_trajs = convert_trajs_to_sb(src_trajs)
     os.makedirs(dst_path.parent, exist_ok=True)
     with open(dst_path, "wb") as f:
       np.savez_compressed(f, **dst_trajs)
 
     print(f"Dumped files to {dst_path}")
+
+
+if __name__ == "__main__":
+  main()

--- a/experiments/convert_traj.py
+++ b/experiments/convert_traj.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 """
-Convert trajectories from imitation List[Trajectory] format to transitions.
-
-Then save as npz in the correct format.
+Convert trajectories from `imitation` format to openai/baselines GAIL format.
 """
 
 from typing import List


### PR DESCRIPTION
Simple script for converting our `rollout.pkl` into the `rollout.npz` format used by openai/baselines GAIL.