### PR TITLE
Handle episode termination in reward models

### DIFF
--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -391,6 +391,7 @@ class AdversarialTrainer:
         obs = np.concatenate([expert_obs_norm, gen_obs_norm])
         acts = np.concatenate([expert_samples.acts, gen_samples.acts])
         next_obs = np.concatenate([expert_samples.next_obs, gen_samples.next_obs])
+        dones = np.concatenate([expert_samples.dones, gen_samples.dones])
         labels_gen_is_one = np.concatenate(
             [np.zeros(n_expert, dtype=int), np.ones(n_gen, dtype=int)]
         )
@@ -404,6 +405,7 @@ class AdversarialTrainer:
             self.discrim.obs_ph: obs,
             self.discrim.act_ph: acts,
             self.discrim.next_obs_ph: next_obs,
+            self.discrim.done_ph: dones,
             self.discrim.labels_gen_is_one_ph: labels_gen_is_one,
             self.discrim.log_policy_act_prob_ph: log_act_prob,
         }

--- a/src/imitation/analysis/mountain_car_plots.py
+++ b/src/imitation/analysis/mountain_car_plots.py
@@ -92,9 +92,9 @@ def make_heatmap(
         obs_vec = np.array([[p, v] for p in pos_space for v in vel_space])
         acts_vec = np.array([act] * len(obs_vec))
         next_obs_vec = _make_next_mc_obs(obs_vec, acts_vec)
-        steps = np.arange(len(acts_vec))
+        dones = np.zeros(len(acts_vec), dtype=np.bool)
 
-        rew = reward_fn(obs_vec, acts_vec, next_obs_vec, steps)
+        rew = reward_fn(obs_vec, acts_vec, next_obs_vec, dones)
         # Transpose because `pcolor` (confusingly) expects its first two arguments
         # to be XY, but its matrix argument to be in RC format.
         rew_matrix = rew.reshape(n_pos_step, n_vel_step).T
@@ -215,8 +215,9 @@ def plot_reward_vs_time(
         for traj in trajs_list:
             T = len(traj.rews)
             X.extend(range(T))
-            steps = np.arange(len(traj.acts))
-            rews = reward_fn(traj.obs[:-1], traj.acts, traj.obs[1:], steps)
+            dones = np.zeros(T, dtype=np.bool)
+            dones[-1] = True
+            rews = reward_fn(traj.obs[:-1], traj.acts, traj.obs[1:], dones)
             Y.extend(rews)
         color = preferred_colors.get(trajs_label, None)
         ax.plot(X, Y, label=trajs_label, c=color)

--- a/src/imitation/rewards/common.py
+++ b/src/imitation/rewards/common.py
@@ -1,7 +1,7 @@
 """Utilities and definitions shared by reward-related code."""
 
 import functools
-from typing import Callable, Optional
+from typing import Callable
 
 import numpy as np
 from stable_baselines.common import vec_env
@@ -13,7 +13,7 @@ def _reward_fn_normalize_inputs(
     obs: np.ndarray,
     acts: np.ndarray,
     next_obs: np.ndarray,
-    steps: Optional[np.ndarray] = None,
+    dones: np.ndarray,
     *,
     reward_fn: RewardFn,
     vec_normalize: vec_env.VecNormalize,
@@ -32,7 +32,7 @@ def _reward_fn_normalize_inputs(
     """
     norm_obs = vec_normalize.normalize_obs(obs)
     norm_next_obs = vec_normalize.normalize_obs(next_obs)
-    rew = reward_fn(norm_obs, acts, norm_next_obs, steps)
+    rew = reward_fn(norm_obs, acts, norm_next_obs, dones)
     if norm_reward:
         rew = vec_normalize.normalize_reward(rew)
     return rew

--- a/src/imitation/rewards/reward_net.py
+++ b/src/imitation/rewards/reward_net.py
@@ -334,13 +334,10 @@ class BasicShapedRewardNet(RewardNetShaped, serialize.LayersSerializable):
     """A shaped reward network with simple, default settings.
 
     With default parameters this RewardNet has two hidden layers [32, 32]
-    for the reward shaping phi network, and a linear function approximator
-    for the theta network. These settings match the network architectures for
-    continuous control experiments described in Appendix D.1 of the
-    AIRL paper.
+    for the theta network and reward shaping phi network.
 
-    This network flattens inputs. So it isn't suitable for training on
-    pixel observations.
+    This network is feed-forward and flattens inputs, so is a poor choice for
+    training on pixel observations.
     """
 
     def __init__(

--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -7,7 +7,7 @@ import numpy as np
 from stable_baselines.common.vec_env import VecEnv
 
 from imitation.rewards import common, discrim_net, reward_net
-from imitation.util import registry, util
+from imitation.util import networks, registry, util
 
 RewardFnLoaderFn = Callable[[str, VecEnv], ContextManager[common.RewardFn]]
 
@@ -25,10 +25,10 @@ def _load_discrim_net(path: str, venv: VecEnv) -> common.RewardFn:
 
 def _load_reward_net_as_fn(shaped: bool) -> RewardFnLoaderFn:
     @contextlib.contextmanager
-    def loader(path: str, venv: VecEnv,) -> Iterator[common.RewardFn]:
+    def loader(path: str, venv: VecEnv) -> Iterator[common.RewardFn]:
         """Load train (shaped) or test (not shaped) reward from path."""
         del venv  # Unused.
-        with util.make_session() as (graph, sess):
+        with networks.make_session() as (graph, sess):
             net = reward_net.RewardNet.load(path)
             reward = net.reward_output_train if shaped else net.reward_output_test
 

--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -36,13 +36,13 @@ def _load_reward_net_as_fn(shaped: bool) -> RewardFnLoaderFn:
                 obs: np.ndarray,
                 act: np.ndarray,
                 next_obs: np.ndarray,
-                steps: np.ndarray,
+                dones: np.ndarray,
             ) -> np.ndarray:
-                del steps
                 fd = {
                     net.obs_ph: obs,
                     net.act_ph: act,
                     net.next_obs_ph: next_obs,
+                    net.done_ph: dones,
                 }
                 rew = sess.run(reward, feed_dict=fd)
                 assert rew.shape == (len(obs),)
@@ -57,9 +57,9 @@ def load_zero(path: str, venv: VecEnv) -> common.RewardFn:
     del path, venv
 
     def f(
-        obs: np.ndarray, act: np.ndarray, next_obs: np.ndarray, steps: np.ndarray
+        obs: np.ndarray, act: np.ndarray, next_obs: np.ndarray, dones: np.ndarray
     ) -> np.ndarray:
-        del act, next_obs, steps  # Unused.
+        del act, next_obs, dones  # Unused.
         return np.zeros(obs.shape[0])
 
     return f

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -13,6 +13,7 @@ import imitation.util.sacred as sacred_util
 from imitation.policies import serialize
 from imitation.rewards.serialize import load_reward
 from imitation.scripts.config.expert_demos import expert_demos_ex
+from imitation.util import networks
 from imitation.util.reward_wrapper import RewardVecEnvWrapper
 
 
@@ -107,7 +108,7 @@ def rollouts_and_policy(
     )
     eval_sample_until = util.rollout.min_episodes(n_episodes_eval)
 
-    with util.make_session():
+    with networks.make_session():
         tf.logging.set_verbosity(tf.logging.INFO)
         util.logger.configure(
             folder=osp.join(log_dir, "rl"), format_strs=["tensorboard", "stdout"]
@@ -185,7 +186,7 @@ def rollouts_and_policy(
 
 
 @expert_demos_ex.command
-@util.make_session()
+@networks.make_session()
 def rollouts_from_policy(
     _run,
     _seed: int,

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -13,9 +13,8 @@ from sacred.observers import FileStorageObserver
 from imitation.algorithms.adversarial import init_trainer
 from imitation.policies import serialize
 from imitation.scripts.config.train_adversarial import train_ex
-from imitation.util import data, rollout
+from imitation.util import data, networks, rollout
 from imitation.util import sacred as sacred_util
-from imitation.util import util
 
 
 def save(trainer, save_path):
@@ -123,7 +122,7 @@ def train(
 
     expert_stats = rollout.rollout_stats(expert_trajs)
 
-    with util.make_session():
+    with networks.make_session():
         if init_tensorboard:
             sb_tensorboard_dir = osp.join(log_dir, "sb_tb")
             kwargs = init_trainer_kwargs

--- a/src/imitation/util/networks.py
+++ b/src/imitation/util/networks.py
@@ -1,0 +1,150 @@
+"""Helper methods to build and run neural networks."""
+
+import collections
+import contextlib
+from typing import Callable, Dict, Iterable, Optional, Sequence, Tuple
+
+import gym
+import tensorflow as tf
+from stable_baselines.common.input import observation_input
+
+# TODO(adam): we should use typing.OrderedDict introduced in Python 3.7.2
+# As of 2020-05-07, pytype does not understand OrderedDict; worth retrying.
+LayersDict = Dict[str, tf.layers.Layer]
+
+
+def build_mlp(
+    hid_sizes: Iterable[int],
+    name: Optional[str] = None,
+    activation: Optional[Callable] = tf.nn.relu,
+    initializer: Optional[Callable] = None,
+) -> LayersDict:
+    """Constructs an MLP, returning an ordered dict of layers."""
+    layers = collections.OrderedDict()
+
+    # Hidden layers
+    for i, size in enumerate(hid_sizes):
+        key = f"{name}_dense{i}"
+        layer = tf.layers.Dense(
+            size, activation=activation, kernel_initializer=initializer, name=key
+        )  # type: tf.layers.Layer
+        layers[key] = layer
+
+    # Final layer
+    layer = tf.layers.Dense(
+        1, kernel_initializer=initializer, name=f"{name}_dense_final"
+    )  # type: tf.layers.Layer
+    layers[f"{name}_dense_final"] = layer
+
+    return layers
+
+
+def sequential(inputs: tf.Tensor, layers: LayersDict,) -> tf.Tensor:
+    """Applies a sequence of layers to an input."""
+    output = inputs
+    for layer in layers.values():
+        output = layer(output)
+    output = tf.squeeze(output, axis=1)
+    return output
+
+
+def build_inputs(
+    observation_space: gym.Space, action_space: gym.Space, scale: bool = False
+) -> Tuple[tf.Tensor, ...]:
+    """Builds placeholders and processed input Tensors.
+
+    Observation `obs_*` and `next_obs_*` placeholders and processed input
+    tensors have shape `(None,) + obs_space.shape`.
+    The action `act_*` placeholder and processed input tensors have shape
+    `(None,) + act_space.shape`.
+
+    Args:
+        observation_space: The observation space.
+        action_space: The action space.
+        scale: Only relevant for environments with Box spaces. If True, then
+            processed input Tensors are automatically scaled to the interval [0, 1].
+
+    Returns:
+        (phs, inps) where phs is a tuple of:
+            obs_ph: Placeholder for old observations.
+            act_ph: Placeholder for actions.
+            next_obs_ph: Placeholder for new observations.
+            dones_ph: Placeholder for boolean episode termination.
+        and inps is a tuple of:
+            obs_inp: Network-ready float32 Tensor with processed old observations.
+            act_inp: Network-ready float32 Tensor with processed actions.
+            next_obs_inp: Network-ready float32 Tensor with processed new observations.
+            dones_inp: Network-ready float32 tensor, with booleans 0-1 coded.
+    """
+    obs_ph, obs_inp = observation_input(observation_space, name="obs", scale=scale)
+    act_ph, act_inp = observation_input(action_space, name="act", scale=scale)
+    next_obs_ph, next_obs_inp = observation_input(
+        observation_space, name="next_obs", scale=scale
+    )
+    done_ph = tf.placeholder(name="dones", shape=(None,), dtype=tf.bool)
+    done_inp = tf.cast(done_ph, dtype=tf.float32)
+    phs = (obs_ph, act_ph, next_obs_ph, done_ph)
+    inps = (obs_inp, act_inp, next_obs_inp, done_inp)
+    return phs, inps
+
+
+@contextlib.contextmanager
+def make_session(close_on_exit: bool = True, **kwargs):
+    """Context manager for a TensorFlow session.
+
+    The session is associated with a newly created graph. Both session and
+    graph are set as default. The session will be closed when exiting this
+    context manager.
+
+    Args:
+      close_on_exit: If True, closes the session upon leaving the context manager.
+      kwargs: passed through to `tf.Session`.
+
+    Yields:
+      (graph, session) where graph is a `tf.Graph` and `session` a `tf.Session`.
+    """
+    graph = tf.Graph()
+    with graph.as_default():
+        session = tf.Session(graph=graph, **kwargs)
+        try:
+            with session.as_default():
+                yield graph, session
+        finally:
+            if close_on_exit:
+                session.close()
+
+
+def build_and_apply_mlp(
+    inputs: Sequence[tf.Tensor],
+    hid_sizes: Optional[Iterable[int]] = None,
+    **kwargs: dict,
+) -> Tuple[tf.Tensor, LayersDict]:
+    """Builds an MLP depending on specified inputs.
+
+    All specified inputs will be flattened and then concatenated. They are then
+    applied using `sequential` to an MLP built using `build_mlp`.
+
+    Arguments:
+      hid_sizes: Number of units at each hidden layer. Default is [], i.e. linear.
+      inputs: Sequence of tensor inputs to flatten and concatenate.
+      **kwargs: Passed through to `util.build_mlp`.
+
+    Returns:
+      (output, mlp) where output is the predicted reward and mlp is a LayersDict.
+
+    Raises:
+      ValueError: If inputs is a length-0 tensor.
+    """
+    if len(inputs) == 0:
+        raise ValueError("Must specify at least one input")
+
+    if hid_sizes is None:
+        hid_sizes = (32, 32)
+
+    with tf.variable_scope("theta"):
+        inputs = [tf.layers.flatten(x) for x in inputs]
+        inputs = tf.concat(inputs, axis=1)
+        mlp = build_mlp(hid_sizes=hid_sizes, name="reward", **kwargs)
+        output = sequential(inputs, mlp)
+
+        return output, mlp

--- a/src/imitation/util/networks.py
+++ b/src/imitation/util/networks.py
@@ -8,8 +8,6 @@ import gym
 import tensorflow as tf
 from stable_baselines.common.input import observation_input
 
-# TODO(adam): we should use typing.OrderedDict introduced in Python 3.7.2
-# As of 2020-05-07, pytype does not understand OrderedDict; worth retrying.
 LayersDict = Dict[str, tf.layers.Layer]
 
 
@@ -39,7 +37,7 @@ def build_mlp(
     return layers
 
 
-def sequential(inputs: tf.Tensor, layers: LayersDict,) -> tf.Tensor:
+def sequential(inputs: tf.Tensor, layers: LayersDict) -> tf.Tensor:
     """Applies a sequence of layers to an input."""
     output = inputs
     for layer in layers.values():
@@ -125,7 +123,9 @@ def build_and_apply_mlp(
     applied using `sequential` to an MLP built using `build_mlp`.
 
     Arguments:
-      hid_sizes: Number of units at each hidden layer. Default is [], i.e. linear.
+        hid_sizes: Number of units at each hidden layer.
+            Default is (32, 32), i.e. two hidden layers with 32 units.
+            () represents linear.
       inputs: Sequence of tensor inputs to flatten and concatenate.
       **kwargs: Passed through to `util.build_mlp`.
 

--- a/src/imitation/util/networks.py
+++ b/src/imitation/util/networks.py
@@ -69,7 +69,7 @@ def build_inputs(
             obs_ph: Placeholder for old observations.
             act_ph: Placeholder for actions.
             next_obs_ph: Placeholder for new observations.
-            dones_ph: Placeholder for boolean episode termination.
+            done_ph: Placeholder for boolean episode termination.
         and inps is a tuple of:
             obs_inp: Network-ready float32 Tensor with processed old observations.
             act_inp: Network-ready float32 Tensor with processed actions.

--- a/src/imitation/util/registry.py
+++ b/src/imitation/util/registry.py
@@ -14,7 +14,7 @@ from typing import (
 import gym
 from stable_baselines.common.vec_env import VecEnv
 
-from imitation.util import util
+from imitation.util import networks
 
 T = TypeVar("T")
 LoaderFn = Callable[[str, VecEnv], T]
@@ -117,7 +117,7 @@ def sess_context(fn: Callable[..., T]) -> Callable[..., ContextManager[T]]:
     @functools.wraps(fn)
     @contextlib.contextmanager
     def wrapper(*args, **kwargs) -> Iterator[T]:
-        with util.make_session():
+        with networks.make_session():
             yield fn(*args, **kwargs)
 
     return wrapper

--- a/src/imitation/util/reward_wrapper.py
+++ b/src/imitation/util/reward_wrapper.py
@@ -48,7 +48,6 @@ class RewardVecEnvWrapper(vec_env.VecEnvWrapper):
 
     def reset(self):
         self._old_obs = self.venv.reset()
-        self._step_counter = np.zeros((self.num_envs,), dtype="int")
         return self._old_obs
 
     def step_async(self, actions):
@@ -69,13 +68,9 @@ class RewardVecEnvWrapper(vec_env.VecEnvWrapper):
             obs_fixed.append(single_obs)
         obs_fixed = np.stack(obs_fixed)
 
-        rews = self.reward_fn(
-            self._old_obs, self._actions, obs_fixed, self._step_counter
-        )
+        rews = self.reward_fn(self._old_obs, self._actions, obs_fixed, np.array(dones),)
         assert len(rews) == len(obs), "must return one rew for each env"
         done_mask = np.asarray(dones, dtype="bool").reshape((len(dones),))
-        self._step_counter += 1
-        self._step_counter[done_mask] = 0
 
         # Update statistics
         self._cumulative_rew += rews

--- a/src/imitation/util/reward_wrapper.py
+++ b/src/imitation/util/reward_wrapper.py
@@ -68,7 +68,7 @@ class RewardVecEnvWrapper(vec_env.VecEnvWrapper):
             obs_fixed.append(single_obs)
         obs_fixed = np.stack(obs_fixed)
 
-        rews = self.reward_fn(self._old_obs, self._actions, obs_fixed, np.array(dones),)
+        rews = self.reward_fn(self._old_obs, self._actions, obs_fixed, np.array(dones))
         assert len(rews) == len(obs), "must return one rew for each env"
         done_mask = np.asarray(dones, dtype="bool").reshape((len(dones),))
 

--- a/src/imitation/util/serialize.py
+++ b/src/imitation/util/serialize.py
@@ -7,7 +7,7 @@ from typing import Type, TypeVar
 
 import tensorflow as tf
 
-from imitation.util import util
+from imitation.util import networks
 
 T = TypeVar("T", bound="Serializable")
 
@@ -61,7 +61,7 @@ class LayersSerializable(Serializable):
         LayersSerializable.__init__(**args, layers=layers)
     """
 
-    def __init__(self, *args, layers: util.LayersDict, **kwargs):
+    def __init__(self, *args, layers: networks.LayersDict, **kwargs):
         self._args = args
         self._kwargs = kwargs
         self._checkpoint = tf.train.Checkpoint(**layers)

--- a/tests/test_reward_net.py
+++ b/tests/test_reward_net.py
@@ -52,6 +52,7 @@ def _make_feed_dict(reward_net: reward_net.RewardNet, transitions: data.Transiti
         reward_net.obs_ph: transitions.obs,
         reward_net.act_ph: transitions.acts,
         reward_net.next_obs_ph: transitions.next_obs,
+        reward_net.done_ph: transitions.dones,
     }
 
 
@@ -86,8 +87,12 @@ def test_serialize_identity(session, env_name, net_cls, tmpdir):
         with serialize.load_reward("RewardNet_shaped", tmpdir, venv) as shaped_fn:
             rewards = session.run(outputs, feed_dict=feed_dict)
 
-            steps = np.zeros((transitions.obs.shape[0],))
-            args = (transitions.obs, transitions.acts, transitions.next_obs, steps)
+            args = (
+                transitions.obs,
+                transitions.acts,
+                transitions.next_obs,
+                transitions.dones,
+            )
             rewards["train"].append(shaped_fn(*args))
             rewards["test"].append(unshaped_fn(*args))
 


### PR DESCRIPTION
This PR:
  - Makes `RewardNetShaped` and subclasses set next potential to be fixed to zero when the episode terminates. 0 is required in the undiscounted case for convergence guarantees (where it can be chosen WLOG).
  - `RewardNet` and subclasses can optionally use episode termination directly for prediction; also make inclusion of state, action and next state configurable.
  - Replaces `steps` (that was not used anywhere as far as I can tell) in `common.RewardFn` with `dones`.
  - Refactors MLP building code into `imitation.util.networks` out of various other files.