### PR TITLE
Fix deprecated np.bool and np.int aliases

### DIFF
--- a/src/imitation/analysis/mountain_car_plots.py
+++ b/src/imitation/analysis/mountain_car_plots.py
@@ -92,7 +92,7 @@ def make_heatmap(
         obs_vec = np.array([[p, v] for p in pos_space for v in vel_space])
         acts_vec = np.array([act] * len(obs_vec))
         next_obs_vec = _make_next_mc_obs(obs_vec, acts_vec)
-        dones = np.zeros(len(acts_vec), dtype=np.bool)
+        dones = np.zeros(len(acts_vec), dtype=bool)
 
         rew = reward_fn(obs_vec, acts_vec, next_obs_vec, dones)
         # Transpose because `pcolor` (confusingly) expects its first two arguments
@@ -212,7 +212,7 @@ def plot_reward_vs_time(
         for traj in trajs_list:
             T = len(traj.rews)
             X.extend(range(T))
-            dones = np.zeros(T, dtype=np.bool)
+            dones = np.zeros(T, dtype=bool)
             dones[-1] = True
             rews = reward_fn(traj.obs[:-1], traj.acts, traj.obs[1:], dones)
             Y.extend(rews)

--- a/src/imitation/data/buffer.py
+++ b/src/imitation/data/buffer.py
@@ -279,7 +279,7 @@ class ReplayBuffer:
             "obs": obs_dtype,
             "acts": act_dtype,
             "next_obs": obs_dtype,
-            "dones": np.bool,
+            "dones": bool,
             "infos": np.object,
         }
         self._buffer = Buffer(capacity, sample_shapes=sample_shapes, dtypes=dtypes)

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -264,7 +264,7 @@ def generate_trajectories(
     # are complete.
     #
     # To start with, all environments are active.
-    active = np.ones(venv.num_envs, dtype=np.bool)
+    active = np.ones(venv.num_envs, dtype=bool)
     while np.any(active):
         acts, _ = get_action(obs, deterministic=deterministic_policy)
         obs, rews, dones, infos = venv.step(acts)
@@ -382,7 +382,7 @@ def flatten_trajectories(
         parts["obs"].append(obs[:-1])
         parts["next_obs"].append(obs[1:])
 
-        dones = np.zeros(len(traj.acts), dtype=np.bool)
+        dones = np.zeros(len(traj.acts), dtype=bool)
         dones[-1] = True
         parts["dones"].append(dones)
 

--- a/src/imitation/data/types.py
+++ b/src/imitation/data/types.py
@@ -235,7 +235,7 @@ class Transitions(TransitionsMinimal):
                 "dones must be 1D array, one entry for each timestep: "
                 f"{self.dones.shape} != ({len(self.acts)},)"
             )
-        if self.dones.dtype != np.bool:
+        if self.dones.dtype != bool:
             raise ValueError(f"dones must be boolean, not {self.dones.dtype}")
 
 

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -69,7 +69,7 @@ def test_buffer(capacity, chunk_len, sample_shape):
 @pytest.mark.parametrize("chunk_len", [1, 4, 9])
 @pytest.mark.parametrize("obs_shape", [(), (1, 2)])
 @pytest.mark.parametrize("act_shape", [(), (5, 4, 4)])
-@pytest.mark.parametrize("dtype", [np.int, np.float32])
+@pytest.mark.parametrize("dtype", [int, np.float32])
 def test_replay_buffer(capacity, chunk_len, obs_shape, act_shape, dtype):
     """Builds a ReplayBuffer with the provided `capacity` and inserts.
 
@@ -95,8 +95,8 @@ def test_replay_buffer(capacity, chunk_len, obs_shape, act_shape, dtype):
         assert buf.size() == min(i, capacity)
         assert buf._buffer._idx == i % capacity
 
-        dones = np.arange(i, i + chunk_len, dtype=np.int32) % 2
-        dones = dones.astype(np.bool)
+        dones = np.arange(i, i + chunk_len, dtype=int32) % 2
+        dones = dones.astype(bool)
         infos = _fill_chunk(9 * capacity + i, chunk_len, (), dtype=dtype)
         infos = np.array([{"a": val} for val in infos])
         batch = types.Transitions(
@@ -122,7 +122,7 @@ def test_replay_buffer(capacity, chunk_len, obs_shape, act_shape, dtype):
         assert sample.acts.dtype == dtype
         assert sample.next_obs.dtype == dtype
         assert info_vals.dtype == dtype
-        assert sample.dones.dtype == np.bool
+        assert sample.dones.dtype == bool
         assert sample.infos.dtype == np.object
 
         # Are samples in range?

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -95,7 +95,7 @@ def test_replay_buffer(capacity, chunk_len, obs_shape, act_shape, dtype):
         assert buf.size() == min(i, capacity)
         assert buf._buffer._idx == i % capacity
 
-        dones = np.arange(i, i + chunk_len, dtype=int32) % 2
+        dones = np.arange(i, i + chunk_len, dtype=np.int32) % 2
         dones = dones.astype(bool)
         infos = _fill_chunk(9 * capacity + i, chunk_len, (), dtype=dtype)
         infos = np.array([{"a": val} for val in infos])

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -68,7 +68,7 @@ def transitions(
 ) -> types.Transitions:
     """Fixture to generate transitions of length `length` iid sampled from spaces."""
     next_obs = np.array([obs_space.sample() for _ in range(length)])
-    dones = np.zeros(length, dtype=np.bool)
+    dones = np.zeros(length, dtype=bool)
     return types.Transitions(
         **dataclasses.asdict(transitions_min), next_obs=next_obs, dones=dones
     )
@@ -191,7 +191,7 @@ class TestData:
 
         with pytest.raises(ValueError, match=r"rewards dtype.* not a float"):
             dataclasses.replace(
-                trajectory_rew, rews=np.zeros(len(trajectory_rew), dtype=np.int)
+                trajectory_rew, rews=np.zeros(len(trajectory_rew), dtype=int)
             )
 
     def test_valid_transitions(
@@ -254,7 +254,7 @@ class TestData:
                 ValueError, match=r"obs and next_obs must have the same dtype:.*"
             ):
                 dataclasses.replace(
-                    trans, next_obs=np.zeros_like(trans.next_obs, dtype=np.bool)
+                    trans, next_obs=np.zeros_like(trans.next_obs, dtype=bool)
                 ),
 
             _check_1d_shape(
@@ -264,7 +264,7 @@ class TestData:
             )
 
             with pytest.raises(ValueError, match=r"dones must be boolean"):
-                dataclasses.replace(trans, dones=np.zeros(len(trans), dtype=np.int))
+                dataclasses.replace(trans, dones=np.zeros(len(trans), dtype=int))
 
         _check_1d_shape(
             fn=lambda bogus_rews: dataclasses.replace(trans, rews=bogus_rews),
@@ -274,7 +274,7 @@ class TestData:
 
         with pytest.raises(ValueError, match=r"rewards dtype.* not a float"):
             dataclasses.replace(
-                transitions_rew, rews=np.zeros(len(transitions_rew), dtype=np.int)
+                transitions_rew, rews=np.zeros(len(transitions_rew), dtype=int)
             )
 
 


### PR DESCRIPTION
np.bool and np.int are just aliases for bool and int. I'm getting
a deprecation warning on my machine, so doing a quick find and
replace.

https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated
