### PR TITLE
Script fixes

### DIFF
--- a/src/imitation/data/types.py
+++ b/src/imitation/data/types.py
@@ -3,6 +3,7 @@
 import dataclasses
 import logging
 import os
+import pathlib
 import pickle
 from typing import Optional, Sequence
 
@@ -210,7 +211,8 @@ def save(path: str, trajectories: Sequence[TrajectoryWithRew]) -> None:
         path: Trajectories are saved to this path.
         trajectories: The trajectories to save.
     """
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    p = pathlib.Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
     with open(path + ".tmp", "wb") as f:
         pickle.dump(trajectories, f)
     # Ensure atomic write

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -73,7 +73,6 @@ def aliases_default_gen_batch_size(algorithm_kwargs, gen_batch_size):
 
 @train_ex.config
 def calc_n_steps(num_vec, gen_batch_size):
-    assert gen_batch_size % num_vec == 0, "num_vec must evenly divide gen_batch_size"
     init_rl_kwargs = dict(n_steps=gen_batch_size // num_vec)
 
 

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -65,12 +65,17 @@ def parallel(
         upload_dir: `upload_dir` argument to `ray.tune.run()`.
     """
     # Basic validation for config options before we enter parallel jobs.
-    for name in base_named_configs:
-        assert isinstance(name, str)
-    for k in base_config_updates:
-        assert isinstance(k, str)
-    assert isinstance(search_space["named_configs"], collections.abc.Sequence)
-    assert isinstance(search_space["config_updates"], collections.abc.Mapping)
+    if not isinstance(base_named_configs, collections.abc.Sequence):
+        raise ValueError("base_named_configs must be a Sequence")
+
+    if not isinstance(base_config_updates, collections.abc.Mapping):
+        raise ValueError("base_config_updates must be a Mapping")
+
+    if not isinstance(search_space["named_configs"], collections.abc.Sequence):
+        raise ValueError('search_space["named_configs"] must be a Sequence')
+
+    if not isinstance(search_space["config_updates"], collections.abc.Mapping):
+        raise ValueError('search_space["config_updates"] must be a Mapping')
 
     # Convert Sacred's ReadOnlyList to List because not picklable.
     base_named_configs = list(base_named_configs)

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -66,16 +66,16 @@ def parallel(
     """
     # Basic validation for config options before we enter parallel jobs.
     if not isinstance(base_named_configs, collections.abc.Sequence):
-        raise ValueError("base_named_configs must be a Sequence")
+        raise TypeError("base_named_configs must be a Sequence")
 
     if not isinstance(base_config_updates, collections.abc.Mapping):
-        raise ValueError("base_config_updates must be a Mapping")
+        raise TypeError("base_config_updates must be a Mapping")
 
     if not isinstance(search_space["named_configs"], collections.abc.Sequence):
-        raise ValueError('search_space["named_configs"] must be a Sequence')
+        raise TypeError('search_space["named_configs"] must be a Sequence')
 
     if not isinstance(search_space["config_updates"], collections.abc.Mapping):
-        raise ValueError('search_space["config_updates"] must be a Mapping')
+        raise TypeError('search_space["config_updates"] must be a Mapping')
 
     # Convert Sacred's ReadOnlyList to List because not picklable.
     base_named_configs = list(base_named_configs)

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -172,11 +172,11 @@ def train(
     # else:
     #     tensorboard_log = None
 
-    # TODO(shwang): Let's get rid of init_rl later on?
-    # It's really just a stub function now.
     gen_algo = util.init_rl(
         # FIXME(sam): ignoring tensorboard_log is a hack to prevent SB3 from
         # re-configuring the logger (SB3 issue #109). See init_rl() for details.
+        # TODO(shwang): Let's get rid of init_rl after SB3 issue #109 is fixed?
+        # Otherwise init_rl is just a stub function.
         venv,
         **init_rl_kwargs,
     )

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -176,7 +176,7 @@ def train(
         # FIXME(sam): ignoring tensorboard_log is a hack to prevent SB3 from
         # re-configuring the logger (SB3 issue #109). See init_rl() for details.
         # TODO(shwang): Let's get rid of init_rl after SB3 issue #109 is fixed?
-        # Otherwise init_rl is just a stub function.
+        # Besides sidestepping #109, init_rl is just a stub function.
         venv,
         **init_rl_kwargs,
     )

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -51,6 +51,7 @@ def train(
     n_episodes_eval: int,
     init_tensorboard: bool,
     checkpoint_interval: int,
+    gen_batch_size: int,
     init_rl_kwargs: Mapping,
     algorithm_kwargs: Mapping[str, Mapping],
     discrim_net_kwargs: Mapping[str, Mapping],
@@ -92,6 +93,9 @@ def train(
             `checkpoint_interval` epochs and after training is complete. If 0,
             then only save weights after training is complete. If <0, then don't
             save weights at all.
+        gen_batch_size: Batch size for generator updates. Sacred automatically uses
+            this to calculate `n_steps` in `init_rl_kwargs`. In the script body, this
+            is only used in sanity checks.
         init_rl_kwargs: Keyword arguments for `init_rl`, the RL algorithm initialization
             utility function.
         algorithm_kwargs: Keyword arguments for the `GAIL` or `AIRL` constructor
@@ -117,19 +121,42 @@ def train(
         "monitor_return" key). "expert_stats" gives the return value of
         `rollout_stats()` on the expert demonstrations loaded from `rollout_path`.
     """
-    assert os.path.exists(rollout_path)
+    if gen_batch_size % num_vec != 0:
+        raise ValueError(
+            f"num_vec={num_vec} must evenly divide gen_batch_size={gen_batch_size}."
+        )
+
+    allowed_keys = {"shared", "gail", "airl"}
+    if not discrim_net_kwargs.keys() <= allowed_keys:
+        raise ValueError(
+            f"Invalid discrim_net_kwargs.keys()={discrim_net_kwargs.keys()}. "
+            f"Allowed keys: {allowed_keys}"
+        )
+    if not algorithm_kwargs.keys() <= allowed_keys:
+        raise ValueError(
+            f"Invalid discrim_net_kwargs.keys()={algorithm_kwargs.keys()}. "
+            f"Allowed keys: {allowed_keys}"
+        )
+
+    if not os.path.exists(rollout_path):
+        raise ValueError(f"File at rollout_path={rollout_path} does not exist.")
+
+    expert_trajs = types.load(rollout_path)
+    if n_expert_demos is not None:
+        if not len(expert_trajs) >= n_expert_demos:
+            raise ValueError(
+                f"Want to use n_expert_demos={n_expert_demos} trajectories, but only "
+                f"{len(expert_trajs)} are available via {rollout_path}."
+            )
+        expert_trajs = expert_trajs[:n_expert_demos]
+    expert_transitions = rollout.flatten_trajectories(expert_trajs)
+
     total_timesteps = int(total_timesteps)
 
     logging.info("Logging to %s", log_dir)
     logger.configure(log_dir, ["tensorboard", "stdout"])
     os.makedirs(log_dir, exist_ok=True)
     sacred_util.build_sacred_symlink(log_dir, _run)
-
-    expert_trajs = types.load(rollout_path)
-    if n_expert_demos is not None:
-        assert len(expert_trajs) >= n_expert_demos
-        expert_trajs = expert_trajs[:n_expert_demos]
-    expert_transitions = rollout.flatten_trajectories(expert_trajs)
 
     venv = util.make_vec_env(
         env_name,
@@ -140,25 +167,19 @@ def train(
         max_episode_steps=max_episode_steps,
     )
 
-    # TODO(shwang): Let's get rid of init_rl later on?
-    # It's really just a stub function now.
-
     # if init_tensorboard:
     #     tensorboard_log = osp.join(log_dir, "sb_tb")
     # else:
     #     tensorboard_log = None
 
+    # TODO(shwang): Let's get rid of init_rl later on?
+    # It's really just a stub function now.
     gen_algo = util.init_rl(
         # FIXME(sam): ignoring tensorboard_log is a hack to prevent SB3 from
         # re-configuring the logger (SB3 issue #109). See init_rl() for details.
         venv,
         **init_rl_kwargs,
     )
-
-    # Convert Sacred's ReadOnlyDict to dict so we can modify it.
-    allowed_keys = {"shared", "gail", "airl"}
-    assert discrim_net_kwargs.keys() <= allowed_keys
-    assert algorithm_kwargs.keys() <= allowed_keys
 
     discrim_kwargs_shared = discrim_net_kwargs.get("shared", {})
     discrim_kwargs_algo = discrim_net_kwargs.get(algorithm, {})

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -284,24 +284,24 @@ def test_parallel(config_updates):
     assert run.status == "COMPLETED"
 
 
-def test_parallel_value_errors(tmpdir):
+def test_parallel_arg_errors(tmpdir):
     """Error on bad algorithm arguments."""
     base_named_configs = ["debug_log_root"]
     base_config_updates = collections.ChainMap(PARALLEL_CONFIG_LOW_RESOURCE)
 
-    with pytest.raises(ValueError, match=".*Sequence.*"):
+    with pytest.raises(TypeError, match=".*Sequence.*"):
         parallel.parallel_ex.run(
             named_configs=base_named_configs,
             config_updates=base_config_updates.new_child(dict(base_named_configs={})),
         )
 
-    with pytest.raises(ValueError, match=".*Mapping.*"):
+    with pytest.raises(TypeError, match=".*Mapping.*"):
         parallel.parallel_ex.run(
             named_configs=base_named_configs,
             config_updates=base_config_updates.new_child(dict(base_config_updates=())),
         )
 
-    with pytest.raises(ValueError, match=".*Sequence.*"):
+    with pytest.raises(TypeError, match=".*Sequence.*"):
         parallel.parallel_ex.run(
             named_configs=base_named_configs,
             config_updates=base_config_updates.new_child(
@@ -309,7 +309,7 @@ def test_parallel_value_errors(tmpdir):
             ),
         )
 
-    with pytest.raises(ValueError, match=".*Mapping.*"):
+    with pytest.raises(TypeError, match=".*Mapping.*"):
         parallel.parallel_ex.run(
             named_configs=base_named_configs,
             config_updates=base_config_updates.new_child(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -5,6 +5,7 @@ codecov might interact poorly with multiprocessing. The 'fast' named_config for 
 experiment implicitly sets parallel=False.
 """
 
+import collections
 import os.path as osp
 import sys
 import tempfile
@@ -136,18 +137,51 @@ def test_train_adversarial(tmpdir):
     _check_train_ex_result(run.result)
 
 
-def test_train_adversarial_algorithm_config_error(tmpdir):
+def test_train_adversarial_algorithm_value_error(tmpdir):
     """Error on bad algorithm arguments."""
-    named_configs = ["cartpole", "fast"]
-    config_updates = {
-        "log_root": tmpdir,
-        "rollout_path": "tests/data/expert_models/cartpole_0/rollouts/final.pkl",
-        "algorithm": "BAD_VALUE",
-    }
+    base_named_configs = ["cartpole", "fast"]
+    base_config_updates = collections.ChainMap(
+        {
+            "log_root": tmpdir,
+            "rollout_path": "tests/data/expert_models/cartpole_0/rollouts/final.pkl",
+        }
+    )
+
     with pytest.raises(ValueError, match=".*BAD_VALUE.*"):
         train_adversarial.train_ex.run(
-            named_configs=named_configs,
-            config_updates=config_updates,
+            named_configs=base_named_configs,
+            config_updates=base_config_updates.new_child(dict(algorithm="BAD_VALUE")),
+        )
+
+    with pytest.raises(ValueError, match=".*BAD_VALUE.*"):
+        train_adversarial.train_ex.run(
+            named_configs=base_named_configs,
+            config_updates=base_config_updates.new_child(
+                dict(discrim_net_kwargs={"BAD_VALUE": "bar"})
+            ),
+        )
+
+    with pytest.raises(ValueError, match=".*BAD_VALUE.*"):
+        train_adversarial.train_ex.run(
+            named_configs=base_named_configs,
+            config_updates=base_config_updates.new_child(
+                dict(algorithm_kwargs={"BAD_VALUE": "bar"})
+            ),
+        )
+
+    with pytest.raises(ValueError, match=".*BAD_VALUE.*"):
+        train_adversarial.train_ex.run(
+            named_configs=base_named_configs,
+            config_updates=base_config_updates.new_child(
+                dict(rollout_path="path/BAD_VALUE")
+            ),
+        )
+
+    n_traj = 1234567
+    with pytest.raises(ValueError, match=f".*{n_traj}.*"):
+        train_adversarial.train_ex.run(
+            named_configs=base_named_configs,
+            config_updates=base_config_updates.new_child(dict(n_expert_demos=n_traj)),
         )
 
 
@@ -248,6 +282,40 @@ def test_parallel(config_updates):
         named_configs=["debug_log_root"], config_updates=config_updates
     )
     assert run.status == "COMPLETED"
+
+
+def test_parallel_value_errors(tmpdir):
+    """Error on bad algorithm arguments."""
+    base_named_configs = ["debug_log_root"]
+    base_config_updates = collections.ChainMap(PARALLEL_CONFIG_LOW_RESOURCE)
+
+    with pytest.raises(ValueError, match=".*Sequence.*"):
+        parallel.parallel_ex.run(
+            named_configs=base_named_configs,
+            config_updates=base_config_updates.new_child(dict(base_named_configs={})),
+        )
+
+    with pytest.raises(ValueError, match=".*Mapping.*"):
+        parallel.parallel_ex.run(
+            named_configs=base_named_configs,
+            config_updates=base_config_updates.new_child(dict(base_config_updates=())),
+        )
+
+    with pytest.raises(ValueError, match=".*Sequence.*"):
+        parallel.parallel_ex.run(
+            named_configs=base_named_configs,
+            config_updates=base_config_updates.new_child(
+                dict(search_space={"named_configs": {}})
+            ),
+        )
+
+    with pytest.raises(ValueError, match=".*Mapping.*"):
+        parallel.parallel_ex.run(
+            named_configs=base_named_configs,
+            config_updates=base_config_updates.new_child(
+                dict(search_space={"config_updates": ()})
+            ),
+        )
 
 
 def _generate_test_rollouts(tmpdir: str, env_named_config: str) -> str:


### PR DESCRIPTION
Change assert statements in Sacred scripts and config files to
ValueErrors in Sacred scripts. Fix expert_demos bug where
`rollout_path` errored if argument did not contain "/".

Addresses part of #215. Resolves #218.