### PR TITLE
Error if Data Loader Ends Early

### DIFF
--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -112,6 +112,7 @@ class EpochOrBatchIteratorWithProgress:
             )
 
         with contextlib.closing(display):
+            prior_epoch_batches = batch_num
             while True:
                 update_desc()
                 for batch in self.data_loader:
@@ -132,6 +133,10 @@ class EpochOrBatchIteratorWithProgress:
                         display.update(1)
                         if batch_num >= self.n_batches:
                             return
+                if batch_num == prior_epoch_batches:
+                    raise StopIteration("epoch_num is increasing without batch_num going up; "
+                                        "perhaps your data loader has not reset properly")
+                prior_epoch_batches = batch_num
                 epoch_num += 1
                 if self.on_epoch_end is not None:
                     self.on_epoch_end()

--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -112,10 +112,11 @@ class EpochOrBatchIteratorWithProgress:
             )
 
         with contextlib.closing(display):
-            prior_epoch_batches = batch_num
             while True:
                 update_desc()
+                got_data_on_epoch = False
                 for batch in self.data_loader:
+                    got_data_on_epoch = True
                     batch_num += 1
                     batch_size = len(batch["obs"])
                     assert batch_size > 0
@@ -133,13 +134,12 @@ class EpochOrBatchIteratorWithProgress:
                         display.update(1)
                         if batch_num >= self.n_batches:
                             return
-                if batch_num == prior_epoch_batches:
+                if not got_data_on_epoch:
                     raise AssertionError(
-                        "epoch_num is increasing without "
-                        "batch_num going up; likely your "
-                        "data loader has not reset properly"
+                        f"Data loader returned no data after "
+                        f"{batch_num} batches, during epoch "
+                        f"{epoch_num} -- did it reset correctly?"
                     )
-                prior_epoch_batches = batch_num
                 epoch_num += 1
                 if self.on_epoch_end is not None:
                     self.on_epoch_end()

--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -134,8 +134,8 @@ class EpochOrBatchIteratorWithProgress:
                         if batch_num >= self.n_batches:
                             return
                 if batch_num == prior_epoch_batches:
-                    raise StopIteration("epoch_num is increasing without batch_num going up; "
-                                        "perhaps your data loader has not reset properly")
+                    raise AssertionError("epoch_num is increasing without batch_num going up; "
+                                         "likely your data loader has not reset properly")
                 prior_epoch_batches = batch_num
                 epoch_num += 1
                 if self.on_epoch_end is not None:

--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -134,8 +134,11 @@ class EpochOrBatchIteratorWithProgress:
                         if batch_num >= self.n_batches:
                             return
                 if batch_num == prior_epoch_batches:
-                    raise AssertionError("epoch_num is increasing without batch_num going up; "
-                                         "likely your data loader has not reset properly")
+                    raise AssertionError(
+                        "epoch_num is increasing without "
+                        "batch_num going up; likely your "
+                        "data loader has not reset properly"
+                    )
                 prior_epoch_batches = batch_num
                 epoch_num += 1
                 if self.on_epoch_end is not None:


### PR DESCRIPTION
A simple fix to give a more clean and comprehensible error in the edge case where your data iterator ends prior to hitting the number of batches you have asked BC to train for. In the current state of the code, this situation results in an infinite loop of `epoch_num` incrementing upwards, with no explicit error 