### PR TITLE
make_vec_env: Don't wrap RolloutInfoWrapper by default

### DIFF
--- a/src/imitation/analysis/mountain_car_plots.py
+++ b/src/imitation/analysis/mountain_car_plots.py
@@ -210,7 +210,7 @@ def plot_reward_vs_time(
         X = []
         Y = []
         for traj in trajs_list:
-            T = len(traj.obs)
+            T = len(traj.acts)
             X.extend(range(T))
             dones = np.zeros(T, dtype=bool)
             dones[-1] = True

--- a/src/imitation/analysis/mountain_car_plots.py
+++ b/src/imitation/analysis/mountain_car_plots.py
@@ -210,9 +210,9 @@ def plot_reward_vs_time(
         X = []
         Y = []
         for traj in trajs_list:
-            T = len(traj.rews)
+            T = len(traj.obs)
             X.extend(range(T))
-            dones = np.zeros(T, dtype=np.bool)
+            dones = np.zeros(T, dtype=bool)
             dones[-1] = True
             rews = reward_fn(traj.obs[:-1], traj.acts, traj.obs[1:], dones)
             Y.extend(rews)

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -133,6 +133,7 @@ def rollouts_and_policy(
         parallel=parallel,
         log_dir=log_dir,
         max_episode_steps=max_episode_steps,
+        use_rollout_info_wrapper=True,
     )
 
     callback_objs = []
@@ -211,6 +212,7 @@ def rollouts_from_policy(
         parallel=parallel,
         log_dir=log_dir,
         max_episode_steps=max_episode_steps,
+        use_rollout_info_wrapper=True,
     )
 
     policy = serialize.load_policy(policy_type, policy_path, venv)

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -8,7 +8,7 @@ from stable_baselines3.common import callbacks
 from stable_baselines3.common.vec_env import VecNormalize
 
 import imitation.util.sacred as sacred_util
-from imitation.data import rollout
+from imitation.data import rollout, wrappers
 from imitation.policies import serialize
 from imitation.rewards.serialize import load_reward
 from imitation.scripts.config.expert_demos import expert_demos_ex
@@ -133,7 +133,7 @@ def rollouts_and_policy(
         parallel=parallel,
         log_dir=log_dir,
         max_episode_steps=max_episode_steps,
-        use_rollout_info_wrapper=True,
+        post_wrappers=[lambda env, idx: wrappers.RolloutInfoWrapper(env)],
     )
 
     callback_objs = []
@@ -212,7 +212,7 @@ def rollouts_from_policy(
         parallel=parallel,
         log_dir=log_dir,
         max_episode_steps=max_episode_steps,
-        use_rollout_info_wrapper=True,
+        post_wrappers=[lambda env, idx: wrappers.RolloutInfoWrapper(env)],
     )
 
     policy = serialize.load_policy(policy_type, policy_path, venv)

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -41,6 +41,7 @@ def make_vec_env(
     parallel: bool = False,
     log_dir: Optional[str] = None,
     max_episode_steps: Optional[int] = None,
+    use_rollout_info_wrapper: bool = False,
     post_wrappers: Optional[Sequence[Callable[[gym.Env, int], gym.Env]]] = None,
 ) -> VecEnv:
     """Returns a VecEnv initialized with `n_envs` Envs.
@@ -57,6 +58,9 @@ def make_vec_env(
             `max_episode_steps` for every TimeLimit wrapper (this automatic
             wrapper is the default behavior when calling `gym.make`). Otherwise
             the environments are passed into the VecEnv unwrapped.
+        use_rollout_info_wrapper: If True, then wrap each env in a
+            `imitation.data.wrappers.RolloutInfoWrapper`. Used by `expert_demos` script
+            to access unnormalized observations and rewards during rollout save.
         post_wrappers: If specified, iteratively wraps each environment with each
             of the wrappers specified in the sequence. The argument should be a Callable
             accepting two arguments, the Env to be wrapped and the environment index,
@@ -96,7 +100,8 @@ def make_vec_env(
             log_path = os.path.join(log_subdir, f"mon{i:03d}")
 
         env = monitor.Monitor(env, log_path)
-        env = wrappers.RolloutInfoWrapper(env)
+        if use_rollout_info_wrapper:
+            env = wrappers.RolloutInfoWrapper(env)
 
         if post_wrappers:
             for wrapper in post_wrappers:

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -23,8 +23,6 @@ from stable_baselines3.common.base_class import BaseAlgorithm
 from stable_baselines3.common.policies import ActorCriticPolicy, BasePolicy
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv, VecEnv
 
-from imitation.data import wrappers
-
 
 def make_unique_timestamp() -> str:
     """Timestamp, with random uuid added to avoid collisions."""
@@ -41,7 +39,6 @@ def make_vec_env(
     parallel: bool = False,
     log_dir: Optional[str] = None,
     max_episode_steps: Optional[int] = None,
-    use_rollout_info_wrapper: bool = False,
     post_wrappers: Optional[Sequence[Callable[[gym.Env, int], gym.Env]]] = None,
 ) -> VecEnv:
     """Returns a VecEnv initialized with `n_envs` Envs.
@@ -58,9 +55,6 @@ def make_vec_env(
             `max_episode_steps` for every TimeLimit wrapper (this automatic
             wrapper is the default behavior when calling `gym.make`). Otherwise
             the environments are passed into the VecEnv unwrapped.
-        use_rollout_info_wrapper: If True, then wrap each env in a
-            `imitation.data.wrappers.RolloutInfoWrapper`. Used by `expert_demos` script
-            to access unnormalized observations and rewards during rollout save.
         post_wrappers: If specified, iteratively wraps each environment with each
             of the wrappers specified in the sequence. The argument should be a Callable
             accepting two arguments, the Env to be wrapped and the environment index,
@@ -100,8 +94,6 @@ def make_vec_env(
             log_path = os.path.join(log_subdir, f"mon{i:03d}")
 
         env = monitor.Monitor(env, log_path)
-        if use_rollout_info_wrapper:
-            env = wrappers.RolloutInfoWrapper(env)
 
         if post_wrappers:
             for wrapper in post_wrappers:


### PR DESCRIPTION
This PR modifies `make_vec_env` to stop wrapping each Env with `RolloutInfoWrapper`, and modifies `expert_demos`.

This wrapper increases the size of the info dict substantially
because it appends all episode observatations to the into dict with
done=True. It is only used by the expert_demos script to save
original (unnormalized) observations and rewards.