### PR TITLE
Fix latent CI errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
             "ntfy[slack]",
             "ipdb",
             "isort~=5.0",
+            "ipykernel",
             "jupyter",
             "pytype",
             "codespell",

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ TESTS_REQUIRE = [
     "flake8-builtins",
     "flake8-debugger",
     "flake8-isort",
+    "ipykernel",
+    "jupyter",
     "pytest",
     "pytest-cov",
     "pytest-notebook",
@@ -69,8 +71,6 @@ setup(
             "ntfy[slack]",
             "ipdb",
             "isort~=5.0",
-            "ipykernel",
-            "jupyter",
             "pytype",
             "codespell",
             # for convenience

--- a/src/imitation/analysis/mountain_car_plots.py
+++ b/src/imitation/analysis/mountain_car_plots.py
@@ -210,9 +210,9 @@ def plot_reward_vs_time(
         X = []
         Y = []
         for traj in trajs_list:
-            T = len(traj.rews)
+            T = len(traj.acts)
             X.extend(range(T))
-            dones = np.zeros(T, dtype=np.bool)
+            dones = np.zeros(T, dtype=bool)
             dones[-1] = True
             rews = reward_fn(traj.obs[:-1], traj.acts, traj.obs[1:], dones)
             Y.extend(rews)


### PR DESCRIPTION
Explicitly install ipykernel to fix Jupyter missing kernel error #287.

Also fix new pytype error in mountain_car_plots.py (newly detection static typing error with new version of pytype).