### PR TITLE
Limit random uuid in unique timestamp to len 6

### DIFF
--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -20,7 +20,7 @@ def make_unique_timestamp() -> str:
     """Timestamp, with random uuid added to avoid collisions."""
     ISO_TIMESTAMP = "%Y%m%d_%H%M%S"
     timestamp = datetime.datetime.now().strftime(ISO_TIMESTAMP)
-    random_uuid = uuid.uuid4().hex
+    random_uuid = uuid.uuid4().hex[:6]
     return f"{timestamp}_{random_uuid}"
 
 


### PR DESCRIPTION
Old format:
`log_dir = '/scratch/steven/imit/DEBUG_GAIL2/Humanoid-v2/20200618_150958_9f7f8f71b6f149d8b6f1dc7ea684ea51`

New format:
`log_dir = '/scratch/steven/imit/DEBUG_GAIL2/Humanoid-v2/20200618_150958_9f7f8f'`


Should be sufficiently unique given the timestamp, and makes Tensorboard more readable.