### PR TITLE
[TF, v0.1] Bugfixes, including for new log callback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
           # Build a wheel then install to avoid copying whole directory (pip issue #2195)
           command: |
             python setup.py sdist bdist_wheel
-            pip install --upgrade dist/imitation-*.whl
+            pip install --upgrade --force-reinstall --no-deps dist/imitation-*.whl
 
 jobs:
   lintandtype:

--- a/src/imitation/envs/resettable_env.py
+++ b/src/imitation/envs/resettable_env.py
@@ -185,7 +185,7 @@ class TabularModelEnv(ResettableEnv, abc.ABC):
 
     @property
     def obs_dtype(self):
-        """Data type of observation."""
+        """Data type of observation vectors (e.g. np.float32)."""
         return self.observation_matrix.dtype
 
     # ############################### #

--- a/src/imitation/envs/resettable_env.py
+++ b/src/imitation/envs/resettable_env.py
@@ -126,7 +126,10 @@ class TabularModelEnv(ResettableEnv, abc.ABC):
         # Construct spaces lazily, so they can depend on properties in subclasses.
         if self._observation_space is None:
             self._observation_space = spaces.Box(
-                low=float("-inf"), high=float("inf"), shape=(self.obs_dim,)
+                low=float("-inf"),
+                high=float("inf"),
+                shape=(self.obs_dim,),
+                dtype=self.obs_dtype,
             )
         return self._observation_space
 
@@ -179,6 +182,11 @@ class TabularModelEnv(ResettableEnv, abc.ABC):
     def obs_dim(self):
         """Size of observation vectors for this MDP."""
         return self.observation_matrix.shape[1]
+
+    @property
+    def obs_dtype(self):
+        """Data type of observation."""
+        return self.observation_matrix.dtype
 
     # ############################### #
     # METHODS THAT MUST BE OVERRIDDEN #

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -3,7 +3,6 @@ import os
 import os.path as osp
 from typing import Optional
 
-import stable_baselines.logger as sb_logger
 import tensorflow as tf
 from sacred.observers import FileStorageObserver
 from stable_baselines.common import callbacks
@@ -140,7 +139,7 @@ def rollouts_and_policy(
                 reward_fn_ctx = load_reward(reward_type, reward_path, venv)
                 reward_fn = stack.enter_context(reward_fn_ctx)
                 venv = RewardVecEnvWrapper(venv, reward_fn)
-                callback_objs.append(venv.make_log_callback(sb_logger))
+                callback_objs.append(venv.make_log_callback())
                 tf.logging.info(
                     f"Wrapped env in reward {reward_type} from {reward_path}."
                 )

--- a/src/imitation/util/reward_wrapper.py
+++ b/src/imitation/util/reward_wrapper.py
@@ -3,7 +3,6 @@ import collections
 from typing import Deque
 
 import numpy as np
-from stable_baselines import logger
 from stable_baselines.common import callbacks, vec_env
 
 from imitation.rewards import common
@@ -12,11 +11,8 @@ from imitation.rewards import common
 class WrappedRewardCallback(callbacks.BaseCallback):
     """Logs mean wrapped reward as part of RL (or other) training."""
 
-    def __init__(
-        self, episode_rewards: Deque[float], log_obj: logger.Logger, *args, **kwargs
-    ):
+    def __init__(self, episode_rewards: Deque[float], *args, **kwargs):
         self.episode_rewards = episode_rewards
-        self.log_obj = log_obj
         super().__init__(self, *args, **kwargs)
 
     def _on_step(self) -> bool:
@@ -57,9 +53,9 @@ class RewardVecEnvWrapper(vec_env.VecEnvWrapper):
         self.reward_fn = reward_fn
         self.reset()
 
-    def make_log_callback(self, log_obj: logger.Logger) -> WrappedRewardCallback:
+    def make_log_callback(self) -> WrappedRewardCallback:
         """Creates `WrappedRewardCallback` connected to this `RewardVecEnvWrapper`."""
-        return WrappedRewardCallback(self.episode_rewards, log_obj)
+        return WrappedRewardCallback(self.episode_rewards)
 
     @property
     def envs(self):

--- a/src/imitation/util/reward_wrapper.py
+++ b/src/imitation/util/reward_wrapper.py
@@ -22,7 +22,7 @@ class WrappedRewardCallback(callbacks.BaseCallback):
         if len(self.episode_rewards) == 0:
             return
         mean = sum(self.episode_rewards) / len(self.episode_rewards)
-        self.logger.record("rollout/ep_rew_wrapped_mean", mean)
+        self.logger.logkv("rollout/ep_rew_wrapped_mean", mean)
 
 
 class RewardVecEnvWrapper(vec_env.VecEnvWrapper):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -245,7 +245,6 @@ def _generate_test_rollouts(tmpdir: str, env_named_config: str) -> str:
     expert_demos.expert_demos_ex.run(
         named_configs=[env_named_config, "fast"],
         config_updates=dict(
-            rollout_save_interval=0,
             log_dir=tmpdir,
         ),
     )


### PR DESCRIPTION
Fixes variety of bugs in TF version. Tests now pass.

  - Make observation space dtype match returned observations.
  - Support new log callback in `AdversarialTrainer`.
  - Delete `rollout_save_interval`.
  - CircleCI: use new `pip` command to always install fresh version of `imitation`.