### PR TITLE
Upgrade Sacred to v0.8.1

### DIFF
--- a/experiments/imit_benchmark.sh
+++ b/experiments/imit_benchmark.sh
@@ -68,6 +68,7 @@ echo "Logging to: ${LOG_ROOT}"
 
 parallel -j 25% --header : --results ${LOG_ROOT}/parallel/ --colsep , --progress \
   python -m imitation.scripts.train_adversarial \
+  --capture=sys \
   ${extra_options} \
   with \
   ${ALGORITHM} \

--- a/experiments/rollouts_from_policies.sh
+++ b/experiments/rollouts_from_policies.sh
@@ -34,6 +34,7 @@ echo "Writing logs in ${OUTPUT_DIR}"
 
 parallel -j 25% --header : --results ${OUTPUT_DIR}/parallel/ --colsep , \
   python -m imitation.scripts.expert_demos rollouts_from_policy \
+  --capture=sys \
   with \
   {env_config_name} \
   log_root="${OUTPUT_DIR}" \

--- a/experiments/train_experts.sh
+++ b/experiments/train_experts.sh
@@ -61,6 +61,7 @@ echo "Writing logs in ${OUTPUT_DIR}"
 # Train experts.
 parallel -j 25% --header : --progress --results ${OUTPUT_DIR}/parallel/ \
   python -m imitation.scripts.expert_demos \
+  --capture=sys \
   with \
   {env} ${extra_configs} \
   seed={seed} \

--- a/experiments/transfer_learn_benchmark.sh
+++ b/experiments/transfer_learn_benchmark.sh
@@ -77,6 +77,7 @@ fi
 echo "Writing logs in ${LOG_ROOT}"
 parallel -j 25% --header : --results ${LOG_ROOT}/parallel/ --colsep , --progress \
   python -m imitation.scripts.expert_demos \
+  --capture=sys \
   ${extra_options} \
   with \
   {env_config_name} ${extra_configs} \

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
         "jax~=0.1.66",
         "jaxlib~=0.1.47",
         # Install from IDSIA/sacred@master once
-        # https://github.com/IDSIA/sacred/pull/737 is merged.
+        # https://github.com/IDSIA/sacred/pull/737 and
+        # https://github.com/IDSIA/sacred/pull/740 are merged.
         "sacred @ git+https://github.com/HumanCompatibleAI/sacred@0.8.1-with-imit-compat",  # noqa: E501
     ],
     tests_require=TESTS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "stable-baselines~=2.10.0",
         "jax~=0.1.66",
         "jaxlib~=0.1.47",
-        "sacred",
+        "sacred~=0.8.1",
     ],
     tests_require=TESTS_REQUIRE,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,9 @@ setup(
         "stable-baselines~=2.10.0",
         "jax~=0.1.66",
         "jaxlib~=0.1.47",
-        # sacred==0.7.5 build is broken without pymongo
-        # sacred>0.7.4 have non-picklable config objects (see GH #109)
-        "sacred==0.7.4",
+        # Install from IDSIA/sacred@master once
+        # https://github.com/IDSIA/sacred/pull/737 is merged.
+        "sacred @ git+https://github.com/HumanCompatibleAI/sacred@0.8.1-with-imit-compat",  # noqa: E501
     ],
     tests_require=TESTS_REQUIRE,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,7 @@ setup(
         "stable-baselines~=2.10.0",
         "jax~=0.1.66",
         "jaxlib~=0.1.47",
-        # TODO(shwang): Install from IDSIA/sacred@master once
-        # https://github.com/IDSIA/sacred/pull/737 and
-        # https://github.com/IDSIA/sacred/pull/740 are merged.
-        "sacred @ git+https://github.com/HumanCompatibleAI/sacred@0.8.1-with-imit-compat",  # noqa: E501
+        "sacred",
     ],
     tests_require=TESTS_REQUIRE,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "stable-baselines~=2.10.0",
         "jax~=0.1.66",
         "jaxlib~=0.1.47",
-        # Install from IDSIA/sacred@master once
+        # TODO(shwang): Install from IDSIA/sacred@master once
         # https://github.com/IDSIA/sacred/pull/737 and
         # https://github.com/IDSIA/sacred/pull/740 are merged.
         "sacred @ git+https://github.com/HumanCompatibleAI/sacred@0.8.1-with-imit-compat",  # noqa: E501

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -348,6 +348,8 @@ def rollout_stats(trajectories: Sequence[types.TrajectoryWithRew]) -> Dict[str, 
             stat_value: np.generic = getattr(np, stat_name)(desc_vals)
             out_stats[f"{desc_name}_{stat_name}"] = stat_value.item()
 
+    for v in out_stats.values():
+        assert isinstance(v, (int, float))
     return out_stats
 
 

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -346,6 +346,9 @@ def rollout_stats(trajectories: Sequence[types.TrajectoryWithRew]) -> Dict[str, 
     for desc_name, desc_vals in traj_descriptors.items():
         for stat_name in stat_names:
             stat_value: np.generic = getattr(np, stat_name)(desc_vals)
+            # Convert numpy type to float or int. The numpy operators always return
+            # a numpy type, but we want to return type float. (int satisfies
+            # float type for the purposes of static-typing).
             out_stats[f"{desc_name}_{stat_name}"] = stat_value.item()
 
     for v in out_stats.values():

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -314,7 +314,7 @@ def generate_trajectories(
     return trajectories
 
 
-def rollout_stats(trajectories: Sequence[types.TrajectoryWithRew]) -> dict:
+def rollout_stats(trajectories: Sequence[types.TrajectoryWithRew]) -> Dict[str, float]:
     """Calculates various stats for a sequence of trajectories.
 
     Args:
@@ -331,7 +331,7 @@ def rollout_stats(trajectories: Sequence[types.TrajectoryWithRew]) -> dict:
         are only included if the `trajectories` contain Monitor infos.
     """
     assert len(trajectories) > 0
-    out_stats = {"n_traj": len(trajectories)}
+    out_stats: Dict[str, float] = {"n_traj": len(trajectories)}
     traj_descriptors = {
         "return": np.asarray([sum(t.rews) for t in trajectories]),
         "len": np.asarray([len(t.rews) for t in trajectories]),
@@ -345,8 +345,9 @@ def rollout_stats(trajectories: Sequence[types.TrajectoryWithRew]) -> dict:
     stat_names = ["min", "mean", "std", "max"]
     for desc_name, desc_vals in traj_descriptors.items():
         for stat_name in stat_names:
-            stat_value = getattr(np, stat_name)(desc_vals)
-            out_stats[f"{desc_name}_{stat_name}"] = stat_value
+            stat_value: np.generic = getattr(np, stat_name)(desc_vals)
+            out_stats[f"{desc_name}_{stat_name}"] = stat_value.item()
+
     return out_stats
 
 

--- a/src/imitation/envs/examples/airl_envs/__init__.py
+++ b/src/imitation/envs/examples/airl_envs/__init__.py
@@ -22,7 +22,7 @@ def _point_maze_register():
 
 _register(
     "imitation/ObjPusher-v0",
-    entry_point=f"pusher_env:PusherEnv",
+    entry_point="pusher_env:PusherEnv",
     kwargs={"sparse_reward": False},
 )
 _register("imitation/TwoDMaze-v0", entry_point="twod_maze:TwoDMaze")

--- a/src/imitation/scripts/analyze.py
+++ b/src/imitation/scripts/analyze.py
@@ -171,5 +171,5 @@ def main_console():
     analysis_ex.run_commandline()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main_console()

--- a/src/imitation/scripts/analyze.py
+++ b/src/imitation/scripts/analyze.py
@@ -166,7 +166,7 @@ def _get_sacred_dicts(
 
 
 def main_console():
-    observer = FileStorageObserver.create(osp.join("output", "sacred", "analyze"))
+    observer = FileStorageObserver(osp.join("output", "sacred", "analyze"))
     analysis_ex.observers.append(observer)
     analysis_ex.run_commandline()
 

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -100,8 +100,6 @@ def paths(env_name, log_root, rollout_hint, data_dir):
         data_dir, "expert_models", f"{rollout_hint}_0", "rollouts", "final.pkl"
     )
 
-    assert os.path.exists(rollout_path), rollout_path
-
 
 # Training algorithm named configs
 

--- a/src/imitation/scripts/eval_policy.py
+++ b/src/imitation/scripts/eval_policy.py
@@ -112,7 +112,11 @@ def eval_policy(
     return rollout.rollout_stats(trajs)
 
 
-if __name__ == "__main__":
+def main_console():
     observer = FileStorageObserver(osp.join("output", "sacred", "eval_policy"))
     eval_policy_ex.observers.append(observer)
     eval_policy_ex.run_commandline()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main_console()

--- a/src/imitation/scripts/eval_policy.py
+++ b/src/imitation/scripts/eval_policy.py
@@ -113,6 +113,6 @@ def eval_policy(
 
 
 if __name__ == "__main__":
-    observer = FileStorageObserver.create(osp.join("output", "sacred", "eval_policy"))
+    observer = FileStorageObserver(osp.join("output", "sacred", "eval_policy"))
     eval_policy_ex.observers.append(observer)
     eval_policy_ex.run_commandline()

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -121,6 +121,7 @@ def rollouts_and_policy(
 
         if init_tensorboard:
             sb_tensorboard_dir = osp.join(log_dir, "sb_tb")
+            init_rl_kwargs = dict(init_rl_kwargs)  # Cast sacred's ReadOnlyDict to dict.
             init_rl_kwargs["tensorboard_log"] = sb_tensorboard_dir
 
         venv = util.make_vec_env(

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -238,5 +238,5 @@ def main_console():
     expert_demos_ex.run_commandline()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main_console()

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -121,7 +121,8 @@ def rollouts_and_policy(
 
         if init_tensorboard:
             sb_tensorboard_dir = osp.join(log_dir, "sb_tb")
-            init_rl_kwargs = dict(init_rl_kwargs)  # Cast sacred's ReadOnlyDict to dict.
+            # Convert sacred's ReadOnlyDict to dict so we can modify on next line.
+            init_rl_kwargs = dict(init_rl_kwargs)
             init_rl_kwargs["tensorboard_log"] = sb_tensorboard_dir
 
         venv = util.make_vec_env(

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -232,7 +232,7 @@ def rollouts_from_policy(
 
 
 def main_console():
-    observer = FileStorageObserver.create(osp.join("output", "sacred", "expert_demos"))
+    observer = FileStorageObserver(osp.join("output", "sacred", "expert_demos"))
     expert_demos_ex.observers.append(observer)
     expert_demos_ex.run_commandline()
 

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -52,7 +52,9 @@ def parallel(
     # change the working directory for each Raylet.
     if sacred_ex_name == "train_adversarial":
         if "data_dir" not in base_config_updates:
-            base_config_updates["data_dir"] = os.path.join(os.getcwd(), "data/")
+            data_dir = os.path.join(os.getcwd(), "data/")
+            base_config_update = dict(base_config_updates)
+            base_config_update["data_dir"] = data_dir
 
     trainable = _ray_tune_sacred_wrapper(
         sacred_ex_name, run_name, base_named_configs, base_config_updates
@@ -119,10 +121,13 @@ def _ray_tune_sacred_wrapper(
         ex.observers.append(observer)
 
         # Apply base configs
-        base_named_configs.extend(config.get("named_configs", []))
-        base_config_updates.update(config.get("config_updates", {}))
-        config["named_configs"] = base_named_configs
-        config["config_updates"] = base_config_updates
+        config["named_configs"] = []
+        config["named_configs"].extend(base_named_configs)
+        config["named_configs"].extend(config.get("named_config", []))
+
+        config["config_updates"] = {}
+        config["config_updates"].update(base_config_updates)
+        config["config_updates"].update(config.get("config_updates", {}))
 
         run = ex.run(**config, options={"--run": run_name})
 

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -38,11 +38,17 @@ def parallel(
             under the 'experiment.name' key. This is equivalent to using the Sacred
             CLI '--name' option on the inner experiment. Offline analysis jobs can use
             this argument to group similar data.
-        search_space: `config` argument to `ray.tune.run()`.
+        search_space: A dictionary which can contain `ray.tune.grid_search` and is
+            passed as the `config` argument to `ray.tune.run()`. After the
+            `search_space` is transformed by Ray, it passed into
+            `sacred_ex.run(**run_kwargs)` as `run_kwargs` (`sacred_ex` is the Sacred
+            Experiment selected via `sacred_ex_name`). Usually `search_space` only has
+            the keys "named_configs" and "config_updates", but any parameter names
+            to `sacred.Experiment.run()` are okay.
         base_named_configs: Default Sacred Run named configs. Any named configs
             taken from `search_space` are higher priority than the base_named_configs.
-            This is done by appending named configs taken from search space to the run's
-            named configs after `base_named_configs` are added.
+            This is done by appending named configs taken from `search_space` to the
+            run's named configs after `base_named_configs` are added.
 
             Named configs in `base_named_configs` doesn't appear in the automatically
             generated Ray directory name, unlike named configs from `search_space`.

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -28,6 +28,10 @@ def parallel(
     logs to "{RAY_LOCAL_DIR}/sacred/". These files are automatically copied over
     to `upload_dir` if that argument is provided.
 
+    WARNING: Sometimes this method will fail upon Sacred cleanup due to
+    https://github.com/IDSIA/sacred/issues/289. Seems to be OS- and
+    Sacred-version-dependent.
+
     Args:
       sacred_ex_name: The Sacred experiment to tune. Either "expert_demos" or
         "train_adversarial".

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -162,7 +162,11 @@ def _ray_tune_sacred_wrapper(
     return inner
 
 
-if __name__ == "__main__":
+def main_console():
     observer = FileStorageObserver(os.path.join("output", "sacred", "parallel"))
     parallel_ex.observers.append(observer)
     parallel_ex.run_commandline()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main_console()

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -152,7 +152,7 @@ def _ray_tune_sacred_wrapper(
         config_updates.update(run_kwargs["config_updates"])
         updated_run_kwargs["config_updates"] = config_updates
 
-        # Apply
+        # Add other run_kwargs items to updated_run_kwargs.
         for k, v in run_kwargs.items():
             if k not in updated_run_kwargs:
                 updated_run_kwargs[k] = v

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -38,14 +38,15 @@ def parallel(
             under the 'experiment.name' key. This is equivalent to using the Sacred
             CLI '--name' option on the inner experiment. Offline analysis jobs can use
             this argument to group similar data.
-        search_space: A dictionary which can contain `ray.tune.grid_search` and is
+        search_space: A dictionary which can contain Ray Tune search objects like
+            `ray.tune.grid_search` and `ray.tune.sample_from`, and is
             passed as the `config` argument to `ray.tune.run()`. After the
             `search_space` is transformed by Ray, it passed into
             `sacred_ex.run(**run_kwargs)` as `run_kwargs` (`sacred_ex` is the Sacred
             Experiment selected via `sacred_ex_name`). Usually `search_space` only has
             the keys "named_configs" and "config_updates", but any parameter names
             to `sacred.Experiment.run()` are okay.
-        base_named_configs: Default Sacred Run named configs. Any named configs
+        base_named_configs: Default Sacred named configs. Any named configs
             taken from `search_space` are higher priority than the base_named_configs.
             Concretely, this priority is implemented by appending named configs taken
             from `search_space` to the run's named configs after `base_named_configs`.
@@ -53,7 +54,7 @@ def parallel(
             Named configs in `base_named_configs` don't appear in the automatically
             generated Ray directory name, unlike named configs from `search_space`.
 
-        base_config_updates: Default Sacred Run config updates. Any config updates taken
+        base_config_updates: Default Sacred config updates. Any config updates taken
             from `search_space` are higher priority than `base_config_updates`.
 
             Config updates in `base_config_updates` don't appear in the automatically
@@ -145,6 +146,7 @@ def _ray_tune_sacred_wrapper(
         """
         # Set Sacred capture mode to "sys" because default "fd" option leads to error.
         # See https://github.com/IDSIA/sacred/issues/289.
+        # TODO(shwang): Stop modifying CAPTURE_MODE once the issue is fixed.
         sacred.SETTINGS.CAPTURE_MODE = "sys"
 
         run_kwargs = config

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -47,10 +47,10 @@ def parallel(
             to `sacred.Experiment.run()` are okay.
         base_named_configs: Default Sacred Run named configs. Any named configs
             taken from `search_space` are higher priority than the base_named_configs.
-            This is done by appending named configs taken from `search_space` to the
-            run's named configs after `base_named_configs` are added.
+            Concretely, this priority is implemented by appending named configs taken
+            from `search_space` to the run's named configs after `base_named_configs`.
 
-            Named configs in `base_named_configs` doesn't appear in the automatically
+            Named configs in `base_named_configs` don't appear in the automatically
             generated Ray directory name, unlike named configs from `search_space`.
 
         base_config_updates: Default Sacred Run config updates. Any config updates taken

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -66,7 +66,8 @@ def parallel(
             base_config_update["data_dir"] = data_dir
 
     trainable = _ray_tune_sacred_wrapper(
-        sacred_ex_name, run_name,
+        sacred_ex_name,
+        run_name,
         copy.deepcopy(base_named_configs),
         copy.deepcopy(base_config_updates),
     )

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, Optional
 
 import ray
 import ray.tune
+import sacred
 from sacred.observers import FileStorageObserver
 
 from imitation.scripts.config.parallel import parallel_ex
@@ -27,6 +28,7 @@ def parallel(
     A Sacred FileObserver is attached to the inner experiment and writes Sacred
     logs to "{RAY_LOCAL_DIR}/sacred/". These files are automatically copied over
     to `upload_dir` if that argument is provided.
+    sacred.SETTINGS.CAPTURE_MODE = "sys"
 
     WARNING: Sometimes this method will fail upon Sacred cleanup due to
     https://github.com/IDSIA/sacred/issues/289. Seems to be OS- and
@@ -129,6 +131,8 @@ def _ray_tune_sacred_wrapper(
             config: Keyword arguments for `ex.run()`, where `ex` is the
                 `sacred.Experiment` instance associated with `sacred_ex_name`.
         """
+        sacred.SETTINGS.CAPTURE_MODE = "sys"
+
         run_kwargs = config
         updated_run_kwargs = {}
         # Import inside function rather than in module because Sacred experiments

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -117,7 +117,7 @@ def _ray_tune_sacred_wrapper(
         }
         ex = experiments[sacred_ex_name]
 
-        observer = FileStorageObserver.create("sacred")
+        observer = FileStorageObserver("sacred")
         ex.observers.append(observer)
 
         # Apply base configs
@@ -142,6 +142,6 @@ def _ray_tune_sacred_wrapper(
 
 
 if __name__ == "__main__":
-    observer = FileStorageObserver.create(os.path.join("output", "sacred", "parallel"))
+    observer = FileStorageObserver(os.path.join("output", "sacred", "parallel"))
     parallel_ex.observers.append(observer)
     parallel_ex.run_commandline()

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -109,6 +109,7 @@ def train(
         return value of `rollout_stats()` on the expert demonstrations loaded from
         `rollout_path`.
     """
+    assert os.path.exists(rollout_path)
     total_timesteps = int(total_timesteps)
 
     tf.logging.info("Logging to %s", log_dir)

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -115,14 +115,12 @@ def train(
     os.makedirs(log_dir, exist_ok=True)
     sacred_util.build_sacred_symlink(log_dir, _run)
 
-    # Calculate stats for expert rollouts. Used for plot and return value.
+    # Calculate stats for expert rollouts. Used for return value.
     expert_trajs = types.load(rollout_path)
 
     if n_expert_demos is not None:
         assert len(expert_trajs) >= n_expert_demos
         expert_trajs = expert_trajs[:n_expert_demos]
-
-    expert_stats = rollout.rollout_stats(expert_trajs)
 
     with networks.make_session():
         if init_tensorboard:
@@ -151,8 +149,8 @@ def train(
         trajs = rollout.generate_trajectories(
             trainer.gen_policy, trainer.venv_test, sample_until=sample_until_eval
         )
+        results["expert_stats"] = rollout.rollout_stats(expert_trajs)
         results["imit_stats"] = rollout.rollout_stats(trajs)
-        results["expert_stats"] = expert_stats
         return results
 
 

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -116,9 +116,7 @@ def train(
     os.makedirs(log_dir, exist_ok=True)
     sacred_util.build_sacred_symlink(log_dir, _run)
 
-    # Calculate stats for expert rollouts. Used for return value.
     expert_trajs = types.load(rollout_path)
-
     if n_expert_demos is not None:
         assert len(expert_trajs) >= n_expert_demos
         expert_trajs = expert_trajs[:n_expert_demos]

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -122,11 +122,16 @@ def train(
         expert_trajs = expert_trajs[:n_expert_demos]
 
     with networks.make_session():
+        # This deep copy converts unpicklable, unmodifiable Sacred ReadOnlyContainers
+        # into regular dicts and lists. This is necessary to modify
+        # `init_trainer_kwargs` in the `if init_tensorboard` block and to
+        # properly serialize RewardNet parameters.
+        init_trainer_kwargs = copy.deepcopy(init_trainer_kwargs)
+
         if init_tensorboard:
             sb_tensorboard_dir = osp.join(log_dir, "sb_tb")
-            kwargs = copy.deepcopy(init_trainer_kwargs)
-            kwargs["init_rl_kwargs"] = kwargs.get("init_rl_kwargs", {})
-            kwargs["init_rl_kwargs"]["tensorboard_log"] = sb_tensorboard_dir
+            init_rl_kwargs = init_trainer_kwargs["init_rl_kwargs"]
+            init_rl_kwargs["tensorboard_log"] = sb_tensorboard_dir
 
         trainer = init_trainer(
             env_name, expert_trajs, seed=_seed, log_dir=log_dir, **init_trainer_kwargs

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -160,5 +160,5 @@ def main_console():
     train_ex.run_commandline()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main_console()

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -3,6 +3,7 @@
 Can be used as a CLI script, or the `train_and_plot` function can be called directly.
 """
 
+import copy
 import os
 import os.path as osp
 from typing import Optional
@@ -126,7 +127,7 @@ def train(
     with networks.make_session():
         if init_tensorboard:
             sb_tensorboard_dir = osp.join(log_dir, "sb_tb")
-            kwargs = init_trainer_kwargs
+            kwargs = copy.deepcopy(init_trainer_kwargs)
             kwargs["init_rl_kwargs"] = kwargs.get("init_rl_kwargs", {})
             kwargs["init_rl_kwargs"]["tensorboard_log"] = sb_tensorboard_dir
 

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -156,7 +156,7 @@ def train(
 
 
 def main_console():
-    observer = FileStorageObserver.create(osp.join("output", "sacred", "train"))
+    observer = FileStorageObserver(osp.join("output", "sacred", "train"))
     train_ex.observers.append(observer)
     train_ex.run_commandline()
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -30,15 +30,16 @@ ALL_SCRIPTS_MODS = [analyze, eval_policy, expert_demos, parallel, train_adversar
 @pytest.fixture(autouse=True)
 def sacred_capture_use_sys():
     temp = sacred.SETTINGS["CAPTURE_MODE"]
-    sacred.SETTINGS["CAPTURE_MODE"] = "sys"
+    sacred.SETTINGS.CAPTURE_MODE = "sys"
     yield
-    sacred.SETTINGS["CAPTURE_MODE"] = temp
+    sacred.SETTINGS.CAPTURE_MODE = temp
 
 
 @pytest.mark.parametrize("script_mod", ALL_SCRIPTS_MODS)
 def test_main_console(script_mod):
     """Smoke tests of main entry point for some cheap coverage."""
-    with mock.patch.object(sys, "argv", ["sacred-pytest-stub", "print_config"]):
+    argv = ["sacred-pytest-stub", "print_config"]
+    with mock.patch.object(sys, "argv", argv):
         script_mod.main_console()
 
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -171,7 +171,8 @@ PARALLEL_CONFIG_UPDATES = [
         search_space={
             "config_updates": {
                 "init_rl_kwargs": {"learning_rate": tune.grid_search([3e-4, 1e-4])},
-            }
+            },
+            "meta_info": {"asdf": "I exist for coverage purposes"},
         },
     ),
     dict(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -256,7 +256,7 @@ def test_analyze_imitation(tmpdir: str, run_names: List[str]):
             command_name="analyze_imitation",
             config_updates=dict(
                 source_dir=sacred_logs_dir,
-                env_name="CartPole-v0",
+                env_name="CartPole-v1",
                 run_name=run_name,
                 csv_output_path=osp.join(tmpdir, "analysis.csv"),
                 verbose=True,

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -49,7 +49,6 @@ def test_main_console(script_mod):
 
 def test_expert_demos_main(tmpdir):
     """Smoke test for imitation.scripts.expert_demos.rollouts_and_policy."""
-    # sacred.SETTINGS["CAPTURE_MODE"] = "no"
     run = expert_demos.expert_demos_ex.run(
         named_configs=["cartpole", "fast"], config_updates=dict(log_root=tmpdir,),
     )

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -191,7 +191,10 @@ PARALLEL_CONFIG_LOW_RESOURCE = {
 
 @pytest.mark.parametrize("config_updates", PARALLEL_CONFIG_UPDATES)
 def test_parallel(config_updates):
-    """Hyperparam tuning smoke test."""
+    """Hyperparam tuning smoke test.
+
+    Sometimes this will fail due to https://github.com/IDSIA/sacred/issues/289.
+    Seems to be OS- and Sacred-version-dependent."""
     # CI server only has 2 cores
     config_updates = dict(config_updates)
     config_updates.update(PARALLEL_CONFIG_LOW_RESOURCE)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -12,6 +12,7 @@ from collections import Counter
 from typing import List, Optional
 from unittest import mock
 
+import sacred
 import pandas as pd
 import pytest
 import ray.tune as tune
@@ -25,6 +26,13 @@ from imitation.scripts import (
 )
 
 ALL_SCRIPTS_MODS = [analyze, eval_policy, expert_demos, parallel, train_adversarial]
+
+@pytest.fixture(autouse=True)
+def sacred_capture_use_sys():
+    temp = sacred.SETTINGS["CAPTURE_MODE"]
+    sacred.SETTINGS["CAPTURE_MODE"] = "sys"
+    yield
+    sacred.SETTINGS["CAPTURE_MODE"] = temp
 
 
 @pytest.mark.parametrize("script_mod", ALL_SCRIPTS_MODS)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -30,6 +30,9 @@ ALL_SCRIPTS_MODS = [analyze, eval_policy, expert_demos, parallel, train_adversar
 
 @pytest.fixture(autouse=True)
 def sacred_capture_use_sys():
+    """Set Sacred capture mode to "sys" because default "fd" option leads to error.
+
+    See https://github.com/IDSIA/sacred/issues/289."""
     temp = sacred.SETTINGS["CAPTURE_MODE"]
     sacred.SETTINGS.CAPTURE_MODE = "sys"
     yield
@@ -46,6 +49,7 @@ def test_main_console(script_mod):
 
 def test_expert_demos_main(tmpdir):
     """Smoke test for imitation.scripts.expert_demos.rollouts_and_policy."""
+    # sacred.SETTINGS["CAPTURE_MODE"] = "no"
     run = expert_demos.expert_demos_ex.run(
         named_configs=["cartpole", "fast"], config_updates=dict(log_root=tmpdir,),
     )
@@ -201,10 +205,7 @@ PARALLEL_CONFIG_LOW_RESOURCE = {
 
 @pytest.mark.parametrize("config_updates", PARALLEL_CONFIG_UPDATES)
 def test_parallel(config_updates):
-    """Hyperparam tuning smoke test.
-
-    Sometimes this will fail due to https://github.com/IDSIA/sacred/issues/289.
-    Seems to be OS- and Sacred-version-dependent."""
+    """Hyperparam tuning smoke test."""
     # CI server only has 2 cores
     config_updates = dict(config_updates)
     config_updates.update(PARALLEL_CONFIG_LOW_RESOURCE)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -33,6 +33,7 @@ def sacred_capture_use_sys():
     """Set Sacred capture mode to "sys" because default "fd" option leads to error.
 
     See https://github.com/IDSIA/sacred/issues/289."""
+    # TODO(shwang): Stop using non-default "sys" mode once the issue is fixed.
     temp = sacred.SETTINGS["CAPTURE_MODE"]
     sacred.SETTINGS.CAPTURE_MODE = "sys"
     yield

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -12,10 +12,10 @@ from collections import Counter
 from typing import List, Optional
 from unittest import mock
 
-import sacred
 import pandas as pd
 import pytest
 import ray.tune as tune
+import sacred
 
 from imitation.scripts import (
     analyze,
@@ -26,6 +26,7 @@ from imitation.scripts import (
 )
 
 ALL_SCRIPTS_MODS = [analyze, eval_policy, expert_demos, parallel, train_adversarial]
+
 
 @pytest.fixture(autouse=True)
 def sacred_capture_use_sys():

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -6,24 +6,37 @@ experiment implicitly sets parallel=False.
 """
 
 import os.path as osp
+import sys
 import tempfile
 from collections import Counter
 from typing import List, Optional
+from unittest import mock
 
 import pandas as pd
 import pytest
 import ray.tune as tune
 
-from imitation.scripts.analyze import analysis_ex
-from imitation.scripts.eval_policy import eval_policy_ex
-from imitation.scripts.expert_demos import expert_demos_ex
-from imitation.scripts.parallel import parallel_ex
-from imitation.scripts.train_adversarial import train_ex
+from imitation.scripts import (
+    analyze,
+    eval_policy,
+    expert_demos,
+    parallel,
+    train_adversarial,
+)
+
+ALL_SCRIPTS_MODS = [analyze, eval_policy, expert_demos, parallel, train_adversarial]
+
+
+@pytest.mark.parametrize("script_mod", ALL_SCRIPTS_MODS)
+def test_main_console(script_mod):
+    """Smoke tests of main entry point for some cheap coverage."""
+    with mock.patch.object(sys, "argv", ["sacred-pytest-stub", "print_config"]):
+        script_mod.main_console()
 
 
 def test_expert_demos_main(tmpdir):
     """Smoke test for imitation.scripts.expert_demos.rollouts_and_policy."""
-    run = expert_demos_ex.run(
+    run = expert_demos.expert_demos_ex.run(
         named_configs=["cartpole", "fast"], config_updates=dict(log_root=tmpdir,),
     )
     assert run.status == "COMPLETED"
@@ -32,7 +45,7 @@ def test_expert_demos_main(tmpdir):
 
 def test_expert_demos_rollouts_from_policy(tmpdir):
     """Smoke test for imitation.scripts.expert_demos.rollouts_from_policy."""
-    run = expert_demos_ex.run(
+    run = expert_demos.expert_demos_ex.run(
         command_name="rollouts_from_policy",
         named_configs=["cartpole", "fast"],
         config_updates=dict(
@@ -58,7 +71,9 @@ def test_eval_policy(config, tmpdir):
         "log_root": tmpdir,
     }
     config_updates.update(config)
-    run = eval_policy_ex.run(config_updates=config_updates, named_configs=["fast"])
+    run = eval_policy.eval_policy_ex.run(
+        config_updates=config_updates, named_configs=["fast"]
+    )
     assert run.status == "COMPLETED"
     wrapped_reward = "reward_type" in config
     _check_rollout_stats(run.result, wrapped_reward)
@@ -97,7 +112,9 @@ def test_train_adversarial(tmpdir):
         "plot_interval": 1,
         "extra_episode_data_interval": 1,
     }
-    run = train_ex.run(named_configs=named_configs, config_updates=config_updates,)
+    run = train_adversarial.train_ex.run(
+        named_configs=named_configs, config_updates=config_updates,
+    )
     assert run.status == "COMPLETED"
     _check_train_ex_result(run.result)
 
@@ -108,7 +125,7 @@ def test_transfer_learning(tmpdir):
     Saves a dummy AIRL test reward, then loads it for transfer learning.
     """
     log_dir_train = osp.join(tmpdir, "train")
-    run = train_ex.run(
+    run = train_adversarial.train_ex.run(
         named_configs=["cartpole", "airl", "fast"],
         config_updates=dict(
             rollout_path="tests/data/expert_models/cartpole_0/rollouts/final.pkl",
@@ -122,7 +139,7 @@ def test_transfer_learning(tmpdir):
 
     log_dir_data = osp.join(tmpdir, "expert_demos")
     discrim_path = osp.join(log_dir_train, "checkpoints", "final", "discrim")
-    run = expert_demos_ex.run(
+    run = expert_demos.expert_demos_ex.run(
         named_configs=["cartpole", "fast"],
         config_updates=dict(
             log_dir=log_dir_data, reward_type="DiscrimNet", reward_path=discrim_path,
@@ -181,14 +198,14 @@ def test_parallel(config_updates):
     # No need for TemporaryDirectory because the hyperparameter tuning script
     # itself generates no artifacts, and "debug_log_root" sets inner experiment's
     # log_root="/tmp/parallel_debug/".
-    run = parallel_ex.run(
+    run = parallel.parallel_ex.run(
         named_configs=["debug_log_root"], config_updates=config_updates
     )
     assert run.status == "COMPLETED"
 
 
 def _generate_test_rollouts(tmpdir: str, env_named_config: str) -> str:
-    expert_demos_ex.run(
+    expert_demos.expert_demos_ex.run(
         named_configs=[env_named_config, "fast"],
         config_updates=dict(rollout_save_interval=0, log_dir=tmpdir,),
     )
@@ -210,7 +227,7 @@ def test_parallel_train_adversarial_custom_env(tmpdir):
         ),
     )
     config_updates.update(PARALLEL_CONFIG_LOW_RESOURCE)
-    run = parallel_ex.run(
+    run = parallel.parallel_ex.run(
         named_configs=["debug_log_root"], config_updates=config_updates
     )
     assert run.status == "COMPLETED"
@@ -224,7 +241,7 @@ def test_analyze_imitation(tmpdir: str, run_names: List[str]):
     for i, run_name in enumerate(run_names):
         with tempfile.TemporaryDirectory(prefix="junk") as junkdir:
             rollout_path = "tests/data/expert_models/cartpole_0/rollouts/final.pkl"
-            run = train_ex.run(
+            run = train_adversarial.train_ex.run(
                 named_configs=["fast", "cartpole"],
                 config_updates=dict(
                     rollout_path=rollout_path, log_dir=junkdir, checkpoint_interval=-1,
@@ -235,10 +252,11 @@ def test_analyze_imitation(tmpdir: str, run_names: List[str]):
 
     # Check that analyze script finds the correct number of logs.
     def check(run_name: Optional[str], count: int) -> None:
-        run = analysis_ex.run(
+        run = analyze.analysis_ex.run(
             command_name="analyze_imitation",
             config_updates=dict(
                 source_dir=sacred_logs_dir,
+                env_name="CartPole-v0",
                 run_name=run_name,
                 csv_output_path=osp.join(tmpdir, "analysis.csv"),
                 verbose=True,
@@ -257,12 +275,12 @@ def test_analyze_imitation(tmpdir: str, run_names: List[str]):
 def test_analyze_gather_tb(tmpdir: str):
     config_updates = dict(local_dir=tmpdir, run_name="test")
     config_updates.update(PARALLEL_CONFIG_LOW_RESOURCE)
-    parallel_run = parallel_ex.run(
+    parallel_run = parallel.parallel_ex.run(
         named_configs=["generate_test_data"], config_updates=config_updates
     )
     assert parallel_run.status == "COMPLETED"
 
-    run = analysis_ex.run(
+    run = analyze.analysis_ex.run(
         command_name="gather_tb_directories", config_updates=dict(source_dir=tmpdir,)
     )
     assert run.status == "COMPLETED"


### PR DESCRIPTION
This PR updates our setup script to install ~~a patched version of Sacred v0.8.1 with two merged PRs.~~ Sacred v0.8.1.

We were unable to upgrade Sacred to the latest version because of issued noted in #109.  I recently submitted a patch to Sacred that makes ReadOnly{Dict,List} picklable, https://github.com/IDSIA/sacred/pull/737.

While running our Ray jobs with this patched version of Sacred, I also found that Sacred experiments run on Raylets fail to close their stdout-capturing `tee`s for some reason, which lead to an unhandled TimeoutError. This issue is fixed by https://github.com/IDSIA/sacred/pull/740, which warns that the tees failed to close instead of crashing.

~~I'm choosing to use our own version instead of IDSIA/sacred for now because the maintainers have not been responsive on issues and PRs for a while now, and I'd like to use `imitation` along with `realistic_benchmarks`, which requires a more recent version of `sacred`.~~

To avoid messing up PyPI and until the PRs are merged by IDSIA to the main repo we've decided to just address the two issues above by converting ReadOnlyContainer to regular python types when necessary, and by using `--capture=sys` to avoid the Tee TimeoutError.