### PR TITLE
Remove device= kwarg from policies, update SB3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ commands:
           # Build a wheel then install to avoid copying whole directory (pip issue #2195)
           command: |
             python setup.py sdist bdist_wheel
-            pip install --upgrade dist/imitation-*.whl
+            pip install --upgrade --force-reinstall --no-deps dist/imitation-*.whl
 
 jobs:
   lintandtype:

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "torch>=1.4.0",
         "tqdm",
         "scikit-learn>=0.21.2",
-        "stable-baselines3~=0.8.0",
+        "stable-baselines3~=0.10.0",
         "jax~=0.1.66",
         "jaxlib~=0.1.47",
         "sacred~=0.8.1",

--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -193,7 +193,6 @@ class BC:
             observation_space=self.observation_space,
             action_space=self.action_space,
             lr_schedule=ConstantLRSchedule(),
-            device=self.device,
         )
         self.policy_kwargs.update(policy_kwargs or {})
         self.device = utils.get_device(device)

--- a/src/imitation/policies/base.py
+++ b/src/imitation/policies/base.py
@@ -15,7 +15,6 @@ class HardCodedPolicy(policies.BasePolicy, abc.ABC):
         super().__init__(
             observation_space=observation_space,
             action_space=action_space,
-            device=th.device("cpu"),
         )
 
     def _predict(self, obs: th.Tensor, deterministic: bool = False):

--- a/src/imitation/policies/serialize.py
+++ b/src/imitation/policies/serialize.py
@@ -42,6 +42,7 @@ class NormalizePolicy(policies.BasePolicy):
         super().__init__(
             observation_space=policy.observation_space,
             action_space=policy.action_space,
+            # innocuous comment to test CI
         )
         self._policy = policy
         self.vec_normalize = vec_normalize

--- a/src/imitation/policies/serialize.py
+++ b/src/imitation/policies/serialize.py
@@ -42,7 +42,6 @@ class NormalizePolicy(policies.BasePolicy):
         super().__init__(
             observation_space=policy.observation_space,
             action_space=policy.action_space,
-            # innocuous comment to test CI
         )
         self._policy = policy
         self.vec_normalize = vec_normalize

--- a/src/imitation/policies/serialize.py
+++ b/src/imitation/policies/serialize.py
@@ -42,7 +42,6 @@ class NormalizePolicy(policies.BasePolicy):
         super().__init__(
             observation_space=policy.observation_space,
             action_space=policy.action_space,
-            device=policy.device,
         )
         self._policy = policy
         self.vec_normalize = vec_normalize


### PR DESCRIPTION
Changes:

- No longer supplies the `device=` keyword argument to policies, since this was removed after SB3 0.8.
- Updates SB3 to 0.10.

Fixes #254.