### PR TITLE
util.sacred.filter_subdirs: Follow symlinks

### DIFF
--- a/src/imitation/util/sacred.py
+++ b/src/imitation/util/sacred.py
@@ -56,7 +56,7 @@ def filter_subdirs(
       A list of all subdirectory paths where `filter_fn(path) == True`.
     """
     filtered_dirs = set()
-    for root, _, _ in os.walk(root_dir, followlinks=True):
+    for root, _, _ in os.walk(root_dir, followlinks=False):
         if filter_fn(root):
             filtered_dirs.add(root)
 

--- a/src/imitation/util/sacred.py
+++ b/src/imitation/util/sacred.py
@@ -56,7 +56,7 @@ def filter_subdirs(
       A list of all subdirectory paths where `filter_fn(path) == True`.
     """
     filtered_dirs = set()
-    for root, _, _ in os.walk(root_dir):
+    for root, _, _ in os.walk(root_dir, followlinks=True):
         if filter_fn(root):
             filtered_dirs.add(root)
 


### PR DESCRIPTION
Recursively search through symlinks (previously ignored), like
those generated by `build_sacred_symlink`. This is useful for
building performance tables from directories that contain Sacred
symlinks but not the actual Sacred directory.
