### PR TITLE
Add input validation for Trajectory* and Transition* classes

### DIFF
--- a/src/imitation/util/buffer.py
+++ b/src/imitation/util/buffer.py
@@ -258,13 +258,7 @@ class ReplayBuffer:
 
         Returns:
             A new ReplayBuffer.
-
-        Raises:
-            ValueError: obs and next_obs have a different dtype.
         """
-        if transitions.obs.dtype != transitions.next_obs.dtype:
-            raise ValueError("obs and next_obs must have the same dtype.")
-
         capacity, *obs_shape = transitions.obs.shape
         _, *act_shape = transitions.acts.shape
         instance = cls(
@@ -305,11 +299,7 @@ class ReplayBuffer:
         # Remove unnecessary fields
         trans_dict = {k: trans_dict[k] for k in self._buffer.sample_shapes.keys()}
 
-        lengths = [len(arr) for arr in trans_dict.values()]
-        if len(set(lengths)) != 1:
-            raise ValueError("Arguments must have the same length.")
-
-        if lengths[0] > self.capacity and truncate_ok:
+        if len(transitions) > self.capacity and truncate_ok:
             trans_dict = {k: v[-self.capacity :] for k, v in trans_dict.items()}
 
         self._buffer.store(trans_dict)

--- a/src/imitation/util/data.py
+++ b/src/imitation/util/data.py
@@ -25,8 +25,8 @@ class Trajectory:
     def __len__(self):
         """Returns number of transitions, `trajectory_len` in attribute docstrings.
 
-        This is equal to the number of actions. So this is zero when there is a
-        single observation."""
+        This is equal to the number of actions, and is always positive.
+        """
         return len(self.acts)
 
     def __post_init__(self):
@@ -36,6 +36,8 @@ class Trajectory:
                 "expected one more observations than actions: "
                 f"{len(self.obs)} != {len(self.acts)} + 1"
             )
+        if len(self.acts) == 0:
+            raise ValueError("Degenerate trajectory: must have at least one action.")
         if self.infos is not None and len(self.infos) != len(self.acts):
             raise ValueError(
                 "infos when present must be present for each action: "
@@ -102,7 +104,7 @@ class Transitions:
     """
 
     def __len__(self):
-        """Returns number of transitions."""
+        """Returns number of transitions. Always positive."""
         return len(self.obs)
 
     def __post_init__(self):
@@ -122,6 +124,8 @@ class Transitions:
                 "obs and acts must have same number of timesteps: "
                 f"{len(self.obs)} != {len(self.acts)}"
             )
+        if len(self.obs) == 0:
+            raise ValueError("Must have non-zero number of observations.")
         if self.dones.shape != (len(self.acts),):
             raise ValueError(
                 "dones must be 1D array, one entry for each timestep: "

--- a/src/imitation/util/data.py
+++ b/src/imitation/util/data.py
@@ -76,7 +76,7 @@ class Transitions:
 
     obs: np.ndarray
     """
-    Previous observations. Shape: (batch_siz4e, ) + observation_shape.
+    Previous observations. Shape: (batch_size, ) + observation_shape.
 
     The i'th observation `obs[i]` in this array is the observation seen
     by the agent when choosing action `acts[i]`.

--- a/src/imitation/util/data.py
+++ b/src/imitation/util/data.py
@@ -19,14 +19,49 @@ class Trajectory:
     acts: np.ndarray
     """Actions, shape (trajectory_len, ) + action_shape."""
 
-    infos: Optional[List[dict]]
-    """A list of info dicts, length trajectory_len."""
+    infos: Optional[Sequence[dict]]
+    """A sequence of info dicts, length trajectory_len."""
+
+    def __len__(self):
+        """Returns number of transitions, `trajectory_len` in attribute docstrings.
+
+        This is equal to the number of actions. So this is zero when there is a
+        single observation."""
+        return len(self.acts)
+
+    def __post_init__(self):
+        """Performs input validation: check shapes are as specified in docstring."""
+        if len(self.obs) != len(self.acts) + 1:
+            raise ValueError(
+                "expected one more observation than actions: "
+                f"{len(self.obs)} != {len(self.acts)} + 1"
+            )
+        if self.infos is not None and len(self.infos) != len(self.acts):
+            raise ValueError(
+                "infos when present must be present for each action:"
+                f"{len(self.infos)} != {len(self.acts)}"
+            )
+
+
+def _rews_validation(rews: np.ndarray, acts: np.ndarray):
+    if rews.shape != (len(acts),):
+        raise ValueError(
+            "rewards must be 1D array, one for each action:"
+            f"{rews.shape} != ({len(acts)},)"
+        )
+    if rews.dtype not in [np.float32, np.float64, np.float128]:
+        raise ValueError("rewards dtype {self.rews.dtype} not a float")
 
 
 @dataclasses.dataclass(frozen=True)
 class TrajectoryWithRew(Trajectory):
     rews: np.ndarray
-    """Reward, shape (trajectory_len, )."""
+    """Reward, shape (trajectory_len, ). dtype float."""
+
+    def __post_init__(self):
+        """Performs input validation on shapes, including for rews."""
+        super().__post_init__()
+        _rews_validation(self.rews, self.acts)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -38,21 +73,58 @@ class Transitions:
     """
 
     obs: np.ndarray
-    """Previous observations. Shape: (batch_size, ) + observation_shape.
-  The i'th observation `obs[i]` in this array is the observation seen
-  by the agent when choosing action `acts[i]`."""
+    """
+    Previous observations. Shape: (batch_size, ) + observation_shape.
+
+    The i'th observation `obs[i]` in this array is the observation seen
+    by the agent when choosing action `acts[i]`. obs.dtype == next_obs.dtype.
+    """
 
     acts: np.ndarray
     """Actions. Shape: (batch_size,) + action_shape."""
 
     next_obs: np.ndarray
     """New observation. Shape: (batch_size, ) + observation_shape.
-  The i'th observation `next_obs[i]` in this array is the observation
-  after the agent has taken action `acts[i]`."""
+
+    The i'th observation `next_obs[i]` in this array is the observation
+    after the agent has taken action `acts[i]`. next_obs.dtype == obs.dtype.
+    """
 
     dones: np.ndarray
-    """Boolean array indicating episode termination. Shape: (batch_size, ).
-  `done[i]` is true iff `next_obs[i]` the last observation of an episode."""
+    """
+    Boolean array indicating episode termination. Shape: (batch_size, ).
+
+    `done[i]` is true iff `next_obs[i]` the last observation of an episode.
+    """
+
+    def __len__(self):
+        """Returns number of transitions."""
+        return len(self.obs)
+
+    def __post_init__(self):
+        """Performs input validation: check shapes & dtypes match docstring."""
+        if self.obs.shape != self.next_obs.shape:
+            raise ValueError(
+                "obs and next_obs must have same shape:"
+                f"{self.obs.shape} != {self.next_obs.shape}"
+            )
+        if self.obs.dtype != self.next_obs.dtype:
+            raise ValueError(
+                "obs and next_obs must have the same dtype:"
+                f"{self.obs.dtype} != {self.next_obs.dtype}"
+            )
+        if len(self.obs) != len(self.acts):
+            raise ValueError(
+                "obs and acts must have same number of timesteps:"
+                f"{len(self.obs)} != {len(self.acts)}"
+            )
+        if self.dones.shape != (len(self.acts),):
+            raise ValueError(
+                "dones must be 1D array, one for each timestep:"
+                f"{self.dones.shape} != ({len(self.acts)},)"
+            )
+        if self.dones.dtype != np.bool:
+            raise ValueError(f"dones must be boolean, not {self.dones.dtype}")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -60,8 +132,17 @@ class TransitionsWithRew(Transitions):
     """A batch of obs-act-obs-rew-done transitions."""
 
     rews: np.ndarray
-    """Reward. Shape: (batch_size, ). The reward `rew[i]` at the i'th timestep is
-  received after the agent has taken action `acts[i]`."""
+    """
+    Reward. Shape: (batch_size, ). dtype float.
+
+    The reward `rew[i]` at the i'th timestep is received after the
+    agent has taken action `acts[i]`.
+    """
+
+    def __post_init__(self):
+        """Performs input validation on shapes, including for rews."""
+        super().__post_init__()
+        _rews_validation(self.rews, self.acts)
 
 
 class _TrajectoryBackwardCompatible(NamedTuple):

--- a/src/imitation/util/data.py
+++ b/src/imitation/util/data.py
@@ -38,7 +38,7 @@ class Trajectory:
             )
         if self.infos is not None and len(self.infos) != len(self.acts):
             raise ValueError(
-                "infos when present must be present for each action:"
+                "infos when present must be present for each action: "
                 f"{len(self.infos)} != {len(self.acts)}"
             )
 
@@ -46,7 +46,7 @@ class Trajectory:
 def _rews_validation(rews: np.ndarray, acts: np.ndarray):
     if rews.shape != (len(acts),):
         raise ValueError(
-            "rewards must be 1D array, one for each action:"
+            "rewards must be 1D array, one for each action: "
             f"{rews.shape} != ({len(acts)},)"
         )
     if rews.dtype not in [np.float32, np.float64, np.float128]:
@@ -105,22 +105,22 @@ class Transitions:
         """Performs input validation: check shapes & dtypes match docstring."""
         if self.obs.shape != self.next_obs.shape:
             raise ValueError(
-                "obs and next_obs must have same shape:"
+                "obs and next_obs must have same shape: "
                 f"{self.obs.shape} != {self.next_obs.shape}"
             )
         if self.obs.dtype != self.next_obs.dtype:
             raise ValueError(
-                "obs and next_obs must have the same dtype:"
+                "obs and next_obs must have the same dtype: "
                 f"{self.obs.dtype} != {self.next_obs.dtype}"
             )
         if len(self.obs) != len(self.acts):
             raise ValueError(
-                "obs and acts must have same number of timesteps:"
+                "obs and acts must have same number of timesteps: "
                 f"{len(self.obs)} != {len(self.acts)}"
             )
         if self.dones.shape != (len(self.acts),):
             raise ValueError(
-                "dones must be 1D array, one for each timestep:"
+                "dones must be 1D array, one for each timestep: "
                 f"{self.dones.shape} != ({len(self.acts)},)"
             )
         if self.dones.dtype != np.bool:

--- a/src/imitation/util/data.py
+++ b/src/imitation/util/data.py
@@ -33,7 +33,7 @@ class Trajectory:
         """Performs input validation: check shapes are as specified in docstring."""
         if len(self.obs) != len(self.acts) + 1:
             raise ValueError(
-                "expected one more observation than actions: "
+                "expected one more observations than actions: "
                 f"{len(self.obs)} != {len(self.acts)} + 1"
             )
         if self.infos is not None and len(self.infos) != len(self.acts):
@@ -46,7 +46,7 @@ class Trajectory:
 def _rews_validation(rews: np.ndarray, acts: np.ndarray):
     if rews.shape != (len(acts),):
         raise ValueError(
-            "rewards must be 1D array, one for each action: "
+            "rewards must be 1D array, one entry for each action: "
             f"{rews.shape} != ({len(acts)},)"
         )
     if rews.dtype not in [np.float32, np.float64, np.float128]:
@@ -59,7 +59,7 @@ class TrajectoryWithRew(Trajectory):
     """Reward, shape (trajectory_len, ). dtype float."""
 
     def __post_init__(self):
-        """Performs input validation on shapes, including for rews."""
+        """Performs input validation, including for rews."""
         super().__post_init__()
         _rews_validation(self.rews, self.acts)
 
@@ -77,7 +77,9 @@ class Transitions:
     Previous observations. Shape: (batch_size, ) + observation_shape.
 
     The i'th observation `obs[i]` in this array is the observation seen
-    by the agent when choosing action `acts[i]`. obs.dtype == next_obs.dtype.
+    by the agent when choosing action `acts[i]`.
+
+    Invariant: obs.dtype == next_obs.dtype.
     """
 
     acts: np.ndarray
@@ -87,7 +89,9 @@ class Transitions:
     """New observation. Shape: (batch_size, ) + observation_shape.
 
     The i'th observation `next_obs[i]` in this array is the observation
-    after the agent has taken action `acts[i]`. next_obs.dtype == obs.dtype.
+    after the agent has taken action `acts[i]`.
+
+    Invariant: next_obs.dtype == obs.dtype.
     """
 
     dones: np.ndarray
@@ -120,7 +124,7 @@ class Transitions:
             )
         if self.dones.shape != (len(self.acts),):
             raise ValueError(
-                "dones must be 1D array, one for each timestep: "
+                "dones must be 1D array, one entry for each timestep: "
                 f"{self.dones.shape} != ({len(self.acts)},)"
             )
         if self.dones.dtype != np.bool:
@@ -140,7 +144,7 @@ class TransitionsWithRew(Transitions):
     """
 
     def __post_init__(self):
-        """Performs input validation on shapes, including for rews."""
+        """Performs input validation, including for rews."""
         super().__post_init__()
         _rews_validation(self.rews, self.acts)
 

--- a/src/imitation/util/data.py
+++ b/src/imitation/util/data.py
@@ -36,13 +36,13 @@ class Trajectory:
                 "expected one more observations than actions: "
                 f"{len(self.obs)} != {len(self.acts)} + 1"
             )
-        if len(self.acts) == 0:
-            raise ValueError("Degenerate trajectory: must have at least one action.")
         if self.infos is not None and len(self.infos) != len(self.acts):
             raise ValueError(
                 "infos when present must be present for each action: "
                 f"{len(self.infos)} != {len(self.acts)}"
             )
+        if len(self.acts) == 0:
+            raise ValueError("Degenerate trajectory: must have at least one action.")
 
 
 def _rews_validation(rews: np.ndarray, acts: np.ndarray):
@@ -76,7 +76,7 @@ class Transitions:
 
     obs: np.ndarray
     """
-    Previous observations. Shape: (batch_size, ) + observation_shape.
+    Previous observations. Shape: (batch_siz4e, ) + observation_shape.
 
     The i'th observation `obs[i]` in this array is the observation seen
     by the agent when choosing action `acts[i]`.
@@ -124,8 +124,6 @@ class Transitions:
                 "obs and acts must have same number of timesteps: "
                 f"{len(self.obs)} != {len(self.acts)}"
             )
-        if len(self.obs) == 0:
-            raise ValueError("Must have non-zero number of observations.")
         if self.dones.shape != (len(self.acts),):
             raise ValueError(
                 "dones must be 1D array, one entry for each timestep: "
@@ -133,6 +131,8 @@ class Transitions:
             )
         if self.dones.dtype != np.bool:
             raise ValueError(f"dones must be boolean, not {self.dones.dtype}")
+        if len(self.obs) == 0:
+            raise ValueError("Must have non-zero number of observations.")
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -95,11 +95,13 @@ def test_replay_buffer(capacity, chunk_len, obs_shape, act_shape, dtype):
         assert len(buf) == min(i, capacity)
         assert buf._buffer._idx == i % capacity
 
+        dones = np.arange(i, i + chunk_len, dtype=np.int32) % 2
+        dones = dones.astype(np.bool)
         batch = data.Transitions(
             obs=_fill_chunk(i, chunk_len, obs_shape, dtype=dtype),
             next_obs=_fill_chunk(3 * capacity + i, chunk_len, obs_shape, dtype=dtype),
             acts=_fill_chunk(6 * capacity + i, chunk_len, act_shape, dtype=dtype),
-            dones=np.arange(i, i + chunk_len, dtype=np.int32) % 2,
+            dones=dones,
         )
         buf.store(batch)
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -186,25 +186,6 @@ def test_replay_buffer_init_errors():
         ReplayBuffer(15, obs_shape=(10, 10), obs_dtype=bool, act_dtype=bool)
 
 
-def test_replay_buffer_store_errors():
-    b = ReplayBuffer(10, obs_shape=(), obs_dtype=bool, act_shape=(), act_dtype=float)
-
-    dtypes = {
-        "obs": np.float32,
-        "next_obs": np.float32,
-        "acts": np.float32,
-        "dones": np.bool,
-    }
-    for odd_field in dtypes.keys():
-        with pytest.raises(ValueError, match=".* same length.*"):
-            transition = {
-                k: np.ones(3 if k == odd_field else 4, dtype=dtype)
-                for k, dtype in dtypes.items()
-            }
-            transition = data.Transitions(**transition)
-            b.store(transition)
-
-
 def test_buffer_from_data():
     data = np.ndarray([50, 30], dtype=bool)
     buf = Buffer.from_data({"k": data})
@@ -236,16 +217,3 @@ def test_replay_buffer_from_data():
         )
     )
     _check_buf(buf_rew)
-
-    with pytest.raises(ValueError, match=r".*same length."):
-        next_obs_toolong = np.array([7, 8, 9], dtype=int)
-        ReplayBuffer.from_data(
-            data.Transitions(
-                obs=obs, acts=acts, next_obs=next_obs_toolong, dones=dones,
-            )
-        )
-    with pytest.raises(ValueError, match=r".*same dtype."):
-        next_obs_float = np.array(next_obs, dtype=float)
-        ReplayBuffer.from_data(
-            data.Transitions(obs=obs, acts=acts, next_obs=next_obs_float, dones=dones,)
-        )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -193,4 +193,6 @@ def test_zero_length_fails():
     with pytest.raises(ValueError, match=r"Degenerate trajectory.*"):
         data.Trajectory(obs=np.array([42]), acts=empty, infos=None)
     with pytest.raises(ValueError, match=r"Must have non-zero number of.*"):
-        data.Transitions(obs=empty, acts=empty, next_obs=empty, dones=empty)
+        data.Transitions(
+            obs=empty, acts=empty, next_obs=empty, dones=empty.astype(np.bool),
+        )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,193 @@
+"""Tests of imitation.util.data.
+
+Mostly checks input validation."""
+
+import functools
+from typing import Any, Callable
+
+import gym
+import numpy as np
+import pytest
+
+from imitation.util import data
+
+SPACES = [
+    gym.spaces.Discrete(3),
+    gym.spaces.MultiDiscrete((3, 4)),
+    gym.spaces.Box(-1, 1, shape=(1,)),
+    gym.spaces.Box(-1, 1, shape=(2,)),
+    gym.spaces.Box(-np.inf, np.inf, shape=(2,)),
+]
+OBS_SPACES = SPACES
+ACT_SPACES = SPACES
+
+
+def _check_1d_shape(fn: Callable[[np.ndarray], Any], length: float, expected_msg: str):
+    for shape in [(), (length, 1), (length, 2), (length - 1,), (length + 1,)]:
+        with pytest.raises(ValueError, match=expected_msg):
+            fn(np.zeros(shape))
+
+
+@pytest.mark.parametrize("obs_space", OBS_SPACES)
+@pytest.mark.parametrize("act_space", ACT_SPACES)
+@pytest.mark.parametrize("length", [0, 1, 2, 10])
+def test_valid_trajectories(
+    obs_space: gym.Space, act_space: gym.Space, length: int
+) -> None:
+    """Checks trajectories can be created for a variety of lengths and spaces."""
+    obs = np.array([obs_space.sample() for _ in range(length + 1)])
+    acts = np.array([act_space.sample() for _ in range(length)])
+    infos = [{} for _ in range(length)]
+    rews = np.random.randn(length)
+
+    traja = data.Trajectory(obs=obs, acts=acts, infos=None)
+    trajb = data.Trajectory(obs=obs, acts=acts, infos=infos)
+    trajc = data.TrajectoryWithRew(obs=obs, acts=acts, infos=None, rews=rews)
+    trajd = data.TrajectoryWithRew(obs=obs, acts=acts, infos=infos, rews=rews)
+    for traj in [traja, trajb, trajc, trajd]:
+        assert len(traj) == length
+
+
+@pytest.mark.parametrize("obs_space", OBS_SPACES)
+@pytest.mark.parametrize("act_space", ACT_SPACES)
+@pytest.mark.parametrize("length", [1, 2, 10])
+def test_invalid_trajectories(
+    obs_space: gym.Space, act_space: gym.Space, length: int
+) -> None:
+    """Checks input validation catches space and dtype related errors."""
+    obs = np.array([obs_space.sample() for _ in range(length + 1)])
+    acts = np.array([act_space.sample() for _ in range(length)])
+    infos = [{} for _ in range(length)]
+    rews = np.random.randn(length)
+
+    for cls in [data.Trajectory, functools.partial(data.TrajectoryWithRew, rews=rews)]:
+        with pytest.raises(
+            ValueError, match=r"expected one more observation than actions.*"
+        ):
+            cls(obs=obs[:-1], acts=acts, infos=None)
+        with pytest.raises(
+            ValueError, match=r"expected one more observation than actions.*"
+        ):
+            cls(obs=obs, acts=acts[:-1], infos=None)
+
+        with pytest.raises(
+            ValueError, match=r"infos when present must be present for each action.*"
+        ):
+            cls(obs=obs, acts=acts, infos=infos[:-1])
+        with pytest.raises(
+            ValueError, match=r"infos when present must be present for each action.*"
+        ):
+            cls(obs=obs[:-1], acts=acts[:-1], infos=infos)
+
+    _check_1d_shape(
+        fn=lambda rews: data.TrajectoryWithRew(
+            obs=obs, acts=acts, infos=infos, rews=rews
+        ),
+        length=length,
+        expected_msg=r"rewards must be 1D array.*",
+    )
+
+    with pytest.raises(ValueError, match=r"rewards dtype.* not a float"):
+        data.TrajectoryWithRew(
+            obs=obs, acts=acts, infos=infos, rews=np.zeros(length, dtype=np.int)
+        )
+
+
+@pytest.mark.parametrize("obs_space", OBS_SPACES)
+@pytest.mark.parametrize("act_space", ACT_SPACES)
+@pytest.mark.parametrize("length", [0, 1, 2, 10])
+def test_valid_transitions(
+    obs_space: gym.Space, act_space: gym.Space, length: int
+) -> None:
+    """Checks trajectories can be created for a variety of lengths and spaces."""
+    obs = np.array([obs_space.sample() for _ in range(length)])
+    next_obs = np.array([obs_space.sample() for _ in range(length)])
+    acts = np.array([act_space.sample() for _ in range(length)])
+    dones = np.zeros(length, dtype=np.bool)
+    rews = np.random.randn(length)
+
+    trans = data.Transitions(obs=obs, acts=acts, next_obs=next_obs, dones=dones)
+    trans_rew = data.TransitionsWithRew(
+        obs=obs, acts=acts, next_obs=next_obs, dones=dones, rews=rews
+    )
+    for traj in [trans, trans_rew]:
+        assert len(traj) == length
+
+
+@pytest.mark.parametrize("obs_space", OBS_SPACES)
+@pytest.mark.parametrize("act_space", ACT_SPACES)
+@pytest.mark.parametrize("length", [1, 2, 10])
+def test_invalid_transitions(
+    obs_space: gym.Space, act_space: gym.Space, length: int
+) -> None:
+    """Checks input validation catches space and dtype related errors."""
+    obs = np.array([obs_space.sample() for _ in range(length)])
+    next_obs = np.array([obs_space.sample() for _ in range(length)])
+    acts = np.array([act_space.sample() for _ in range(length)])
+    dones = np.zeros(length, dtype=np.bool)
+    rews = np.random.randn(length)
+
+    for cls in [
+        data.Transitions,
+        functools.partial(data.TransitionsWithRew, rews=rews),
+    ]:
+        with pytest.raises(
+            ValueError, match=r"obs and next_obs must have same shape:.*"
+        ):
+            cls(obs=obs[:-1], acts=acts, next_obs=next_obs, dones=dones)
+        with pytest.raises(
+            ValueError, match=r"obs and next_obs must have same shape:.*"
+        ):
+            cls(obs=obs, acts=acts, next_obs=np.zeros((length, 4, 2)), dones=dones)
+
+        with pytest.raises(
+            ValueError, match=r"obs and next_obs must have the same dtype:.*"
+        ):
+            cls(
+                obs=obs,
+                acts=acts,
+                next_obs=np.zeros_like(obs, dtype=np.bool),
+                dones=dones,
+            )
+
+        with pytest.raises(
+            ValueError, match=r"obs and acts must have same number of timesteps:.*"
+        ):
+            cls(obs=obs[:-1], acts=acts, next_obs=next_obs[:-1], dones=dones)
+        with pytest.raises(
+            ValueError, match=r"obs and acts must have same number of timesteps:.*"
+        ):
+            cls(obs=obs, acts=acts[:-1], next_obs=next_obs, dones=dones)
+
+        _check_1d_shape(
+            fn=lambda bogus_dones: cls(
+                obs=obs, acts=acts, next_obs=next_obs, dones=bogus_dones,
+            ),
+            length=length,
+            expected_msg=r"dones must be 1D array.*",
+        )
+
+        with pytest.raises(ValueError, match=r"dones must be boolean"):
+            cls(
+                obs=obs,
+                acts=acts,
+                next_obs=next_obs,
+                dones=np.zeros(length, dtype=np.int),
+            )
+
+    _check_1d_shape(
+        fn=lambda bogus_rews: data.TransitionsWithRew(
+            obs=obs, acts=acts, next_obs=next_obs, dones=dones, rews=bogus_rews
+        ),
+        length=length,
+        expected_msg=r"rewards must be 1D array.*",
+    )
+
+    with pytest.raises(ValueError, match=r"rewards dtype.* not a float"):
+        data.TransitionsWithRew(
+            obs=obs,
+            acts=acts,
+            next_obs=next_obs,
+            dones=dones,
+            rews=np.zeros(length, dtype=np.int),
+        )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -62,11 +62,11 @@ def test_invalid_trajectories(
 
     for cls in [data.Trajectory, functools.partial(data.TrajectoryWithRew, rews=rews)]:
         with pytest.raises(
-            ValueError, match=r"expected one more observation than actions.*"
+            ValueError, match=r"expected one more observations than actions.*"
         ):
             cls(obs=obs[:-1], acts=acts, infos=None)
         with pytest.raises(
-            ValueError, match=r"expected one more observation than actions.*"
+            ValueError, match=r"expected one more observations than actions.*"
         ):
             cls(obs=obs, acts=acts[:-1], infos=None)
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -20,6 +20,7 @@ SPACES = [
 ]
 OBS_SPACES = SPACES
 ACT_SPACES = SPACES
+LENGTHS = [0, 1, 2, 10]
 
 
 def _check_1d_shape(fn: Callable[[np.ndarray], Any], length: float, expected_msg: str):
@@ -31,163 +32,163 @@ def _check_1d_shape(fn: Callable[[np.ndarray], Any], length: float, expected_msg
 @pytest.mark.parametrize("obs_space", OBS_SPACES)
 @pytest.mark.parametrize("act_space", ACT_SPACES)
 @pytest.mark.parametrize("length", [0, 1, 2, 10])
-def test_valid_trajectories(
-    obs_space: gym.Space, act_space: gym.Space, length: int
-) -> None:
-    """Checks trajectories can be created for a variety of lengths and spaces."""
-    obs = np.array([obs_space.sample() for _ in range(length + 1)])
-    acts = np.array([act_space.sample() for _ in range(length)])
-    infos = [{} for _ in range(length)]
-    rews = np.random.randn(length)
+class TestData:
+    def test_valid_trajectories(
+        self, obs_space: gym.Space, act_space: gym.Space, length: int
+    ) -> None:
+        """Checks trajectories can be created for a variety of lengths and spaces."""
+        obs = np.array([obs_space.sample() for _ in range(length + 1)])
+        acts = np.array([act_space.sample() for _ in range(length)])
+        infos = [{} for _ in range(length)]
+        rews = np.random.randn(length)
 
-    traja = data.Trajectory(obs=obs, acts=acts, infos=None)
-    trajb = data.Trajectory(obs=obs, acts=acts, infos=infos)
-    trajc = data.TrajectoryWithRew(obs=obs, acts=acts, infos=None, rews=rews)
-    trajd = data.TrajectoryWithRew(obs=obs, acts=acts, infos=infos, rews=rews)
-    for traj in [traja, trajb, trajc, trajd]:
-        assert len(traj) == length
+        traja = data.Trajectory(obs=obs, acts=acts, infos=None)
+        trajb = data.Trajectory(obs=obs, acts=acts, infos=infos)
+        trajc = data.TrajectoryWithRew(obs=obs, acts=acts, infos=None, rews=rews)
+        trajd = data.TrajectoryWithRew(obs=obs, acts=acts, infos=infos, rews=rews)
+        for traj in [traja, trajb, trajc, trajd]:
+            assert len(traj) == length
 
+    def test_invalid_trajectories(
+        self, obs_space: gym.Space, act_space: gym.Space, length: int
+    ) -> None:
+        """Checks input validation catches space and dtype related errors."""
+        if length == 0:
+            pytest.skip("Need length>0.")
 
-@pytest.mark.parametrize("obs_space", OBS_SPACES)
-@pytest.mark.parametrize("act_space", ACT_SPACES)
-@pytest.mark.parametrize("length", [1, 2, 10])
-def test_invalid_trajectories(
-    obs_space: gym.Space, act_space: gym.Space, length: int
-) -> None:
-    """Checks input validation catches space and dtype related errors."""
-    obs = np.array([obs_space.sample() for _ in range(length + 1)])
-    acts = np.array([act_space.sample() for _ in range(length)])
-    infos = [{} for _ in range(length)]
-    rews = np.random.randn(length)
+        obs = np.array([obs_space.sample() for _ in range(length + 1)])
+        acts = np.array([act_space.sample() for _ in range(length)])
+        infos = [{} for _ in range(length)]
+        rews = np.random.randn(length)
 
-    for cls in [data.Trajectory, functools.partial(data.TrajectoryWithRew, rews=rews)]:
-        with pytest.raises(
-            ValueError, match=r"expected one more observations than actions.*"
-        ):
-            cls(obs=obs[:-1], acts=acts, infos=None)
-        with pytest.raises(
-            ValueError, match=r"expected one more observations than actions.*"
-        ):
-            cls(obs=obs, acts=acts[:-1], infos=None)
+        for cls in [
+            data.Trajectory,
+            functools.partial(data.TrajectoryWithRew, rews=rews),
+        ]:
+            with pytest.raises(
+                ValueError, match=r"expected one more observations than actions.*"
+            ):
+                cls(obs=obs[:-1], acts=acts, infos=None)
+            with pytest.raises(
+                ValueError, match=r"expected one more observations than actions.*"
+            ):
+                cls(obs=obs, acts=acts[:-1], infos=None)
 
-        with pytest.raises(
-            ValueError, match=r"infos when present must be present for each action.*"
-        ):
-            cls(obs=obs, acts=acts, infos=infos[:-1])
-        with pytest.raises(
-            ValueError, match=r"infos when present must be present for each action.*"
-        ):
-            cls(obs=obs[:-1], acts=acts[:-1], infos=infos)
-
-    _check_1d_shape(
-        fn=lambda rews: data.TrajectoryWithRew(
-            obs=obs, acts=acts, infos=infos, rews=rews
-        ),
-        length=length,
-        expected_msg=r"rewards must be 1D array.*",
-    )
-
-    with pytest.raises(ValueError, match=r"rewards dtype.* not a float"):
-        data.TrajectoryWithRew(
-            obs=obs, acts=acts, infos=infos, rews=np.zeros(length, dtype=np.int)
-        )
-
-
-@pytest.mark.parametrize("obs_space", OBS_SPACES)
-@pytest.mark.parametrize("act_space", ACT_SPACES)
-@pytest.mark.parametrize("length", [0, 1, 2, 10])
-def test_valid_transitions(
-    obs_space: gym.Space, act_space: gym.Space, length: int
-) -> None:
-    """Checks trajectories can be created for a variety of lengths and spaces."""
-    obs = np.array([obs_space.sample() for _ in range(length)])
-    next_obs = np.array([obs_space.sample() for _ in range(length)])
-    acts = np.array([act_space.sample() for _ in range(length)])
-    dones = np.zeros(length, dtype=np.bool)
-    rews = np.random.randn(length)
-
-    trans = data.Transitions(obs=obs, acts=acts, next_obs=next_obs, dones=dones)
-    trans_rew = data.TransitionsWithRew(
-        obs=obs, acts=acts, next_obs=next_obs, dones=dones, rews=rews
-    )
-    for traj in [trans, trans_rew]:
-        assert len(traj) == length
-
-
-@pytest.mark.parametrize("obs_space", OBS_SPACES)
-@pytest.mark.parametrize("act_space", ACT_SPACES)
-@pytest.mark.parametrize("length", [1, 2, 10])
-def test_invalid_transitions(
-    obs_space: gym.Space, act_space: gym.Space, length: int
-) -> None:
-    """Checks input validation catches space and dtype related errors."""
-    obs = np.array([obs_space.sample() for _ in range(length)])
-    next_obs = np.array([obs_space.sample() for _ in range(length)])
-    acts = np.array([act_space.sample() for _ in range(length)])
-    dones = np.zeros(length, dtype=np.bool)
-    rews = np.random.randn(length)
-
-    for cls in [
-        data.Transitions,
-        functools.partial(data.TransitionsWithRew, rews=rews),
-    ]:
-        with pytest.raises(
-            ValueError, match=r"obs and next_obs must have same shape:.*"
-        ):
-            cls(obs=obs[:-1], acts=acts, next_obs=next_obs, dones=dones)
-        with pytest.raises(
-            ValueError, match=r"obs and next_obs must have same shape:.*"
-        ):
-            cls(obs=obs, acts=acts, next_obs=np.zeros((length, 4, 2)), dones=dones)
-
-        with pytest.raises(
-            ValueError, match=r"obs and next_obs must have the same dtype:.*"
-        ):
-            cls(
-                obs=obs,
-                acts=acts,
-                next_obs=np.zeros_like(obs, dtype=np.bool),
-                dones=dones,
-            )
-
-        with pytest.raises(
-            ValueError, match=r"obs and acts must have same number of timesteps:.*"
-        ):
-            cls(obs=obs[:-1], acts=acts, next_obs=next_obs[:-1], dones=dones)
-        with pytest.raises(
-            ValueError, match=r"obs and acts must have same number of timesteps:.*"
-        ):
-            cls(obs=obs, acts=acts[:-1], next_obs=next_obs, dones=dones)
+            with pytest.raises(
+                ValueError,
+                match=r"infos when present must be present for each action.*",
+            ):
+                cls(obs=obs, acts=acts, infos=infos[:-1])
+            with pytest.raises(
+                ValueError,
+                match=r"infos when present must be present for each action.*",
+            ):
+                cls(obs=obs[:-1], acts=acts[:-1], infos=infos)
 
         _check_1d_shape(
-            fn=lambda bogus_dones: cls(
-                obs=obs, acts=acts, next_obs=next_obs, dones=bogus_dones,
+            fn=lambda rews: data.TrajectoryWithRew(
+                obs=obs, acts=acts, infos=infos, rews=rews
             ),
             length=length,
-            expected_msg=r"dones must be 1D array.*",
+            expected_msg=r"rewards must be 1D array.*",
         )
 
-        with pytest.raises(ValueError, match=r"dones must be boolean"):
-            cls(
+        with pytest.raises(ValueError, match=r"rewards dtype.* not a float"):
+            data.TrajectoryWithRew(
+                obs=obs, acts=acts, infos=infos, rews=np.zeros(length, dtype=np.int)
+            )
+
+    def test_valid_transitions(
+        self, obs_space: gym.Space, act_space: gym.Space, length: int
+    ) -> None:
+        """Checks trajectories can be created for a variety of lengths and spaces."""
+        obs = np.array([obs_space.sample() for _ in range(length)])
+        next_obs = np.array([obs_space.sample() for _ in range(length)])
+        acts = np.array([act_space.sample() for _ in range(length)])
+        dones = np.zeros(length, dtype=np.bool)
+        rews = np.random.randn(length)
+
+        trans = data.Transitions(obs=obs, acts=acts, next_obs=next_obs, dones=dones)
+        trans_rew = data.TransitionsWithRew(
+            obs=obs, acts=acts, next_obs=next_obs, dones=dones, rews=rews
+        )
+        for traj in [trans, trans_rew]:
+            assert len(traj) == length
+
+    def test_invalid_transitions(
+        self, obs_space: gym.Space, act_space: gym.Space, length: int
+    ) -> None:
+        """Checks input validation catches space and dtype related errors."""
+        if length == 0:
+            pytest.skip("Need length>0.")
+
+        obs = np.array([obs_space.sample() for _ in range(length)])
+        next_obs = np.array([obs_space.sample() for _ in range(length)])
+        acts = np.array([act_space.sample() for _ in range(length)])
+        dones = np.zeros(length, dtype=np.bool)
+        rews = np.random.randn(length)
+
+        for cls in [
+            data.Transitions,
+            functools.partial(data.TransitionsWithRew, rews=rews),
+        ]:
+            with pytest.raises(
+                ValueError, match=r"obs and next_obs must have same shape:.*"
+            ):
+                cls(obs=obs[:-1], acts=acts, next_obs=next_obs, dones=dones)
+            with pytest.raises(
+                ValueError, match=r"obs and next_obs must have same shape:.*"
+            ):
+                cls(obs=obs, acts=acts, next_obs=np.zeros((length, 4, 2)), dones=dones)
+
+            with pytest.raises(
+                ValueError, match=r"obs and next_obs must have the same dtype:.*"
+            ):
+                cls(
+                    obs=obs,
+                    acts=acts,
+                    next_obs=np.zeros_like(obs, dtype=np.bool),
+                    dones=dones,
+                )
+
+            with pytest.raises(
+                ValueError, match=r"obs and acts must have same number of timesteps:.*"
+            ):
+                cls(obs=obs[:-1], acts=acts, next_obs=next_obs[:-1], dones=dones)
+            with pytest.raises(
+                ValueError, match=r"obs and acts must have same number of timesteps:.*"
+            ):
+                cls(obs=obs, acts=acts[:-1], next_obs=next_obs, dones=dones)
+
+            _check_1d_shape(
+                fn=lambda bogus_dones: cls(
+                    obs=obs, acts=acts, next_obs=next_obs, dones=bogus_dones,
+                ),
+                length=length,
+                expected_msg=r"dones must be 1D array.*",
+            )
+
+            with pytest.raises(ValueError, match=r"dones must be boolean"):
+                cls(
+                    obs=obs,
+                    acts=acts,
+                    next_obs=next_obs,
+                    dones=np.zeros(length, dtype=np.int),
+                )
+
+        _check_1d_shape(
+            fn=lambda bogus_rews: data.TransitionsWithRew(
+                obs=obs, acts=acts, next_obs=next_obs, dones=dones, rews=bogus_rews
+            ),
+            length=length,
+            expected_msg=r"rewards must be 1D array.*",
+        )
+
+        with pytest.raises(ValueError, match=r"rewards dtype.* not a float"):
+            data.TransitionsWithRew(
                 obs=obs,
                 acts=acts,
                 next_obs=next_obs,
-                dones=np.zeros(length, dtype=np.int),
+                dones=dones,
+                rews=np.zeros(length, dtype=np.int),
             )
-
-    _check_1d_shape(
-        fn=lambda bogus_rews: data.TransitionsWithRew(
-            obs=obs, acts=acts, next_obs=next_obs, dones=dones, rews=bogus_rews
-        ),
-        length=length,
-        expected_msg=r"rewards must be 1D array.*",
-    )
-
-    with pytest.raises(ValueError, match=r"rewards dtype.* not a float"):
-        data.TransitionsWithRew(
-            obs=obs,
-            acts=acts,
-            next_obs=next_obs,
-            dones=dones,
-            rews=np.zeros(length, dtype=np.int),
-        )


### PR DESCRIPTION
Data classes support input validation via the `__post_init__` method, so add this to catch some common abuses.

This doesn't stop someone who really wants to shoot themselves in the foot: while the data classes themselves are frozen, NumPy arrays are still mutable. But it should prevent most accidents.

Removed some now-redundant input validation in `ReplayBuffer` checking for cases which are no longer possible.

For review: particularly interested if can think of anything else worth checking, or if there's a way to make the tests more compact. There's a lot of almost-but-not-quite duplicated code between Transitions and Trajectory that I can't see how to avoid.