### PR TITLE
Migrate to new SB callback API

### DIFF
--- a/experiments/download_models.sh
+++ b/experiments/download_models.sh
@@ -49,4 +49,4 @@ elif [[ -d "${DATA_DIR}" ]]; then
   rm -r "${DATA_DIR}"
 fi
 
-aws s3 sync "${FLAGS[@]}" s3://shwang-chai/public/data/ "${DATA_DIR}"
+aws --no-sign-request s3 sync "${FLAGS[@]}" s3://shwang-chai/public/data/ "${DATA_DIR}"

--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -169,7 +169,7 @@ class AdversarialTrainer:
             self.venv_wrapped = reward_wrapper.RewardVecEnvWrapper(
                 self.venv_norm_obs, self.discrim.predict_reward_train
             )
-            self.gen_callback = self.venv_wrapped.log_callback
+            self.gen_callback = self.venv_wrapped.make_log_callback()
         self.venv_train = vec_env.VecNormalize(
             self.venv_wrapped, norm_obs=False, norm_reward=normalize_reward
         )
@@ -277,12 +277,10 @@ class AdversarialTrainer:
             self.gen_algo.learn(
                 total_timesteps=total_timesteps,
                 reset_num_timesteps=False,
+                callback=self.gen_callback,
                 **learn_kwargs,
             )
             self._global_step += 1
-
-            if self.gen_callback:
-                self.gen_callback(logger)
 
         gen_samples = self.venv_buffering.pop_transitions()
         self._gen_replay_buffer.store(gen_samples)

--- a/src/imitation/envs/resettable_env.py
+++ b/src/imitation/envs/resettable_env.py
@@ -126,7 +126,10 @@ class TabularModelEnv(ResettableEnv, abc.ABC):
         # Construct spaces lazily, so they can depend on properties in subclasses.
         if self._observation_space is None:
             self._observation_space = spaces.Box(
-                low=float("-inf"), high=float("inf"), shape=(self.obs_dim,)
+                low=float("-inf"),
+                high=float("inf"),
+                shape=(self.obs_dim,),
+                dtype=self.obs_dtype,
             )
         return self._observation_space
 
@@ -179,6 +182,11 @@ class TabularModelEnv(ResettableEnv, abc.ABC):
     def obs_dim(self):
         """Size of observation vectors for this MDP."""
         return self.observation_matrix.shape[1]
+
+    @property
+    def obs_dtype(self):
+        """Data type of observation vectors (e.g. np.float32)."""
+        return self.observation_matrix.dtype
 
     # ############################### #
     # METHODS THAT MUST BE OVERRIDDEN #

--- a/src/imitation/scripts/config/expert_demos.py
+++ b/src/imitation/scripts/config/expert_demos.py
@@ -25,12 +25,11 @@ def expert_demos_defaults():
     reward_type = None  # override reward type
     reward_path = None  # override reward path
 
-    rollout_save_interval = -1  # Num updates between saves (<=0 disables)
     rollout_save_final = True  # If True, save after training is finished.
     rollout_save_n_timesteps = None  # Min timesteps saved per file, optional.
     rollout_save_n_episodes = None  # Num episodes saved per file, optional.
 
-    policy_save_interval = 2000  # Num updates between saves (<=0 disables)
+    policy_save_interval = 10000  # Num timesteps between saves (<=0 disables)
     policy_save_final = True  # If True, save after training is finished.
 
     init_tensorboard = False  # If True, then write Tensorboard logs.

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -17,25 +17,6 @@ from imitation.util import logger, util
 from imitation.util.reward_wrapper import RewardVecEnvWrapper
 
 
-class SavePolicyCallback(callbacks.EventCallback):
-    def __init__(
-        self, policy_dir: str, vec_normalize: Optional[VecNormalize], *args, **kwargs
-    ):
-        """Builds SavePolicyCallback.
-
-        Args:
-            policy_dir: Directory to save checkpoints.
-            vec_normalize: VecNormalize object to save alongside policy.
-        """
-        super().__init__(*args, **kwargs)
-        self.policy_dir = policy_dir
-        self.vec_normalize = vec_normalize
-
-    def _on_step(self) -> bool:
-        output_dir = osp.join(self.policy_dir, f"{self.num_timesteps:012d}")
-        serialize.save_stable_model(output_dir, self.model, self.vec_normalize)
-
-
 @expert_demos_ex.main
 def rollouts_and_policy(
     _run,
@@ -169,7 +150,7 @@ def rollouts_and_policy(
     policy = util.init_rl(venv, verbose=1, **init_rl_kwargs)
 
     if policy_save_interval > 0:
-        save_policy_callback = SavePolicyCallback(policy_dir, vec_normalize)
+        save_policy_callback = serialize.SavePolicyCallback(policy_dir, vec_normalize)
         save_policy_callback = callbacks.EveryNTimesteps(
             policy_save_interval, save_policy_callback
         )

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -147,8 +147,6 @@ def rollouts_and_policy(
     if normalize:
         venv = vec_normalize = VecNormalize(venv, **normalize_kwargs)
 
-    policy = util.init_rl(venv, verbose=1, **init_rl_kwargs)
-
     if policy_save_interval > 0:
         save_policy_callback = serialize.SavePolicyCallback(policy_dir, vec_normalize)
         save_policy_callback = callbacks.EveryNTimesteps(
@@ -157,6 +155,7 @@ def rollouts_and_policy(
         callback_objs.append(save_policy_callback)
     callback = callbacks.CallbackList(callback_objs)
 
+    policy = util.init_rl(venv, verbose=1, **init_rl_kwargs)
     policy.learn(total_timesteps, callback=callback)
 
     # Save final artifacts after training is complete.

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 from sacred.observers import FileStorageObserver
 from stable_baselines3.common import callbacks
-from stable_baselines3.common import logger as sb_logger
 from stable_baselines3.common.vec_env import VecNormalize
 
 import imitation.util.sacred as sacred_util
@@ -140,7 +139,7 @@ def rollouts_and_policy(
     if reward_type is not None:
         reward_fn = load_reward(reward_type, reward_path, venv)
         venv = RewardVecEnvWrapper(venv, reward_fn)
-        callback_objs.append(venv.make_log_callback(sb_logger))
+        callback_objs.append(venv.make_log_callback())
         logging.info(f"Wrapped env in reward {reward_type} from {reward_path}.")
 
     vec_normalize = None

--- a/src/imitation/util/reward_wrapper.py
+++ b/src/imitation/util/reward_wrapper.py
@@ -4,7 +4,7 @@ import collections
 from typing import Deque
 
 import numpy as np
-from stable_baselines3.common import callbacks, logger, vec_env
+from stable_baselines3.common import callbacks, vec_env
 
 from imitation.rewards import common
 
@@ -12,11 +12,8 @@ from imitation.rewards import common
 class WrappedRewardCallback(callbacks.BaseCallback):
     """Logs mean wrapped reward as part of RL (or other) training."""
 
-    def __init__(
-        self, episode_rewards: Deque[float], log_obj: logger.Logger, *args, **kwargs
-    ):
+    def __init__(self, episode_rewards: Deque[float], *args, **kwargs):
         self.episode_rewards = episode_rewards
-        self.log_obj = log_obj
         super().__init__(self, *args, **kwargs)
 
     def _on_step(self) -> bool:
@@ -57,9 +54,9 @@ class RewardVecEnvWrapper(vec_env.VecEnvWrapper):
         self.reward_fn = reward_fn
         self.reset()
 
-    def make_log_callback(self, log_obj: logger.Logger) -> WrappedRewardCallback:
+    def make_log_callback(self) -> WrappedRewardCallback:
         """Creates `WrappedRewardCallback` connected to this `RewardVecEnvWrapper`."""
-        return WrappedRewardCallback(self.episode_rewards, log_obj)
+        return WrappedRewardCallback(self.episode_rewards)
 
     @property
     def envs(self):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -69,7 +69,6 @@ def test_expert_demos_rollouts_from_policy(tmpdir):
         config_updates=dict(
             log_root=tmpdir,
             rollout_save_path=osp.join(tmpdir, "rollouts", "test.pkl"),
-            rollout_save_interval=1,
             policy_path="tests/data/expert_models/cartpole_0/policies/final/",
         ),
     )
@@ -322,7 +321,6 @@ def _generate_test_rollouts(tmpdir: str, env_named_config: str) -> str:
     expert_demos.expert_demos_ex.run(
         named_configs=[env_named_config, "fast"],
         config_updates=dict(
-            rollout_save_interval=0,
             log_dir=tmpdir,
         ),
     )


### PR DESCRIPTION
This PR replaces the old-style function callback used for SB `train` with the new-style class callback. This has the following semantic changes:
    - `policy_save_interval` now controls how many *timesteps* the policy gets saved, not the number of epochs. (The functional callback was de facto based on something approximately equal to timesteps, since it got called on each rollout timestep as well, but that was not the intention nor the old-style behaviour.)
    - `RewardVecEnvWrapper` callback now only gets called at the start of each rollout, which (at least for PPO) should correspond with each time the log gets printed. Previously it was getting called at each timestep.
    - I deleted the functionality to save rollouts except at the end of training. The way it was previously implemented I think could interfere with training, since it does rollouts in the *same* environment as training. To avoid this we'd need to use a separate evaluation environment, with `VecNormalize` statistics set up to match, which is possible but non-trivial. The functionality is disabled by default and I've not seen us ever use it, so it seemed easiest to delete it. But I can implement it properly if there's enough demand.

I haven't done any benchmarking but this should speed things up a bit, and more importantly avoid creating GBs of near-identical policy checkpoints each time we run this script :)