### PR TITLE
train_adversarial: Use correct eval environment

### DIFF
--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -201,7 +201,7 @@ def train(
     results = {}
     sample_until_eval = rollout.min_episodes(n_episodes_eval)
     trajs = rollout.generate_trajectories(
-        trainer.gen_algo, trainer.venv_test, sample_until=sample_until_eval
+        trainer.gen_algo, trainer.venv_train_norm, sample_until=sample_until_eval
     )
     results["expert_stats"] = rollout.rollout_stats(expert_trajs)
     results["imit_stats"] = rollout.rollout_stats(trajs)


### PR DESCRIPTION
Final evaluation environment used to be unnormalized, leading to
Sacred reporting worse final performance than actual.