### PR TITLE
Rename benchmark_environments to seals

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 TF_VERSION = ">=1.15.0,<2.0"
 TESTS_REQUIRE = [
-    "seals~=0.0.1",
+    "seals~=0.1.0",
     # remove pin once https://github.com/nedbat/coveragepy/issues/881 fixed
     "black",
     "coverage==4.5.4",

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,7 @@ from setuptools import find_packages, setup
 
 TF_VERSION = ">=1.15.0,<2.0"
 TESTS_REQUIRE = [
-    # TODO(adam): use PyPi rather than Git once we make first release
-    (
-        "benchmark-environments @ "
-        "git+https://github.com/HumanCompatibleAI/benchmark-environments.git"
-    ),
+    "seals~=0.0.1",
     # remove pin once https://github.com/nedbat/coveragepy/issues/881 fixed
     "black",
     "coverage==4.5.4",

--- a/src/imitation/scripts/__init__.py
+++ b/src/imitation/scripts/__init__.py
@@ -2,7 +2,7 @@
 
 try:
     # pytype: disable=import-error
-    import benchmark_environments.classic_control  # noqa: F401
+    import seals  # noqa: F401
 
     # pytype: enable=import-error
 except ImportError:

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -2,7 +2,7 @@
 
 import gym
 import pytest
-from benchmark_environments.testing import envs as bench_test
+from seals.testing import envs as bench_test
 
 # Unused imports is for side-effect of registering environments
 from imitation.envs import examples  # noqa: F401


### PR DESCRIPTION
Now `seals` is released on `PyPi`, use latest release plus rename imports.