### PR TITLE
Adversarial.gen_batch_size: Fix vec scaling bug

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -23,7 +23,7 @@ with open("tests/data/expert_models/cartpole_0/rollouts/final.pkl", "rb") as f:
 # (observation, actions, next_observation) transitions.
 transitions = rollout.flatten_trajectories(trajectories)
 
-venv = util.make_vec_env("CartPole-v1")
+venv = util.make_vec_env("CartPole-v1", n_envs=2)
 
 tempdir = tempfile.TemporaryDirectory(prefix="quickstart")
 tempdir_path = pathlib.Path(tempdir.name)
@@ -40,7 +40,7 @@ gail_trainer = adversarial.GAIL(
     venv,
     expert_data=transitions,
     expert_batch_size=32,
-    gen_algo=sb3.PPO("MlpPolicy", venv, verbose=1),
+    gen_algo=sb3.PPO("MlpPolicy", venv, verbose=1, n_steps=1024),
 )
 gail_trainer.train(total_timesteps=2048)
 
@@ -50,6 +50,6 @@ airl_trainer = adversarial.AIRL(
     venv,
     expert_data=transitions,
     expert_batch_size=32,
-    gen_algo=sb3.PPO("MlpPolicy", venv, verbose=1),
+    gen_algo=sb3.PPO("MlpPolicy", venv, verbose=1, n_steps=1024),
 )
 airl_trainer.train(total_timesteps=2048)

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -178,7 +178,7 @@ class AdversarialTrainer:
 
     @property
     def gen_batch_size(self) -> int:
-        return self.gen_algo.n_steps * self.venv.num_envs
+        return self.gen_algo.n_steps * self.gen_algo.get_env().num_envs
 
     def train_disc(
         self,

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -178,9 +178,7 @@ class AdversarialTrainer:
 
     @property
     def gen_batch_size(self) -> int:
-        # TODO(shwang): Is `n_steps` really the generator batch size? Isn't the batch
-        #  size actually `n_steps` * `n_vec`? I'm surprised that this works.
-        return self.gen_algo.n_steps
+        return self.gen_algo.n_steps * self.venv.num_envs
 
     def train_disc(
         self,

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -235,8 +235,9 @@ def fast():
 
     Useful for test cases.
     """
-    # need a minimum of 5 total_timesteps for adversarial training code to run
-    total_timesteps = 5
+    # Need a minimum of 10 total_timesteps for adversarial training code to pass
+    # "any update happened" assertion inside training loop.
+    total_timesteps = 10
     n_expert_demos = 1
     n_episodes_eval = 1
     algorithm_kwargs = dict(

--- a/tests/test_mountain_car_plots.py
+++ b/tests/test_mountain_car_plots.py
@@ -78,12 +78,11 @@ def test_batch_reward_heatmaps(trajs, tmpdir, rand_policy):
     # Generate reward function and generator policy checkpoints.
     log_dir = tmpdir / "train_adversarial"
     run = train_adversarial.train_ex.run(
-        named_configs=["mountain_car"],
+        named_configs=["mountain_car", "fast"],
         config_updates=dict(
             rollout_path=rollout_path,
             checkpoint_interval=1,
             log_dir=(tmpdir / "train_adversarial"),
-            total_timesteps=256,
         ),
     )
     assert run.status == "COMPLETED"


### PR DESCRIPTION
Fixes #234.

Along the way I had to change some default batch sizes and training timesteps to prevent an "`AdversarialTrainer.train()` is a no-op because too few steps" error from firing. (This assertion used to be erroneously based on a lower `gen_batch_size`.)