### PR TITLE
Move Jax dependencies to setup extra

### DIFF
--- a/ci/build_venv.sh
+++ b/ci/build_venv.sh
@@ -9,4 +9,4 @@ fi
 
 virtualenv -p python3.7 ${venv}
 source ${venv}/bin/activate
-pip install .[cpu,docs,parallel,test] gym[mujoco]
+pip install .[cpu,docs,jax,parallel,test] gym[mujoco]

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,6 @@ setup(
         "tqdm",
         "scikit-learn>=0.21.2",
         "stable-baselines3~=0.10.0",
-        "jax~=0.2.8",
-        "jaxlib~=0.1.59",
         "sacred~=0.8.1",
         "tensorboard>=1.14",
     ],
@@ -76,6 +74,10 @@ setup(
             # for convenience
             *TESTS_REQUIRE,
             *DOCS_REQUIRE,
+        ],
+        "jax": [
+            "jax~=0.2.8",
+            "jaxlib~=0.1.59",
         ],
         "test": TESTS_REQUIRE,
         "docs": DOCS_REQUIRE,

--- a/src/imitation/algorithms/tabular_irl.py
+++ b/src/imitation/algorithms/tabular_irl.py
@@ -7,17 +7,45 @@ PyTorch/TensorFlow, and some code for simple reward models.
 
 .. _PhD thesis:
     http://www.cs.cmu.edu/~bziebart/publications/thesis-bziebart.pdf
+
+.. note::
+    Our current implementation of MCE IRL uses Jax, which is not bundled with the
+    default ``pip`` installation of ``imitation`` because Jax is incompatible with
+    Windows. You can install the Jax dependencies used by MCE IRL via
+    ``pip install imitation[jax]``.
+
+    We are considering porting MCE IRL from Jax to PyTorch in a future release.
 """
 
 import abc
 import logging
+import warnings
 
-import jax
-import jax.experimental.stax as jstax
-import jax.numpy as jnp
-import jax.random as jrandom
 import numpy as np
 import scipy
+
+try:
+    # pytype: disable=import-error
+    import jax
+    import jax.experimental.stax as jstax
+    import jax.numpy as jnp
+    import jax.random as jrandom
+
+    # pytype: enable=import-error
+
+except ImportError:
+    msg = (
+        f"Failed to import module {__name__} because Jax dependency is not installed. "
+        "See module docstring for more information on installation and OS "
+        "compatibility."
+    )
+    # ImportWarning is more appropriate than UserWarning here, but ImportWarning
+    # has been ignored by default since Python 3.7:
+    # https://docs.python.org/3/library/devmode.html#effects-of-the-python-development-mode
+    warnings.warn(msg)
+
+    # Also hide module functions to make Jax import failure more immediately obvious.
+    __all__ = []
 
 
 def mce_partition_fh(env, *, R=None):

--- a/src/imitation/algorithms/tabular_irl.py
+++ b/src/imitation/algorithms/tabular_irl.py
@@ -19,7 +19,6 @@ PyTorch/TensorFlow, and some code for simple reward models.
 
 import abc
 import logging
-import warnings
 
 import numpy as np
 import scipy
@@ -32,8 +31,7 @@ try:
     import jax.random as jrandom
 
     # pytype: enable=import-error
-
-except ImportError:
+except ImportError as e:  # pragma: no cover
     msg = (
         f"Failed to import module {__name__} because Jax dependency is not installed. "
         "See module docstring for more information on installation and OS "
@@ -42,10 +40,7 @@ except ImportError:
     # ImportWarning is more appropriate than UserWarning here, but ImportWarning
     # has been ignored by default since Python 3.7:
     # https://docs.python.org/3/library/devmode.html#effects-of-the-python-development-mode
-    warnings.warn(msg)
-
-    # Also hide module functions to make Jax import failure more immediately obvious.
-    __all__ = []
+    raise ImportError(msg) from e
 
 
 def mce_partition_fh(env, *, R=None):

--- a/tests/test_tabular.py
+++ b/tests/test_tabular.py
@@ -17,7 +17,7 @@ from imitation.envs.resettable_env import TabularModelEnv
 JAX_IMPORT_FAIL = False
 try:
     import jax.experimental.optimizers as jaxopt  # pytype: disable=import-error
-except ImportError:
+except ImportError:  # pragma: no cover
     JAX_IMPORT_FAIL = True
 
 

--- a/tests/test_tabular.py
+++ b/tests/test_tabular.py
@@ -21,7 +21,11 @@ except ImportError:
     JAX_IMPORT_FAIL = True
 
 
-skip_if_no_jax = pytest.mark.skipif(JAX_IMPORT_FAIL)
+skip_if_no_jax = pytest.mark.skipif(
+    JAX_IMPORT_FAIL,
+    reason=("jax not installed (see imitation.algorithms.tabular_irl docstring for "
+            "installation info)")
+)
 
 
 def rollouts(env, n=10, seed=None):

--- a/tests/test_tabular.py
+++ b/tests/test_tabular.py
@@ -1,7 +1,6 @@
 """Test tabular environments and tabular MCE IRL."""
 
 import gym
-import jax.experimental.optimizers as jaxopt
 import numpy as np
 import pytest
 
@@ -14,6 +13,15 @@ from imitation.algorithms.tabular_irl import (
 )
 from imitation.envs.examples.model_envs import RandomMDP
 from imitation.envs.resettable_env import TabularModelEnv
+
+JAX_IMPORT_FAIL = False
+try:
+    import jax.experimental.optimizers as jaxopt  # pytype: disable=import-error
+except ImportError:
+    JAX_IMPORT_FAIL = True
+
+
+skip_if_no_jax = pytest.mark.skipif(JAX_IMPORT_FAIL)
 
 
 def rollouts(env, n=10, seed=None):
@@ -35,6 +43,7 @@ def rollouts(env, n=10, seed=None):
     return rv
 
 
+@skip_if_no_jax
 def test_random_mdp():
     for i in range(3):
         n_states = 4 * (i + 3)
@@ -81,6 +90,7 @@ def test_random_mdp():
         assert len(set(map(str, trajectories))) == 1
 
 
+@skip_if_no_jax
 def test_policy_om_random_mdp():
     """Test that optimal policy occupancy measure ("om") for a random MDP is sane."""
     mdp = gym.make("imitation/Random-v0")
@@ -182,6 +192,7 @@ class ReasonableMDP(TabularModelEnv):
     horizon = 20
 
 
+@skip_if_no_jax
 def test_policy_om_reasonable_mdp():
     # MDP described above
     mdp = ReasonableMDP()
@@ -217,6 +228,7 @@ def test_policy_om_reasonable_mdp():
     "model_class,model_kwargs",
     [(LinearRewardModel, dict()), (MLPRewardModel, dict(hiddens=[32, 32]))],
 )
+@skip_if_no_jax
 def test_mce_irl_reasonable_mdp(model_class, model_kwargs):
     # test MCE IRL on the MDP
     mdp = ReasonableMDP()

--- a/tests/test_tabular.py
+++ b/tests/test_tabular.py
@@ -23,8 +23,10 @@ except ImportError:
 
 skip_if_no_jax = pytest.mark.skipif(
     JAX_IMPORT_FAIL,
-    reason=("jax not installed (see imitation.algorithms.tabular_irl docstring for "
-            "installation info)")
+    reason=(
+        "jax not installed (see imitation.algorithms.tabular_irl docstring for "
+        "installation info)"
+    ),
 )
 
 


### PR DESCRIPTION
This PR moves the `jax` and `jaxlib` dependencies (used only by
`imitation.algorithms.tabular_irl`) from the main package
requirements to a new "jax" extra.

It also adds a warning to `tabular_irl.py` that is displayed when the
submodule is imported but `jax` cannot be imported, and adds
new documentation to the same submodule explaining how to install
the jax extra.

`tests/test_tabular.py` is also updated to skip tests when
Jax isn't installed.

`pip install jax` is not available for Windows machines, and this
change might make `imitation` Windows-compatible (haven't checked
personally.)
