### PR TITLE
Don't set policy's environment in generate_trajectories

### DIFF
--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Hashable, List, Optional, Sequence, Union
 import numpy as np
 from stable_baselines3.common.base_class import BaseAlgorithm
 from stable_baselines3.common.policies import BasePolicy
+from stable_baselines3.common.utils import check_for_correct_spaces
 from stable_baselines3.common.vec_env import VecEnv
 
 from imitation.data import types
@@ -242,7 +243,8 @@ def generate_trajectories(
     """
     get_action = policy.predict
     if isinstance(policy, BaseAlgorithm):
-        policy.set_env(venv)
+        # check that the observation and action spaces of policy and environment match
+        check_for_correct_spaces(venv, policy.observation_space, policy.action_space)
 
     # Collect rollout tuples.
     trajectories = []


### PR DESCRIPTION
Previously, `generate_trajectories` could change the environment attached to the `policy` if it was a `BaseAlgorithm`. This seems like an unwanted side effect and I think it's unnecessary (`generate_trajectory` only uses `policy.predict`, which doesn't require the environment to be set).

I did keep the check whether observation/action space match, just put it into `generate_trajectories` directly instead of using `policy.set_env`.