### PR TITLE
Use Stable Baselines master to fix pickle error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,10 @@ setup(
         "numpy>=1.15",
         "tqdm",
         "scikit-learn>=0.21.2",
-        "stable-baselines~=2.10.0",
+        # TODO(shwang): Stop using GitHub pointer once
+        # https://github.com/hill-a/stable-baselines/pull/935 is part of Stable
+        # Baselines release.
+        "stable-baselines @ git+https://github.com/hill-a/stable-baselines.git",
         "jax~=0.1.66",
         "jaxlib~=0.1.47",
         "sacred~=0.8.1",


### PR DESCRIPTION
Some of our Ray-based tests were failing due to https://github.com/hill-a/stable-baselines/issues/937 .

We're planning on pointing to Stable Baselines master until we've migrated to SB3, or when https://github.com/hill-a/stable-baselines/pull/935 is on PyPI (probably as stable-baselines v2.11).