### PR TITLE
compute_train_stats: Fix logits passed in as proba

### DIFF
--- a/src/imitation/rewards/common.py
+++ b/src/imitation/rewards/common.py
@@ -132,7 +132,7 @@ def compute_train_stats(
         _n_gen_or_1 = max(1, n_generated)
         generated_acc = _n_pred_gen / float(_n_gen_or_1)
 
-        label_dist = th.distributions.Bernoulli(disc_logits_gen_is_high)
+        label_dist = th.distributions.Bernoulli(logits=disc_logits_gen_is_high)
         entropy = th.mean(label_dist.entropy())
 
     pairs = [


### PR DESCRIPTION
Fixes an ~"negative probability out-of-bounds" error I ran into when I was training.

See: https://pytorch.org/docs/stable/distributions.html#bernoulli for func signature