### PR TITLE
DiscrimNetGAIL: Add negative rewards option

### DIFF
--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -417,7 +417,7 @@ class GAIL(AdversarialTrainer):
         expert_demos: types.Transitions,
         gen_policy: base_class.BaseRLModel,
         *,
-        discrim_kwargs: Optional[Mapping] = None,
+        discrim_net_kwargs: Optional[Mapping] = None,
         **kwargs,
     ):
         """Generative Adversarial Imitation Learning.
@@ -427,13 +427,13 @@ class GAIL(AdversarialTrainer):
         as follows:
 
         Args:
-            discrim_kwargs: Optional keyword arguments to use while constructing the
+            discrim_net_kwargs: Optional keyword arguments to use while constructing the
                 DiscrimNetGAIL.
 
         """
-        discrim_kwargs = discrim_kwargs or {}
+        discrim_net_kwargs = discrim_net_kwargs or {}
         discrim = discrim_net.DiscrimNetGAIL(
-            venv.observation_space, venv.action_space, **discrim_kwargs
+            venv.observation_space, venv.action_space, **discrim_net_kwargs
         )
         super().__init__(venv, gen_policy, discrim, expert_demos, **kwargs)
 
@@ -447,7 +447,7 @@ class AIRL(AdversarialTrainer):
         *,
         reward_net_cls: Type[reward_net.RewardNet] = reward_net.BasicShapedRewardNet,
         reward_net_kwargs: Optional[Mapping] = None,
-        discrim_kwargs: Optional[Mapping] = None,
+        discrim_net_kwargs: Optional[Mapping] = None,
         **kwargs,
     ):
         """Adversarial Inverse Reinforcement Learning.
@@ -461,7 +461,7 @@ class AIRL(AdversarialTrainer):
                 the AIRL discriminator.
             reward_net_kwargs: Optional keyword arguments to use while constructing
                 the reward network.
-            discrim_kwargs: Optional keyword arguments to use while constructing the
+            discrim_net_kwargs: Optional keyword arguments to use while constructing the
                 DiscrimNetAIRL.
         """
         # TODO(shwang): Maybe offer str=>Type[RewardNet] conversion like
@@ -475,6 +475,6 @@ class AIRL(AdversarialTrainer):
             **reward_net_kwargs,  # pytype: disable=not-instantiable
         )
 
-        discrim_kwargs = discrim_kwargs or {}
-        discrim = discrim_net.DiscrimNetAIRL(reward_network, **discrim_kwargs)
+        discrim_net_kwargs = discrim_net_kwargs or {}
+        discrim = discrim_net.DiscrimNetAIRL(reward_network, **discrim_net_kwargs)
         super().__init__(venv, gen_policy, discrim, expert_demos, **kwargs)

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -140,6 +140,9 @@ def cartpole():
 def mountain_car():
     env_name = "MountainCar-v0"
     rollout_hint = "mountain_car"
+    # Original paper used negative rewards, as this is a variable-length episode
+    # environment with only negative rewards.
+    discrim_net_kwargs = {"gail": {"positive_rewards": False}}
 
 
 @train_ex.named_config

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -155,9 +155,11 @@ def train(
         assert discrim_net_kwargs.keys() <= allowed_keys
         assert algorithm_kwargs.keys() <= allowed_keys
 
-        discrim_kwargs_shared = discrim_net_kwargs.get("shared", {})
-        discrim_kwargs_algo = discrim_net_kwargs.get(algorithm, {})
-        final_discrim_kwargs = dict(**discrim_kwargs_shared, **discrim_kwargs_algo)
+        discrim_net_kwargs_shared = discrim_net_kwargs.get("shared", {})
+        discrim_net_kwargs_algo = discrim_net_kwargs.get(algorithm, {})
+        final_discrim_net_kwargs = dict(
+            **discrim_net_kwargs_shared, **discrim_net_kwargs_algo
+        )
 
         algorithm_kwargs_shared = algorithm_kwargs.get("shared", {})
         algorithm_kwargs_algo = algorithm_kwargs.get(algorithm, {})
@@ -177,7 +179,7 @@ def train(
             expert_demos=expert_transitions,
             gen_policy=gen_policy,
             log_dir=log_dir,
-            discrim_kwargs=final_discrim_kwargs,
+            discrim_net_kwargs=final_discrim_net_kwargs,
             **final_algorithm_kwargs,
         )
 

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -8,7 +8,12 @@ from imitation.algorithms import adversarial
 from imitation.data import rollout, types
 from imitation.util import logger, util
 
-ALGORITHM_CLS = [adversarial.AIRL, adversarial.GAIL]
+# List of (algorithm_cls, algorithm_kwargs).
+ALGORITHM_PARAMS = [
+    (adversarial.AIRL, {}),
+    (adversarial.GAIL, {"discrim_net_kwargs": {"positive_rewards": True}}),
+    (adversarial.GAIL, {"discrim_net_kwargs": {"positive_rewards": False}}),
+]
 IN_CODECOV = "COV_CORE_CONFIG" in os.environ
 # Disable SubprocVecEnv tests for code coverage test since
 # multiprocessing support is flaky in py.test --cov
@@ -17,13 +22,13 @@ PARALLEL = [False] if IN_CODECOV else [True, False]
 
 @pytest.fixture(autouse=True)
 def setup_and_teardown(session):
-    # Uses conftest.session fixture for everything in this file
+    # Uses conftest.session fixture for everything in this file.
     yield
 
 
 @pytest.fixture(params=PARALLEL)
 def _parallel(request):
-    """Auto-parametrizes `_parallel` for the `trainer` fixture.
+    """Auto-parametrizes `_parallel` for the `model` fixture.
 
     This way we don't have to add a @pytest.mark.parametrize("_parallel", ... )
     decorator in front of every test. I couldn't find a better way to do this that
@@ -31,14 +36,15 @@ def _parallel(request):
     return request.param
 
 
-@pytest.fixture(params=ALGORITHM_CLS)
-def _algorithm_cls(request):
-    """Auto-parametrizes `_algorithm_cls` for the `trainer` fixture."""
+@pytest.fixture(params=ALGORITHM_PARAMS)
+def _algorithm_params(request):
+    """Auto-parametrizes `_algorithm_params` for the `model` fixture."""
     return request.param
 
 
 @pytest.fixture
-def trainer(_algorithm_cls, _parallel: bool, tmpdir: str):
+def model(_algorithm_params, _parallel: bool, tmpdir: str):
+    algorithm_cls, algorithm_kwargs = _algorithm_params
     trajs = types.load("tests/data/expert_models/cartpole_0/rollouts/final.pkl")
     expert_demos = rollout.flatten_trajectories(trajs)
     logger.configure(tmpdir, ["tensorboard", "stdout"])
@@ -49,30 +55,34 @@ def trainer(_algorithm_cls, _parallel: bool, tmpdir: str):
 
     gen_policy = util.init_rl(venv, verbose=1)
 
-    return _algorithm_cls(
-        venv=venv, expert_demos=expert_demos, gen_policy=gen_policy, log_dir=tmpdir,
+    return algorithm_cls(
+        venv=venv,
+        expert_demos=expert_demos,
+        gen_policy=gen_policy,
+        log_dir=tmpdir,
+        **algorithm_kwargs,
     )
 
 
-def test_train_disc_step_no_crash(tmpdir, trainer, n_timesteps=200):
+def test_train_disc_step_no_crash(tmpdir, model, n_timesteps=200):
     transitions = rollout.generate_transitions(
-        trainer.gen_policy, trainer.venv, n_timesteps=n_timesteps
+        model.gen_policy, model.venv, n_timesteps=n_timesteps
     )
-    trainer.train_disc_step(gen_samples=transitions)
+    model.train_disc_step(gen_samples=transitions)
 
 
-def test_train_gen_train_disc_no_crash(tmpdir, trainer, n_updates=2):
-    trainer.train_gen(n_updates * trainer.gen_batch_size)
-    trainer.train_disc()
+def test_train_gen_train_disc_no_crash(tmpdir, model, n_updates=2):
+    model.train_gen(n_updates * model.gen_batch_size)
+    model.train_disc()
 
 
 @pytest.mark.expensive
-def test_train_disc_improve_D(tmpdir, trainer, n_timesteps=200, n_steps=1000):
+def test_train_disc_improve_D(tmpdir, model, n_timesteps=200, n_steps=1000):
     gen_samples = rollout.generate_transitions(
-        trainer.gen_policy, trainer.venv_train_norm, n_timesteps=n_timesteps
+        model.gen_policy, model.venv_train_norm, n_timesteps=n_timesteps
     )
-    loss1 = trainer.eval_disc_loss(gen_samples=gen_samples)
+    loss1 = model.eval_disc_loss(gen_samples=gen_samples)
     for _ in range(n_steps):
-        trainer.train_disc_step(gen_samples=gen_samples)
-    loss2 = trainer.eval_disc_loss(gen_samples=gen_samples)
+        model.train_disc_step(gen_samples=gen_samples)
+    loss2 = model.eval_disc_loss(gen_samples=gen_samples)
     assert loss2 < loss1

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -1,4 +1,4 @@
-"""Tests for imitation.trainer.Trainer and util.trainer.init_trainer."""
+"""Tests for imitation.algorithms.adversarial"""
 
 import os
 


### PR DESCRIPTION
Adds an parameter to DiscrimNetGAIL constructor that flips the training reward sign. Also sets train_adversarial's `mountain_car` named config to use negative training reward by default.

Finally, adds coverage for negative training reward in test_trainer, which is renamed to test_adversarial in this PR. `discrim_kwargs` everywhere is renamed to `discrim_net_kwargs` for consistency with `reward_net_kwargs`.