### PR TITLE
AdversarialTrainer: Rename discrim to discrim_net

### DIFF
--- a/src/imitation/algorithms/adversarial.py
+++ b/src/imitation/algorithms/adversarial.py
@@ -34,11 +34,14 @@ class AdversarialTrainer:
     If `debug_use_ground_truth=True` was passed into the initializer then
     `self.venv_train` is the same as `self.venv`."""
 
+    discrim_net: discrim_nets.DiscrimNet
+    """The discriminator network."""
+
     def __init__(
         self,
         venv: vec_env.VecEnv,
         gen_algo: on_policy_algorithm.OnPolicyAlgorithm,
-        discrim: discrim_nets.DiscrimNet,
+        discrim_net: discrim_nets.DiscrimNet,
         expert_data: Union[Iterable[Mapping], types.Transitions],
         expert_batch_size: int,
         n_disc_updates_per_round: int = 2,
@@ -60,7 +63,7 @@ class AdversarialTrainer:
             gen_algo: The generator RL algorithm that is trained to maximize
                 discriminator confusion. The generator batch size
                 `self.gen_batch_size` is inferred from `gen_algo.n_steps`.
-            discrim: The discriminator network. This will be moved to the same
+            discrim_net: The discriminator network. This will be moved to the same
                 device as `gen_algo`.
             expert_data: Either a `torch.utils.data.DataLoader`-like object or an
                 instance of `Transitions` which is automatically converted into a
@@ -139,13 +142,13 @@ class AdversarialTrainer:
         self._log_dir = log_dir
 
         # Create graph for optimising/recording stats on discriminator
-        self.discrim = discrim.to(self.gen_algo.device)
+        self.discrim_net = discrim_net.to(self.gen_algo.device)
         self._disc_opt_cls = disc_opt_cls
         self._disc_opt_kwargs = disc_opt_kwargs or {}
         self._init_tensorboard = init_tensorboard
         self._init_tensorboard_graph = init_tensorboard_graph
         self._disc_opt = self._disc_opt_cls(
-            self.discrim.parameters(), **self._disc_opt_kwargs
+            self.discrim_net.parameters(), **self._disc_opt_kwargs
         )
 
         if self._init_tensorboard:
@@ -167,7 +170,7 @@ class AdversarialTrainer:
             self.gen_callback = None
         else:
             self.venv_wrapped = reward_wrapper.RewardVecEnvWrapper(
-                self.venv_norm_obs, self.discrim.predict_reward_train
+                self.venv_norm_obs, self.discrim_net.predict_reward_train
             )
             self.gen_callback = self.venv_wrapped.make_log_callback()
         self.venv_train = vec_env.VecNormalize(
@@ -222,14 +225,14 @@ class AdversarialTrainer:
             batch = self._make_disc_train_batch(
                 gen_samples=gen_samples, expert_samples=expert_samples
             )
-            disc_logits = self.discrim.logits_gen_is_high(
+            disc_logits = self.discrim_net.logits_gen_is_high(
                 batch["state"],
                 batch["action"],
                 batch["next_state"],
                 batch["done"],
                 batch["log_policy_act_prob"],
             )
-            loss = self.discrim.disc_loss(disc_logits, batch["labels_gen_is_one"])
+            loss = self.discrim_net.disc_loss(disc_logits, batch["labels_gen_is_one"])
 
             # do gradient step
             self._disc_opt.zero_grad()
@@ -240,7 +243,9 @@ class AdversarialTrainer:
             # compute/write stats and TensorBoard data
             with th.no_grad():
                 train_stats = rew_common.compute_train_stats(
-                    disc_logits, batch["labels_gen_is_one"], loss
+                    disc_logits,
+                    batch["labels_gen_is_one"],
+                    loss,
                 )
             logger.record("global_step", self._global_step)
             for k, v in train_stats.items():
@@ -320,17 +325,17 @@ class AdversarialTrainer:
             logger.dump(self._global_step)
 
     def _torchify_array(self, ndarray: np.ndarray, **kwargs) -> th.Tensor:
-        return th.as_tensor(ndarray, device=self.discrim.device(), **kwargs)
+        return th.as_tensor(ndarray, device=self.discrim_net.device(), **kwargs)
 
     def _torchify_with_space(
         self, ndarray: np.ndarray, space: gym.Space, **kwargs
     ) -> th.Tensor:
-        tensor = th.as_tensor(ndarray, device=self.discrim.device(), **kwargs)
+        tensor = th.as_tensor(ndarray, device=self.discrim_net.device(), **kwargs)
         preprocessed = preprocessing.preprocess_obs(
             tensor,
             space,
             # TODO(sam): can I remove "scale" kwarg in DiscrimNet etc.?
-            normalize_images=self.discrim.scale,
+            normalize_images=self.discrim_net.scale,
         )
         return preprocessed
 
@@ -414,10 +419,10 @@ class AdversarialTrainer:
         log_act_prob = log_act_prob.reshape((n_samples,))
 
         batch_dict = {
-            "state": self._torchify_with_space(obs, self.discrim.observation_space),
-            "action": self._torchify_with_space(acts, self.discrim.action_space),
+            "state": self._torchify_with_space(obs, self.discrim_net.observation_space),
+            "action": self._torchify_with_space(acts, self.discrim_net.action_space),
             "next_state": self._torchify_with_space(
-                next_obs, self.discrim.observation_space
+                next_obs, self.discrim_net.observation_space
             ),
             "done": self._torchify_array(dones),
             "labels_gen_is_one": self._torchify_array(labels_gen_is_one),
@@ -460,6 +465,10 @@ class GAIL(AdversarialTrainer):
 
 
 class AIRL(AdversarialTrainer):
+
+    reward_net: reward_nets.RewardNet
+    """The AIRL reward network, used by the imitation policy."""
+
     def __init__(
         self,
         venv: vec_env.VecEnv,

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -25,7 +25,7 @@ def save(trainer, save_path):
     # We implement this here and not in Trainer since we do not want to actually
     # serialize the whole Trainer (including e.g. expert demonstrations).
     os.makedirs(save_path, exist_ok=True)
-    th.save(trainer.discrim, os.path.join(save_path, "discrim.pt"))
+    th.save(trainer.discrim_net, os.path.join(save_path, "discrim.pt"))
     # TODO(gleave): unify this with the saving logic in data_collect?
     # (Needs #43 to be merged before attempting.)
     serialize.save_stable_model(


### PR DESCRIPTION
This PR renames `AdversarialTrainer.discrim` to`AdversarialTrainer.discrim_net`, matching the naming scheme for `AIRL.reward_net`.
