### PR TITLE
DAgger logging fix

### DIFF
--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -113,10 +113,10 @@ class EpochOrBatchIteratorWithProgress:
         batch_suffix = epoch_suffix = ""
         if self.use_epochs:
             display = tqdm.tqdm(total=self.n_epochs)
-            epoch_suffix = f"/{self.n_epochs}"
+            epoch_suffix = f"/{epoch_num_start + self.n_epochs}"
         else:  # Use batches.
             display = tqdm.tqdm(total=self.n_batches)
-            batch_suffix = f"/{self.n_batches}"
+            batch_suffix = f"/{batch_num_start + self.n_batches}"
 
         def update_desc():
             display.set_description(

--- a/src/imitation/algorithms/dagger.py
+++ b/src/imitation/algorithms/dagger.py
@@ -268,6 +268,9 @@ class DAggerTrainer:
         self.beta_schedule = beta_schedule
         self.scratch_dir = scratch_dir
         self.env = env
+        self.samples_so_far = 0
+        self.batch_num = 0
+        self.epoch_num = 0
         self.round_num = 0
         self.bc_kwargs = bc_kwargs
         self._last_loaded_round = -1
@@ -348,8 +351,19 @@ class DAggerTrainer:
         logging.info("Loading demonstrations")
         self._try_load_demos()
         logging.info(f"Training at round {self.round_num}")
-        self.bc_trainer.train(**train_kwargs)
+        train_kwargs.update(
+            {
+                "samples_so_far": self.samples_so_far,
+                "batch_num": self.batch_num,
+                "epoch_num": self.epoch_num,
+            }
+        )
+        samples_so_far, batch_num, epoch_num = self.bc_trainer.train(**train_kwargs)
+        self.samples_so_far += samples_so_far
+        self.batch_num += batch_num
+        self.epoch_num += epoch_num
         self.round_num += 1
+
         logging.info(f"New round number is {self.round_num}")
         return self.round_num
 


### PR DESCRIPTION
Currently, visualization of the training progress of DAgger on the tensorboard does not work because the reported results for each round of dagger start at `batch_num = 0`. As a result, the loss graph and other results are not "causal", they jump backwards in time after every round.

This PR adds an option `stateful_iter` to `EpochOrBatchIteratorWithProgress` that allows the iterator to consider poch and batch counts from previous rounds. By default, `stateful_iter = False` which causes the counters to be reset at the beginning of each call to `__iter__` be reset.

`BC.train` now admits to pass offests for epoches, batches and samples and constructs the `EpochOrBatchIteratorWithProgress` as stateful to respect these offsets.

Finally, `DaggerTrainer.extend_and_update` keeps track of these states over multiple rounds and passes the corresponding offsets to `BC.train` for each call.