### PR TITLE
Remove code coverage for Sacred config scripts

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,6 +12,7 @@ coverage:
         paths:
           - "src/imitation/envs/examples/"
           - "src/imitation/scripts/"
+          - "!src/imitation/scripts/config"
       tests:
         # Should not have dead code in our tests
         target: 100%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -30,6 +30,7 @@ coverage:
           - "examples/"
           - "src/imitation/envs/examples/"
           - "src/imitation/scripts/"
+          - "!src/imitation/scripts/config"
       tests:
         target: 100%
         paths:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,7 +12,6 @@ coverage:
         paths:
           - "src/imitation/envs/examples/"
           - "src/imitation/scripts/"
-          - "!src/imitation/scripts/config"
       tests:
         # Should not have dead code in our tests
         target: 100%


### PR DESCRIPTION
Code coverage checks currently fail whenever we add a new
Sacred config or namedconfig function because the body of these
functions is never meant to be executed. This patch excludes the
files containing these functions from CodeCov checks.

(Example of failure: #298)
