### PR TITLE
Fix observation normalization

### DIFF
--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -271,6 +271,7 @@ class AdversarialTrainer:
                 **learn_kwargs,
             )
             self._global_step += 1
+            self.venv_wrapped.log_callback(logger)
 
         gen_samples = self.venv_buffering.pop_transitions()
         self._gen_replay_buffer.store(gen_samples)

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -379,18 +379,17 @@ class AdversarialTrainer:
         assert n_gen == len(gen_samples["acts"])
         assert n_gen == len(gen_samples["next_obs"])
 
-        # Policy and reward network were trained on normalized observations.
-        expert_obs_norm = self.venv_train_norm.normalize_obs(expert_samples["obs"])
-        gen_obs_norm = self.venv_train_norm.normalize_obs(gen_samples["obs"])
-
         # Concatenate rollouts, and label each row as expert or generator.
-        obs = np.concatenate([expert_obs_norm, gen_obs_norm])
+        obs = np.concatenate([expert_samples["obs"], gen_samples["obs"]])
         acts = np.concatenate([expert_samples["acts"], gen_samples["acts"]])
         next_obs = np.concatenate([expert_samples["next_obs"], gen_samples["next_obs"]])
         dones = np.concatenate([expert_samples["dones"], gen_samples["dones"]])
         labels_gen_is_one = np.concatenate(
             [np.zeros(n_expert, dtype=int), np.ones(n_gen, dtype=int)]
         )
+        # Policy and reward network were trained on normalized observations.
+        obs = self.venv_train_norm.normalize_obs(obs)
+        next_obs = self.venv_train_norm.normalize_obs(next_obs)
 
         # Calculate generator-policy log probabilities.
         with th.no_grad():

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -31,7 +31,7 @@ def save(trainer, save_path):
     serialize.save_stable_model(
         os.path.join(save_path, "gen_policy"),
         trainer.gen_algo,
-        trainer.venv_train_norm,
+        trainer.venv_norm_obs,
     )
 
 
@@ -222,7 +222,7 @@ def train(
     results = {}
     sample_until_eval = rollout.min_episodes(n_episodes_eval)
     trajs = rollout.generate_trajectories(
-        trainer.gen_algo, trainer.venv_train_norm, sample_until=sample_until_eval
+        trainer.gen_algo, trainer.venv_train, sample_until=sample_until_eval
     )
     results["expert_stats"] = rollout.rollout_stats(expert_trajs)
     results["imit_stats"] = rollout.rollout_stats(trajs)

--- a/src/imitation/util/reward_wrapper.py
+++ b/src/imitation/util/reward_wrapper.py
@@ -40,7 +40,7 @@ class RewardVecEnvWrapper(vec_env.VecEnvWrapper):
         if len(self.episode_rewards) == 0:
             return
         mean = sum(self.episode_rewards) / len(self.episode_rewards)
-        logger.record("eprewmean_wrapped", mean)
+        logger.record("rollout/wrapped_eprewmean", mean)
 
     @property
     def envs(self):

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -162,7 +162,7 @@ def test_train_disc_improve_D(
     expert_samples = types.dataclass_quick_asdict(expert_samples)
     gen_samples = rollout.generate_transitions(
         trainer.gen_algo,
-        trainer.venv_train_norm,
+        trainer.venv_train,
         n_timesteps=expert_batch_size,
         truncate=True,
     )


### PR DESCRIPTION
*Changes*

1) The current implementation of AdversarialTrainer only normalizes the `obs` component, not the `next_obs` component.

    Our base reward networks don't use `next_obs` by default, so this is not as bad as it seems, but we do use it for potential shaping. This is problematic since this inconsistent normalization makes it no longer be potential shaping, and does actually change the optimal policy.

2) `VecNormalize` was applied *after* reward wrapping. So `DiscrimNet.predict_train_reward` gets called on un-normalized observations. Yet we train the discriminator on normalized observations!

    I've swapped the order, so we normalize observations first. I introduce another `VecNormalize` to normalize (and clip) rewards but not observations after the wrapped reward.

3) I added keyword arguments that let you control whether to normalize observations or rewards. There are some environments in particular where normalizing observations is unnecessary or undesirable (e.g. Atari).

4) I deleted `venv_test` since it is not used anywhere and complicates the code. I think it is plausible that we should in fact be using it somewhere, it looks like `train_adversarial` used to use it for the final rollout stage but that got swapped to `venv_train` sometime during the port.

5) I also deleted `device` in `AdversarialTrainer` which is unused. Maybe we should make it do something, but if it does nothing its inclusion is just confusing.

*Benchmark*

Running `train_adversarial` with the default config on CartPole, I got:
  - Before the change
    - GAIL: Seed 1: 379 SD 33.5. Seed 2: 500 SD 0.0. Seed 3: 381 SD 22.8.
    - AIRL: Seed 1: 8.73 SD 0.54. Seed 2: 8.84 SD 0.49. Seed 3: 9.17 SD 0.76.
  - After the change
    - GAIL: Seed 1: 438 SD 26. Seed 2: 500 SD 0.0. Seed 3: 500.0 SD 0.0.
    - AIRL: Seed 1: 9.5 SD 0.70 (but it did peak at around ~100 part way through training). Seed 2: 497 SD 12.8. Seed 3: 18.52 SD 6.5.

Of course `CartPole-v1` is a stupid evaluation environment since if the discriminator happens to be the right sign then RL will learn the right policy. (I would not be surprised if this is why it works with AIRL some of the time given how high variance this is.) Still, the changes have certainly not made training performance any worse, and it seems like it may be a bit more stable.

I tried to get it working with `seals/CartPole-v0` which is fixed horizon but couldn't. Might just need more timesteps or other hyperparameters tweaked. Since even RL training on the ground-truth is a lot slower in that environment.