### PR TITLE
Refactor `init_trainer` into `GAIL` and `AIRL` subclasses

### DIFF
--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -145,7 +145,7 @@ class AdversarialTrainer:
         self._gen_replay_buffer = buffer.ReplayBuffer(
             gen_replay_buffer_capacity, self.venv
         )
-        self._exp_replay_buffer = buffer.ReplayBuffer.from_data(expert_demos)
+        self._exp_replay_buffer = buffer.ReplayBuffer.from_data(self.expert_demos)
         if self.disc_batch_size // 2 > len(self._exp_replay_buffer):
             warn(
                 "The discriminator batch size is more than twice the number of "

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -1,6 +1,6 @@
 import os
 from functools import partial
-from typing import Callable, Optional, Type
+from typing import Callable, Mapping, Optional, Type
 from warnings import warn
 
 import numpy as np
@@ -43,7 +43,7 @@ class AdversarialTrainer:
         disc_batch_size: int = 2048,
         disc_minibatch_size: int = 256,
         disc_opt_cls: tf.train.Optimizer = tf.train.AdamOptimizer,
-        disc_opt_kwargs: dict = {},
+        disc_opt_kwargs: Optional[Mapping] = None,
         gen_replay_buffer_capacity: Optional[int] = None,
         init_tensorboard: bool = False,
         init_tensorboard_graph: bool = False,
@@ -110,7 +110,7 @@ class AdversarialTrainer:
         # Create graph for optimising/recording stats on discriminator
         self._discrim = discrim
         self._disc_opt_cls = disc_opt_cls
-        self._disc_opt_kwargs = disc_opt_kwargs
+        self._disc_opt_kwargs = disc_opt_kwargs or {}
         self._init_tensorboard = init_tensorboard
         self._init_tensorboard_graph = init_tensorboard_graph
         self._build_graph()
@@ -268,7 +268,9 @@ class AdversarialTrainer:
         return np.mean(self._sess.run(self.discrim.disc_loss, feed_dict=fd))
 
     def train_gen(
-        self, total_timesteps: Optional[int] = None, learn_kwargs: Optional[dict] = None
+        self,
+        total_timesteps: Optional[int] = None,
+        learn_kwargs: Optional[Mapping] = None,
     ):
         """Trains the generator to maximize the discriminator loss.
 
@@ -416,7 +418,7 @@ class GAIL(AdversarialTrainer):
         expert_demos: types.Transitions,
         gen_policy: base_class.BaseRLModel,
         *,
-        discrim_kwargs: Optional[dict] = None,
+        discrim_kwargs: Optional[Mapping] = None,
         **kwargs,
     ):
         """Generative Adversarial Imitation Learning.
@@ -449,8 +451,8 @@ class AIRL(AdversarialTrainer):
         gen_policy: base_class.BaseRLModel,
         *,
         reward_net_cls: Type[reward_net.RewardNet] = reward_net.BasicShapedRewardNet,
-        reward_net_kwargs: Optional[dict] = None,
-        discrim_kwargs: Optional[dict] = None,
+        reward_net_kwargs: Optional[Mapping] = None,
+        discrim_kwargs: Optional[Mapping] = None,
         **kwargs,
     ):
         """Adversarial Inverse Reinforcement Learning.

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -14,7 +14,7 @@ from imitation.util import logger, reward_wrapper
 
 
 class AdversarialTrainer:
-    """Trainer for GAIL and AIRL."""
+    """Base class for adversarial imitation learning algorithms like GAIL and AIRL."""
 
     venv: vec_env.VecEnv
     """The original vectorized environment."""
@@ -48,7 +48,7 @@ class AdversarialTrainer:
         init_tensorboard_graph: bool = False,
         debug_use_ground_truth: bool = False,
     ):
-        """Builds Trainer.
+        """Builds AdversarialTrainer.
 
         Args:
             venv: The vectorized environment to train in.

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -428,10 +428,6 @@ class GAIL(AdversarialTrainer):
         as follows:
 
         Args:
-            reward_net_cls: Reward network constructor. The reward network is part of
-                the AIRL discriminator.
-            reward_net_kwargs: Optional keyword arguments to use while constructing
-                the reward network.
             discrim_kwargs: Optional keyword arguments to use while constructing the
                 DiscrimNetGAIL.
 

--- a/src/imitation/envs/examples/airl_envs/__init__.py
+++ b/src/imitation/envs/examples/airl_envs/__init__.py
@@ -22,7 +22,7 @@ def _point_maze_register():
 
 _register(
     "imitation/ObjPusher-v0",
-    entry_point=f"pusher_env:PusherEnv",
+    entry_point="pusher_env:PusherEnv",
     kwargs={"sparse_reward": False},
 )
 _register("imitation/TwoDMaze-v0", entry_point="twod_maze:TwoDMaze")

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -17,7 +17,7 @@ train_ex = sacred.Experiment("train_adversarial", interactive=True)
 def train_defaults():
     env_name = "CartPole-v1"  # environment to train on
     total_timesteps = 1e5  # Num of environment transitions to sample
-    algorithm = "gail"
+    algorithm = "gail"  # Either "airl" or "gail"
 
     n_expert_demos = None  # Num demos used. None uses every demo possible
     n_episodes_eval = 50  # Num of episodes for final mean ground truth return
@@ -42,15 +42,13 @@ def train_defaults():
     airl_entropy_weight = 1.0  # Entropy weight in AIRL training reward
 
     # GAIL-specific options
-    gail_discrim_net_scale = True
+    gail_discrim_net_scale = True  # Whether to scale observation inputs to discrim net
 
     # Shared kwargs between GAIL and AIRL
     algorithm_kwargs = dict()  # Other kwargs to GAIL/AIRL/Adversarial constructor
     discrim_kwargs = dict()  # Kwargs for initializing {GAIL,AIRL}DiscrimNet
 
-    # Modifies the __init__ arguments for GAIL and AIRL.
-    # Really, I should just make these into real arguments. Since init_rl_kwargs
-    # is just a stub.
+    # Modifies the __init__ arguments for the imitation policy.
     init_rl_kwargs = dict(
         policy_class=base.FeedForward32Policy, **DEFAULT_INIT_RL_KWARGS
     )

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -116,11 +116,13 @@ def paths(env_name, log_root, rollout_hint, data_dir):
 
 @train_ex.named_config
 def gail():
+    """Quick alias for algorithm=gail"""
     algorithm = "gail"
 
 
 @train_ex.named_config
 def airl():
+    """Quick alias for algorithm=airl"""
     algorithm = "airl"
 
 

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -46,7 +46,7 @@ def train_defaults():
     )
 
     # Kwargs for initializing {GAIL,AIRL}DiscrimNet
-    discrim_net_kwargs = dict(shared={}, airl={}, gail={},)
+    discrim_net_kwargs = dict(shared={}, airl={}, gail={})
 
     # Modifies the __init__ arguments for the imitation policy
     init_rl_kwargs = dict(
@@ -110,12 +110,12 @@ def airl():
 
 # Shared settings
 
-MUJOCO_SHARED_LOCALS = dict(discrim_net_kwargs=dict(airl=dict(entropy_weight=0.1),))
+MUJOCO_SHARED_LOCALS = dict(discrim_net_kwargs=dict(airl=dict(entropy_weight=0.1)))
 
 ANT_SHARED_LOCALS = dict(
     total_timesteps=3e7,
     max_episode_steps=500,  # To match `inverse_rl` settings.
-    algorithm_kwargs=dict(shared=dict(disc_batch_size=2048 * 8,),),
+    algorithm_kwargs=dict(shared=dict(disc_batch_size=2048 * 8)),
     gen_batch_size=2048 * 8,
 )
 
@@ -246,7 +246,7 @@ def fast():
     total_timesteps = 10
     n_expert_demos = 1
     n_episodes_eval = 1
-    algorithm_kwargs = dict(shared=dict(disc_batch_size=2, disc_minibatch_size=2,),)
+    algorithm_kwargs = dict(shared=dict(disc_batch_size=2, disc_minibatch_size=2))
     gen_batch_size = 2
     parallel = False  # easier to debug with everything in one process
     max_episode_steps = 100

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -6,7 +6,6 @@ import sacred
 from stable_baselines.common import policies
 
 from imitation.policies import base
-from imitation.rewards import reward_net
 from imitation.scripts.config.common import DEFAULT_INIT_RL_KWARGS
 from imitation.util import util
 
@@ -36,22 +35,24 @@ def train_defaults():
     parallel = True
     max_episode_steps = None  # Set to positive int to limit episode horizons
 
-    # AIRL-specific options
-    airl_reward_net_cls = reward_net.BasicShapedRewardNet  # AIRL reward net class
-    airl_reward_net_kwargs = dict()  # AIRL reward net class init kwargs
-    airl_entropy_weight = 1.0  # Entropy weight in AIRL training reward
-
-    # GAIL-specific options
-    gail_discrim_net_scale = True  # Whether to scale observation inputs to discrim net
-
-    # Shared kwargs between GAIL and AIRL
-    algorithm_kwargs = dict()  # Other kwargs to GAIL/AIRL/Adversarial constructor
-    discrim_kwargs = dict()  # Kwargs for initializing {GAIL,AIRL}DiscrimNet
-
-    # Modifies the __init__ arguments for the imitation policy.
-    init_rl_kwargs = dict(
-        policy_class=base.FeedForward32Policy, **DEFAULT_INIT_RL_KWARGS
+    # Kwargs for initializing GAIL and AIRL
+    algorithm_kwargs = dict(
+        shared=dict(
+            disc_batch_size=2048,  # Batch size for discriminator updates
+            disc_minibatch_size=512,  # Num discriminator updates per batch
+        ),
+        airl={},
+        gail={},
     )
+
+    # Kwargs for initializing {GAIL,AIRL}DiscrimNet
+    discrim_net_kwargs = dict(shared={}, airl={}, gail={},)
+
+    # Modifies the __init__ arguments for the imitation policy
+    init_rl_kwargs = dict(
+        policy_class=base.FeedForward32Policy, **DEFAULT_INIT_RL_KWARGS,
+    )
+    gen_batch_size = 2048  # Batch size for generator updates
 
     log_root = os.path.join("output", "train_adversarial")  # output directory
     checkpoint_interval = 0  # Num epochs between checkpoints (<0 disables)
@@ -59,35 +60,20 @@ def train_defaults():
     rollout_hint = None  # Used to generate default rollout_path
     data_dir = "data/"  # Default data directory
 
-    disc_batch_size = 2048  # Batch size for discriminator updates
-    disc_minibatch_size = 512  # Num discriminator updates per batch
-    gen_batch_size = 2048  # Batch size for generator updates
-
 
 @train_ex.config
-def aliases_default_gen_batch_size(gen_batch_size):
+def aliases_default_gen_batch_size(algorithm_kwargs, gen_batch_size):
     # Setting generator buffer capacity and discriminator batch size to
     # the same number is equivalent to not using a replay buffer at all.
     # "Disabling" the replay buffer seems to improve convergence speed, but may
     # come at a cost of stability.
 
-    gen_replay_buffer_size = gen_batch_size  # Num generator transitions stored
+    algorithm_kwargs["shared"]["gen_replay_buffer_capacity"] = gen_batch_size
 
 
 @train_ex.config
-def apply_init_algorithm_kwargs_aliases(
-    disc_minibatch_size, disc_batch_size, gen_replay_buffer_size
-):
-    algorithm_kwargs = dict(
-        disc_minibatch_size=disc_minibatch_size,
-        gen_replay_buffer_capacity=gen_replay_buffer_size,
-        disc_batch_size=disc_batch_size,
-    )
-
-
-@train_ex.config
-def calc_n_steps(num_vec, init_rl_kwargs, gen_batch_size):
-    assert gen_batch_size % num_vec == 0, "num_vec must evenly divide " "gen_batch_size"
+def calc_n_steps(num_vec, gen_batch_size):
+    assert gen_batch_size % num_vec == 0, "num_vec must evenly divide gen_batch_size"
     init_rl_kwargs = dict(n_steps=gen_batch_size // num_vec)
 
 
@@ -126,13 +112,13 @@ def airl():
 
 # Shared settings
 
-MUJOCO_SHARED_LOCALS = dict(airl_entropy_weight=0.1)
+MUJOCO_SHARED_LOCALS = dict(discrim_net_kwargs=dict(airl=dict(entropy_weight=0.1),))
 
 ANT_SHARED_LOCALS = dict(
     total_timesteps=3e7,
-    gen_batch_size=2048 * 8,
-    disc_batch_size=2048 * 8,
     max_episode_steps=500,  # To match `inverse_rl` settings.
+    algorithm_kwargs=dict(shared=dict(disc_batch_size=2048 * 8,),),
+    gen_batch_size=2048 * 8,
 )
 
 
@@ -149,7 +135,7 @@ def acrobot():
 def cartpole():
     env_name = "CartPole-v1"
     rollout_hint = "cartpole"
-    gail_discrim_net_scale = False
+    discrim_net_kwargs = {"gail": {"scale": False}}
 
 
 @train_ex.named_config
@@ -211,7 +197,7 @@ def swimmer():
     env_name = "Swimmer-v2"
     rollout_hint = "swimmer"
     total_timesteps = 2e6
-    init_rl_kwargs = dict(policy_network_class=policies.MlpPolicy,)
+    init_rl_kwargs = dict(policy_network_class=policies.MlpPolicy)
 
 
 @train_ex.named_config
@@ -234,6 +220,9 @@ def two_d_maze():
 @train_ex.named_config
 def custom_ant():
     locals().update(**MUJOCO_SHARED_LOCALS)
+    # Watch out -- ANT_SHARED_LOCALS could erroneously erase nested dict keys from
+    # MUJOCO_SHARED_LOCALS because `locals().update()` doesn't merge dicts
+    # "Sacred-style".
     locals().update(**ANT_SHARED_LOCALS)
     env_name = "imitation/CustomAnt-v0"
     rollout_hint = "custom_ant"
@@ -259,11 +248,8 @@ def fast():
     total_timesteps = 10
     n_expert_demos = 1
     n_episodes_eval = 1
+    algorithm_kwargs = dict(shared=dict(disc_batch_size=2, disc_minibatch_size=2,),)
     gen_batch_size = 2
-    disc_batch_size = 2
-    disc_minibatch_size = 2
-    show_plots = False
-    n_plot_episodes = 1
     parallel = False  # easier to debug with everything in one process
     max_episode_steps = 100
     num_vec = 2

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -101,11 +101,11 @@ def train(
             `algorithm_kwargs["gail"]` is passed to the `GAIL` constructor when
             `algorithm == "gail"`. `algorithm_kwargs["shared"]`, if provided, is passed
             to both the `AIRL` and `GAIL` constructors. Duplicate keyword argument keys
-            between `algorithm_kwargs["global"]` and `algorithm_kwargs["airl"]` (or
+            between `algorithm_kwargs["shared"]` and `algorithm_kwargs["airl"]` (or
             "gail") leads to an error.
         discrim_net_kwargs: Keyword arguments for the `DiscrimNet` constructor. Unlike a
             regular kwargs argument, this argument can only have the following keys:
-            "global", "airl", "gail". These keys have the same meaning as they do in
+            "shared", "airl", "gail". These keys have the same meaning as they do in
             `algorithm_kwargs`.
 
     Returns:
@@ -162,7 +162,7 @@ def train(
         algorithm_kwargs_shared = algorithm_kwargs.get("shared", {})
         algorithm_kwargs_algo = algorithm_kwargs.get(algorithm, {})
         final_algorithm_kwargs = dict(
-            **algorithm_kwargs_shared, **algorithm_kwargs_algo
+            **algorithm_kwargs_shared, **algorithm_kwargs_algo,
         )
 
         if algorithm.lower() == "gail":

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -1,11 +1,11 @@
-"""Train GAIL or AIRL and plot its output.
+"""Train GAIL or AIRL.
 
 Can be used as a CLI script, or the `train_and_plot` function can be called directly.
 """
 
 import os
 import os.path as osp
-from typing import Mapping, Optional, Type
+from typing import Mapping, Optional
 
 import tensorflow as tf
 from sacred.observers import FileStorageObserver
@@ -13,7 +13,6 @@ from sacred.observers import FileStorageObserver
 from imitation.algorithms import adversarial
 from imitation.data import rollout, types
 from imitation.policies import serialize
-from imitation.rewards import reward_net
 from imitation.scripts.config.train_adversarial import train_ex
 from imitation.util import logger, networks
 from imitation.util import sacred as sacred_util
@@ -50,13 +49,9 @@ def train(
     n_episodes_eval: int,
     init_tensorboard: bool,
     checkpoint_interval: int,
-    gail_discrim_net_scale: bool,
-    airl_entropy_weight: float,
-    airl_reward_net_cls: Type[reward_net.RewardNet],
-    airl_reward_net_kwargs: Mapping,
     init_rl_kwargs: Mapping,
-    algorithm_kwargs: Mapping,
-    discrim_kwargs: Mapping,
+    algorithm_kwargs: Mapping[str, Mapping],
+    discrim_net_kwargs: Mapping[str, Mapping],
 ) -> dict:
     """Train an adversarial-network-based imitation learning algorithm.
 
@@ -95,26 +90,23 @@ def train(
             `checkpoint_interval` epochs and after training is complete. If 0,
             then only save weights after training is complete. If <0, then don't
             save weights at all.
-        gail_discrim_net_scale: If True, then normalize observation inputs coming into
-            the `DiscrimNetGAIL` using the bounds of the environment's observation
-            space. Argument is ignored when training AIRL.
-        airl_entropy_weight: The entropy weight for AIRL training reward. Argument is
-            ignored when training GAIL.
-        airl_reward_net_cls: The `RewardNet` class to instantiate when initializing the
-            `DiscrimNetAIRL`. Argument is ignored when training GAIL.
-        airl_reward_net_kwargs: Keyword arguments to pass into the
-            `RewardNet` constructor. Passing in `action_space` and `observation_space`
-            results in error because they are automatically inferred from `venv`.
         init_rl_kwargs: Keyword arguments for `init_rl`, the RL algorithm initialization
             utility function.
-        algorithm_kwargs: Keyword arguments for the `GAIL` or `AIRL` constructor that
-            can apply to either constructor, likely keyword arguments inherited from
-            the superclass constructor, `Adversarial.__init__`. Adding a keyword
-            argument that is specific to either algorithm results in an error
-            from duplicate keyword arguments because algorithm-specific keyword
-            arguments are already set by the `gail_*` and `airl_*` parameters
-            to this function.
-        discrim_kwargs: Keyword arguments for the `DiscrimNet` constructor.
+        algorithm_kwargs: Keyword arguments for the `GAIL` or `AIRL` constructor
+            that can apply to either constructor. Unlike a regular kwargs argument, this
+            argument can only have the following keys: "shared", "airl", and "gail".
+
+            `algorithm_kwargs["airl"]`, if it is provided, is a kwargs `Mapping` passed
+            to the `AIRL` constructor when `algorithm == "airl"`. Likewise
+            `algorithm_kwargs["gail"]` is passed to the `GAIL` constructor when
+            `algorithm == "gail"`. `algorithm_kwargs["shared"]`, if provided, is passed
+            to both the `AIRL` and `GAIL` constructors. Duplicate keyword argument keys
+            between `algorithm_kwargs["global"]` and `algorithm_kwargs["airl"]` (or
+            "gail") leads to an error.
+        discrim_net_kwargs: Keyword arguments for the `DiscrimNet` constructor. Unlike a
+            regular kwargs argument, this argument can only have the following keys:
+            "global", "airl", "gail". These keys have the same meaning as they do in
+            `algorithm_kwargs`.
 
     Returns:
         A dictionary with two keys. "imit_stats" gives the return value of
@@ -159,18 +151,24 @@ def train(
         )
 
         # Convert Sacred's ReadOnlyDict to dict so we can modify it.
-        discrim_kwargs = dict(discrim_kwargs)
-        auto_algorithm_kwargs = {}
+        allowed_keys = {"shared", "gail", "airl"}
+        assert discrim_net_kwargs.keys() <= allowed_keys
+        assert algorithm_kwargs.keys() <= allowed_keys
+
+        discrim_kwargs_shared = discrim_net_kwargs.get("shared", {})
+        discrim_kwargs_algo = discrim_net_kwargs.get(algorithm, {})
+        final_discrim_kwargs = dict(**discrim_kwargs_shared, **discrim_kwargs_algo)
+
+        algorithm_kwargs_shared = algorithm_kwargs.get("shared", {})
+        algorithm_kwargs_algo = algorithm_kwargs.get(algorithm, {})
+        final_algorithm_kwargs = dict(
+            **algorithm_kwargs_shared, **algorithm_kwargs_algo
+        )
+
         if algorithm.lower() == "gail":
             algo_cls = adversarial.GAIL
-            discrim_kwargs["scale"] = gail_discrim_net_scale
         elif algorithm.lower() == "airl":
             algo_cls = adversarial.AIRL
-            assert "entropy_weight" not in discrim_kwargs
-            discrim_kwargs["entropy_weight"] = airl_entropy_weight
-
-            auto_algorithm_kwargs["reward_net_cls"] = airl_reward_net_cls
-            auto_algorithm_kwargs["reward_net_kwargs"] = airl_reward_net_kwargs
         else:
             raise ValueError(f"Invalid value algorithm={algorithm}.")
 
@@ -179,10 +177,8 @@ def train(
             expert_demos=expert_transitions,
             gen_policy=gen_policy,
             log_dir=log_dir,
-            discrim_kwargs=discrim_kwargs,
-            # pytype is confused by the branching `if algorithm ==`.
-            **auto_algorithm_kwargs,  # pytype: disable=wrong-keyword-args
-            **algorithm_kwargs,
+            discrim_kwargs=final_discrim_kwargs,
+            **final_algorithm_kwargs,
         )
 
         def callback(epoch):

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -5,17 +5,19 @@ Can be used as a CLI script, or the `train_and_plot` function can be called dire
 
 import os
 import os.path as osp
-from typing import Optional
+from typing import Mapping, Optional, Type
 
 import tensorflow as tf
 from sacred.observers import FileStorageObserver
 
 from imitation.algorithms import adversarial
-from imitation.data import dataset, rollout, types
+from imitation.data import rollout, types
 from imitation.policies import serialize
+from imitation.rewards import reward_net
 from imitation.scripts.config.train_adversarial import train_ex
-from imitation.util import logger, networks, util
+from imitation.util import logger, networks
 from imitation.util import sacred as sacred_util
+from imitation.util import util
 
 
 def save(trainer, save_path):
@@ -36,7 +38,11 @@ def save(trainer, save_path):
 def train(
     _run,
     _seed: int,
+    algorithm: str,
     env_name: str,
+    num_vec: int,
+    parallel: bool,
+    max_episode_steps: Optional[int],
     rollout_path: str,
     n_expert_demos: Optional[int],
     log_dir: str,
@@ -44,61 +50,77 @@ def train(
     n_episodes_eval: int,
     init_tensorboard: bool,
     checkpoint_interval: int,
-
+    gail_discrim_net_scale: bool,
     airl_entropy_weight: float,
-    num_vec: int,
-    parallel: bool,
-    max_episode_steps: Optional[int],
-    scale: bool,
-    trainer_kwargs: dict,
-    discrim_kwargs: dict,
-    reward_kwargs: dict,
-    init_rl_kwargs: dict,
-    algorithm: str,
+    airl_reward_net_cls: Type[reward_net.RewardNet],
+    airl_reward_net_kwargs: Mapping,
+    init_rl_kwargs: Mapping,
+    algorithm_kwargs: Mapping,
+    discrim_kwargs: Mapping,
 ) -> dict:
     """Train an adversarial-network-based imitation learning algorithm.
 
     Checkpoints:
-      - DiscrimNets are saved to f"{log_dir}/checkpoints/{step}/discrim/",
-        where step is either the training epoch or "final".
-      - Generator policies are saved to
-        f"{log_dir}/checkpoints/{step}/gen_policy/".
+        - DiscrimNets are saved to `f"{log_dir}/checkpoints/{step}/discrim/"`,
+            where step is either the training epoch or "final".
+        - Generator policies are saved to `f"{log_dir}/checkpoints/{step}/gen_policy/"`.
 
     Args:
-      _seed: Random seed.
-      env_name: The environment to train in.
-      rollout_path: Path to pickle containing list of Trajectories. Used as
-        expert demonstrations.
-      n_expert_demos: The number of expert trajectories to actually use
-        after loading them from `rollout_path`.
-        If None, then use all available trajectories.
-        If `n_expert_demos` is an `int`, then use exactly `n_expert_demos`
-        trajectories, erroring if there aren't enough trajectories. If there are
-        surplus trajectories, then use the
-        first `n_expert_demos` trajectories and drop the rest.
-      log_dir: Directory to save models and other logging to.
-
-      init_trainer_kwargs: Keyword arguments passed to `init_trainer`,
-        used to initialize the trainer.
-      total_timesteps: The number of transitions to sample from the environment
-        during training.
-      n_episodes_eval: The number of episodes to average over when calculating
-        the average episode reward of the imitation policy for return.
-
-      init_tensorboard: If True, then write tensorboard logs to `{log_dir}/sb_tb`.
-
-      checkpoint_interval: Save the discriminator and generator models every
-        `checkpoint_interval` epochs and after training is complete. If 0,
-        then only save weights after training is complete. If <0, then don't
-        save weights at all.
+        _seed: Random seed.
+        algorithm: A case-insensitive string determining which adversarial imitation
+            learning algorithm is executed. Either "airl" or "gail".
+        env_name: The environment to train in.
+        num_vec: Number of `gym.Env` to vectorize.
+        parallel: Whether to use "true" parallelism. If True, then use `SubProcVecEnv`.
+            Otherwise, use `DummyVecEnv` which steps through environments serially.
+        max_episode_steps: If not None, then a TimeLimit wrapper is applied to each
+            environment to artificially limit the maximum number of timesteps in an
+            episode.
+        rollout_path: Path to pickle containing list of Trajectories. Used as
+            expert demonstrations.
+        n_expert_demos: The number of expert trajectories to actually use
+            after loading them from `rollout_path`.
+            If None, then use all available trajectories.
+            If `n_expert_demos` is an `int`, then use exactly `n_expert_demos`
+            trajectories, erroring if there aren't enough trajectories. If there are
+            surplus trajectories, then use the
+            first `n_expert_demos` trajectories and drop the rest.
+        log_dir: Directory to save models and other logging to.
+        total_timesteps: The number of transitions to sample from the environment
+            during training.
+        n_episodes_eval: The number of episodes to average over when calculating
+            the average episode reward of the imitation policy for return.
+        init_tensorboard: If True, then write tensorboard logs to `{log_dir}/sb_tb`.
+        checkpoint_interval: Save the discriminator and generator models every
+            `checkpoint_interval` epochs and after training is complete. If 0,
+            then only save weights after training is complete. If <0, then don't
+            save weights at all.
+        gail_discrim_net_scale: If True, then scale observation inputs coming into the
+            `DiscrimNetGAIL` by the bounds of the environment's observation. Argument is
+            ignored when training AIRL.
+        airl_entropy_weight: The entropy weight for AIRL training reward. Argument is
+            ignored when training GAIL.
+        airl_reward_net_cls: The `RewardNet` class to instantiate when initializing the
+            `DiscrimNetAIRL`. Argument is ignored when training GAIL.
+        airl_reward_net_kwargs: Additional keyword arguments to pass into the
+            `RewardNet` constructor. `action_space` and `observation_space` are
+            automatically inferred.
+        init_rl_kwargs: Keyword arguments for `init_rl`, the RL algorithm initialization
+            utility function.
+        algorithm_kwargs: Keyword arguments for the `GAIL` or `AIRL` constructor that
+            can apply to either constructor, likely keyword arguments inherited from
+            the superclass constructor, `Adversarial.__init__`. Putting a keyword
+            argument that is specific to either algorithm will result in an error
+            from duplicate keyword arguments.
+        discrim_kwargs: Keyword arguments for the `DiscrimNet` constructor.
 
     Returns:
-      A dictionary with two keys. "imit_stats" gives the return value of
-        `rollout_stats()` on rollouts test-reward-wrapped
-        environment, using the final policy (remember that the ground-truth reward
-        can be recovered from the "monitor_return" key). "expert_stats" gives the
-        return value of `rollout_stats()` on the expert demonstrations loaded from
-        `rollout_path`.
+        A dictionary with two keys. "imit_stats" gives the return value of
+            `rollout_stats()` on rollouts test-reward-wrapped
+            environment, using the final policy (remember that the ground-truth reward
+            can be recovered from the "monitor_return" key). "expert_stats" gives the
+            return value of `rollout_stats()` on the expert demonstrations loaded from
+            `rollout_path`.
     """
     assert os.path.exists(rollout_path)
     total_timesteps = int(total_timesteps)
@@ -112,16 +134,13 @@ def train(
     if n_expert_demos is not None:
         assert len(expert_trajs) >= n_expert_demos
         expert_trajs = expert_trajs[:n_expert_demos]
+    expert_transitions = rollout.flatten_trajectories(expert_trajs)
 
     with networks.make_session():
         if init_tensorboard:
             tensorboard_log = osp.join(log_dir, "sb_tb")
         else:
             tensorboard_log = None
-
-        import dataclasses
-        expert_trans = rollout.flatten_trajectories(expert_trajs)
-        expert_dataset = dataset.SimpleDataset(data_map=dataclasses.asdict(expert_trans))
 
         venv = util.make_vec_env(
             env_name,
@@ -134,37 +153,35 @@ def train(
 
         # TODO(shwang): Let's get rid of init_rl later on?
         # It's really just a stub function now.
-        gen_policy = util.init_rl(venv, verbose=1, tensorboard_log=tensorboard_log,
-                                  **init_rl_kwargs)
+        gen_policy = util.init_rl(
+            venv, verbose=1, tensorboard_log=tensorboard_log, **init_rl_kwargs
+        )
 
-        other_algo_kwargs = {}
-        if algorithm == "gail":
+        # Convert Sacred's ReadOnlyDict to dict so we can modify it.
+        discrim_kwargs = dict(discrim_kwargs)
+        auto_algorithm_kwargs = {}
+        if algorithm.lower() == "gail":
             algo_cls = adversarial.GAIL
-        elif algorithm == "airl":
+            discrim_kwargs["scale"] = gail_discrim_net_scale
+        elif algorithm.lower() == "airl":
             algo_cls = adversarial.AIRL
+            assert "entropy_weight" not in discrim_kwargs
+            discrim_kwargs["entropy_weight"] = airl_entropy_weight
 
-            # TODO(shwang): Let's do custom reward_net_cls
-            other_algo_kwargs["reward_kwargs"] = reward_kwargs
-            other_algo_kwargs["reward_net_cls"] = reward_net.BasicShapedRewardNet(
-                venv.observation_space, venv.action_space, scale=scale)
-            other_algo_kwargs["airl_entropy_weight"] = airl_entropy_weight
+            auto_algorithm_kwargs["reward_net_cls"] = airl_reward_net_cls
+            auto_algorithm_kwargs["reward_net_kwargs"] = airl_reward_net_kwargs
         else:
             raise ValueError(algorithm)
 
         trainer = algo_cls(
             venv=venv,
-            expert_dataset=expert_dataset,
+            expert_demos=expert_transitions,
             gen_policy=gen_policy,
             log_dir=log_dir,
-            scale=scale,
-            # TODO(shwang): Consider using capture instead of repeating these arguments?
-            # I'm a bit reluctant becuase it might mean that it's harder to call the
-            # __init__ directly, but I'm not sure if that's actually true.
             discrim_kwargs=discrim_kwargs,
-            trainer_kwargs=trainer_kwargs,
-
             # pytype is confused by the branching `if algorithm ==`.
-            **other_algo_kwargs,  # pytype: disable=wrong-keyword-args
+            **auto_algorithm_kwargs,  # pytype: disable=wrong-keyword-args
+            **algorithm_kwargs,
         )
 
         def callback(epoch):

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -83,8 +83,8 @@ def train(
             If None, then use all available trajectories.
             If `n_expert_demos` is an `int`, then use exactly `n_expert_demos`
             trajectories, erroring if there aren't enough trajectories. If there are
-            surplus trajectories, then use the
-            first `n_expert_demos` trajectories and drop the rest.
+            surplus trajectories, then use the first `n_expert_demos` trajectories and
+            drop the rest.
         log_dir: Directory to save models and other logging to.
         total_timesteps: The number of transitions to sample from the environment
             during training.
@@ -95,32 +95,33 @@ def train(
             `checkpoint_interval` epochs and after training is complete. If 0,
             then only save weights after training is complete. If <0, then don't
             save weights at all.
-        gail_discrim_net_scale: If True, then scale observation inputs coming into the
-            `DiscrimNetGAIL` by the bounds of the environment's observation. Argument is
-            ignored when training AIRL.
+        gail_discrim_net_scale: If True, then normalize observation inputs coming into
+            the `DiscrimNetGAIL` using the bounds of the environment's observation
+            space. Argument is ignored when training AIRL.
         airl_entropy_weight: The entropy weight for AIRL training reward. Argument is
             ignored when training GAIL.
         airl_reward_net_cls: The `RewardNet` class to instantiate when initializing the
             `DiscrimNetAIRL`. Argument is ignored when training GAIL.
-        airl_reward_net_kwargs: Additional keyword arguments to pass into the
-            `RewardNet` constructor. `action_space` and `observation_space` are
-            automatically inferred.
+        airl_reward_net_kwargs: Keyword arguments to pass into the
+            `RewardNet` constructor. Passing in `action_space` and `observation_space`
+            results in error because they are automatically inferred from `venv`.
         init_rl_kwargs: Keyword arguments for `init_rl`, the RL algorithm initialization
             utility function.
         algorithm_kwargs: Keyword arguments for the `GAIL` or `AIRL` constructor that
             can apply to either constructor, likely keyword arguments inherited from
-            the superclass constructor, `Adversarial.__init__`. Putting a keyword
-            argument that is specific to either algorithm will result in an error
-            from duplicate keyword arguments.
+            the superclass constructor, `Adversarial.__init__`. Adding a keyword
+            argument that is specific to either algorithm results in an error
+            from duplicate keyword arguments because algorithm-specific keyword
+            arguments are already set by the `gail_*` and `airl_*` parameters
+            to this function.
         discrim_kwargs: Keyword arguments for the `DiscrimNet` constructor.
 
     Returns:
         A dictionary with two keys. "imit_stats" gives the return value of
-            `rollout_stats()` on rollouts test-reward-wrapped
-            environment, using the final policy (remember that the ground-truth reward
-            can be recovered from the "monitor_return" key). "expert_stats" gives the
-            return value of `rollout_stats()` on the expert demonstrations loaded from
-            `rollout_path`.
+        `rollout_stats()` on rollouts test-reward-wrapped environment, using the final
+        policy (remember that the ground-truth reward can be recovered from the
+        "monitor_return" key). "expert_stats" gives the return value of
+        `rollout_stats()` on the expert demonstrations loaded from `rollout_path`.
     """
     assert os.path.exists(rollout_path)
     total_timesteps = int(total_timesteps)

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -142,7 +142,11 @@ def train(
             algo_cls = adversarial.GAIL
         elif algorithm == "airl":
             algo_cls = adversarial.AIRL
+
+            # TODO(shwang): Let's do custom reward_net_cls
             other_algo_kwargs["reward_kwargs"] = reward_kwargs
+            other_algo_kwargs["reward_net_cls"] = reward_net.BasicShapedRewardNet(
+                venv.observation_space, venv.action_space, scale=scale)
             other_algo_kwargs["airl_entropy_weight"] = airl_entropy_weight
         else:
             raise ValueError(algorithm)

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -171,7 +171,7 @@ def train(
             auto_algorithm_kwargs["reward_net_cls"] = airl_reward_net_cls
             auto_algorithm_kwargs["reward_net_kwargs"] = airl_reward_net_kwargs
         else:
-            raise ValueError(algorithm)
+            raise ValueError(f"Invalid value algorithm={algorithm}.")
 
         trainer = algo_cls(
             venv=venv,

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -34,7 +34,7 @@ def test_expert_demos_main(tmpdir):
 
 def test_expert_demos_rollouts_from_policy(tmpdir):
     """Smoke test for imitation.scripts.expert_demos.rollouts_from_policy."""
-    run = expert_demos_ex.run(
+    run = expert_demos.expert_demos_ex.run(
         command_name="rollouts_from_policy",
         named_configs=["cartpole", "fast"],
         config_updates=dict(
@@ -60,7 +60,9 @@ def test_eval_policy(config, tmpdir):
         "log_root": tmpdir,
     }
     config_updates.update(config)
-    run = eval_policy_ex.run(config_updates=config_updates, named_configs=["fast"])
+    run = eval_policy.eval_policy_ex.run(
+        config_updates=config_updates, named_configs=["fast"]
+    )
     assert run.status == "COMPLETED"
     wrapped_reward = "reward_type" in config
     _check_rollout_stats(run.result, wrapped_reward)
@@ -155,11 +157,12 @@ PARALLEL_CONFIG_UPDATES = [
             ),
         },
         search_space={
+            "named_configs": tune.grid_search([["gail"], ["airl"]]),
             "config_updates": {
-                "reward_kwargs": {
+                "airl_reward_net_kwargs": {
                     "phi_units": tune.grid_search([[16, 16], [7, 9]]),
                 },
-            }
+            },
         },
     ),
 ]
@@ -204,11 +207,7 @@ def test_parallel_train_adversarial_custom_env(tmpdir):
         sacred_ex_name="train_adversarial",
         n_seeds=1,
         base_named_configs=[env_named_config, "fast"],
-        base_config_updates=dict(
-            parallel=True,
-            num_vec=2,
-            rollout_path=rollout_path,
-        ),
+        base_config_updates=dict(parallel=True, num_vec=2, rollout_path=rollout_path,),
     )
     config_updates.update(PARALLEL_CONFIG_LOW_RESOURCE)
     run = parallel.parallel_ex.run(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -112,7 +112,6 @@ def test_train_adversarial_algorithm_config_error(tmpdir):
     config_updates = {
         "log_root": tmpdir,
         "rollout_path": "tests/data/expert_models/cartpole_0/rollouts/final.pkl",
-        "init_tensorboard": True,
         "algorithm": "BAD_VALUE",
     }
     with pytest.raises(ValueError, match=".*BAD_VALUE.*"):
@@ -174,8 +173,12 @@ PARALLEL_CONFIG_UPDATES = [
         search_space={
             "config_updates": {
                 "algorithm": tune.grid_search(["gail", "airl"]),
-                "airl_reward_net_kwargs": {
-                    "phi_units": tune.grid_search([[16, 16], [7, 9]]),
+                "algorithm_kwargs": {
+                    "airl": {
+                        "reward_net_kwargs": {
+                            "phi_units": tune.grid_search([[16, 16], [7, 9]]),
+                        }
+                    }
                 },
             },
         },

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -106,6 +106,21 @@ def test_train_adversarial(tmpdir):
     _check_train_ex_result(run.result)
 
 
+def test_train_adversarial_algorithm_config_error(tmpdir):
+    """Error on bad algorithm arguments."""
+    named_configs = ["cartpole", "fast"]
+    config_updates = {
+        "log_root": tmpdir,
+        "rollout_path": "tests/data/expert_models/cartpole_0/rollouts/final.pkl",
+        "init_tensorboard": True,
+        "algorithm": "BAD_VALUE",
+    }
+    with pytest.raises(ValueError, match=".*BAD_VALUE.*"):
+        train_adversarial.train_ex.run(
+            named_configs=named_configs, config_updates=config_updates,
+        )
+
+
 def test_transfer_learning(tmpdir):
     """Transfer learning smoke test.
 
@@ -157,8 +172,8 @@ PARALLEL_CONFIG_UPDATES = [
             ),
         },
         search_space={
-            "named_configs": tune.grid_search([["gail"], ["airl"]]),
             "config_updates": {
+                "algorithm": tune.grid_search(["gail", "airl"]),
                 "airl_reward_net_kwargs": {
                     "phi_units": tune.grid_search([[16, 16], [7, 9]]),
                 },

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -14,16 +14,18 @@ import pandas as pd
 import pytest
 import ray.tune as tune
 
-from imitation.scripts.analyze import analysis_ex
-from imitation.scripts.eval_policy import eval_policy_ex
-from imitation.scripts.expert_demos import expert_demos_ex
-from imitation.scripts.parallel import parallel_ex
-from imitation.scripts.train_adversarial import train_ex
+from imitation.scripts import (
+    analyze,
+    eval_policy,
+    expert_demos,
+    parallel,
+    train_adversarial,
+)
 
 
 def test_expert_demos_main(tmpdir):
     """Smoke test for imitation.scripts.expert_demos.rollouts_and_policy."""
-    run = expert_demos_ex.run(
+    run = expert_demos.expert_demos_ex.run(
         named_configs=["cartpole", "fast"], config_updates=dict(log_root=tmpdir,),
     )
     assert run.status == "COMPLETED"
@@ -94,10 +96,10 @@ def test_train_adversarial(tmpdir):
         "log_root": tmpdir,
         "rollout_path": "tests/data/expert_models/cartpole_0/rollouts/final.pkl",
         "init_tensorboard": True,
-        "plot_interval": 1,
-        "extra_episode_data_interval": 1,
     }
-    run = train_ex.run(named_configs=named_configs, config_updates=config_updates,)
+    run = train_adversarial.train_ex.run(
+        named_configs=named_configs, config_updates=config_updates,
+    )
     assert run.status == "COMPLETED"
     _check_train_ex_result(run.result)
 
@@ -108,7 +110,7 @@ def test_transfer_learning(tmpdir):
     Saves a dummy AIRL test reward, then loads it for transfer learning.
     """
     log_dir_train = osp.join(tmpdir, "train")
-    run = train_ex.run(
+    run = train_adversarial.train_ex.run(
         named_configs=["cartpole", "airl", "fast"],
         config_updates=dict(
             rollout_path="tests/data/expert_models/cartpole_0/rollouts/final.pkl",
@@ -122,7 +124,7 @@ def test_transfer_learning(tmpdir):
 
     log_dir_data = osp.join(tmpdir, "expert_demos")
     discrim_path = osp.join(log_dir_train, "checkpoints", "final", "discrim")
-    run = expert_demos_ex.run(
+    run = expert_demos.expert_demos_ex.run(
         named_configs=["cartpole", "fast"],
         config_updates=dict(
             log_dir=log_dir_data, reward_type="DiscrimNet", reward_path=discrim_path,
@@ -154,10 +156,8 @@ PARALLEL_CONFIG_UPDATES = [
         },
         search_space={
             "config_updates": {
-                "init_trainer_kwargs": {
-                    "reward_kwargs": {
-                        "phi_units": tune.grid_search([[16, 16], [7, 9]]),
-                    },
+                "reward_kwargs": {
+                    "phi_units": tune.grid_search([[16, 16], [7, 9]]),
                 },
             }
         },
@@ -181,14 +181,14 @@ def test_parallel(config_updates):
     # No need for TemporaryDirectory because the hyperparameter tuning script
     # itself generates no artifacts, and "debug_log_root" sets inner experiment's
     # log_root="/tmp/parallel_debug/".
-    run = parallel_ex.run(
+    run = parallel.parallel_ex.run(
         named_configs=["debug_log_root"], config_updates=config_updates
     )
     assert run.status == "COMPLETED"
 
 
 def _generate_test_rollouts(tmpdir: str, env_named_config: str) -> str:
-    expert_demos_ex.run(
+    expert_demos.expert_demos_ex.run(
         named_configs=[env_named_config, "fast"],
         config_updates=dict(rollout_save_interval=0, log_dir=tmpdir,),
     )
@@ -205,12 +205,13 @@ def test_parallel_train_adversarial_custom_env(tmpdir):
         n_seeds=1,
         base_named_configs=[env_named_config, "fast"],
         base_config_updates=dict(
-            init_trainer_kwargs=dict(parallel=True, num_vec=2,),
+            parallel=True,
+            num_vec=2,
             rollout_path=rollout_path,
         ),
     )
     config_updates.update(PARALLEL_CONFIG_LOW_RESOURCE)
-    run = parallel_ex.run(
+    run = parallel.parallel_ex.run(
         named_configs=["debug_log_root"], config_updates=config_updates
     )
     assert run.status == "COMPLETED"
@@ -224,7 +225,7 @@ def test_analyze_imitation(tmpdir: str, run_names: List[str]):
     for i, run_name in enumerate(run_names):
         with tempfile.TemporaryDirectory(prefix="junk") as junkdir:
             rollout_path = "tests/data/expert_models/cartpole_0/rollouts/final.pkl"
-            run = train_ex.run(
+            run = train_adversarial.train_ex.run(
                 named_configs=["fast", "cartpole"],
                 config_updates=dict(
                     rollout_path=rollout_path, log_dir=junkdir, checkpoint_interval=-1,
@@ -235,10 +236,11 @@ def test_analyze_imitation(tmpdir: str, run_names: List[str]):
 
     # Check that analyze script finds the correct number of logs.
     def check(run_name: Optional[str], count: int) -> None:
-        run = analysis_ex.run(
+        run = analyze.analysis_ex.run(
             command_name="analyze_imitation",
             config_updates=dict(
                 source_dir=sacred_logs_dir,
+                env_name="CartPole-v1",
                 run_name=run_name,
                 csv_output_path=osp.join(tmpdir, "analysis.csv"),
                 verbose=True,
@@ -257,12 +259,12 @@ def test_analyze_imitation(tmpdir: str, run_names: List[str]):
 def test_analyze_gather_tb(tmpdir: str):
     config_updates = dict(local_dir=tmpdir, run_name="test")
     config_updates.update(PARALLEL_CONFIG_LOW_RESOURCE)
-    parallel_run = parallel_ex.run(
+    parallel_run = parallel.parallel_ex.run(
         named_configs=["generate_test_data"], config_updates=config_updates
     )
     assert parallel_run.status == "COMPLETED"
 
-    run = analysis_ex.run(
+    run = analyze.analysis_ex.run(
         command_name="gather_tb_directories", config_updates=dict(source_dir=tmpdir,)
     )
     assert run.status == "COMPLETED"

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -23,16 +23,17 @@ def setup_and_teardown(session):
 
 @pytest.fixture(params=PARALLEL)
 def _parallel(request):
-    # Auto-parametrizes `_parallel` for the trainer fixture. This way we don't have to
-    # add a @pytest.mark.parametrize("_parallel", ... ) decorator in front of
-    # every test. I couldn't find a better way to do this that didn't involve the
-    # aforementioned `parameterize` duplication.
+    """Auto-parametrizes `_parallel` for the `trainer` fixture.
+
+    This way we don't have to add a @pytest.mark.parametrize("_parallel", ... )
+    decorator in front of every test. I couldn't find a better way to do this that
+    didn't involve the aforementioned `parameterize` duplication."""
     return request.param
 
 
 @pytest.fixture(params=ALGORITHM_CLS)
 def _algorithm_cls(request):
-    # Auto-parametrizes `_algorithm_cls` for the trainer fixture.
+    """Auto-parametrizes `_algorithm_cls` for the `trainer` fixture."""
     return request.param
 
 


### PR DESCRIPTION
Refactor of `adversarial.py` and `train_adversarial.py`.

Main changes:
* `init_trainer` functionality moved into new `GAIL` and `AIRL` class constructors and `train_adversarial` main body.
* `AdversarialTrainer` renamed to `Adversarial`.