### PR TITLE
bc: Option for hiding progress bar

### DIFF
--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -55,6 +55,7 @@ class ConstantLRSchedule:
 
 class _NoopTqdm:
     """Dummy replacement for tqdm.tqdm() when we don't want a progress bar visible."""
+
     def close(self):
         pass
 

--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -53,6 +53,18 @@ class ConstantLRSchedule:
         return self.lr
 
 
+class _NoopTqdm:
+    """Dummy replacement for tqdm.tqdm() when we don't want a progress bar visible."""
+    def close(self):
+        pass
+
+    def set_description(self, s):
+        pass
+
+    def update(self, n):
+        pass
+
+
 class EpochOrBatchIteratorWithProgress:
     def __init__(
         self,
@@ -61,6 +73,7 @@ class EpochOrBatchIteratorWithProgress:
         n_batches: Optional[int] = None,
         on_epoch_end: Optional[Callable[[], None]] = None,
         on_batch_end: Optional[Callable[[], None]] = None,
+        progress_bar_visible: bool = True,
     ):
         """Wraps DataLoader so that all BC batches can be processed in a one for-loop.
 
@@ -76,6 +89,7 @@ class EpochOrBatchIteratorWithProgress:
                 end of every epoch.
             on_batch_end: A callback function without parameters to be called at the
                 end of every batch.
+            progress_bar_visible: If True, then show a tqdm progress bar.
         """
         if n_epochs is not None and n_batches is None:
             self.use_epochs = True
@@ -91,6 +105,7 @@ class EpochOrBatchIteratorWithProgress:
         self.n_batches = n_batches
         self.on_epoch_end = on_epoch_end
         self.on_batch_end = on_batch_end
+        self.progress_bar_visible = progress_bar_visible
 
     def __iter__(self) -> Iterable[Tuple[dict, dict]]:
         """Yields batches while updating tqdm display to display progress."""
@@ -99,12 +114,15 @@ class EpochOrBatchIteratorWithProgress:
         epoch_num = 0
         batch_num = 0
         batch_suffix = epoch_suffix = ""
-        if self.use_epochs:
-            display = tqdm.tqdm(total=self.n_epochs)
-            epoch_suffix = f"/{self.n_epochs}"
-        else:  # Use batches.
-            display = tqdm.tqdm(total=self.n_batches)
-            batch_suffix = f"/{self.n_batches}"
+        if self.progress_bar_visible:
+            if self.use_epochs:
+                display = tqdm.tqdm(total=self.n_epochs)
+                epoch_suffix = f"/{self.n_epochs}"
+            else:  # Use batches.
+                display = tqdm.tqdm(total=self.n_batches)
+                batch_suffix = f"/{self.n_batches}"
+        else:
+            display = _NoopTqdm()
 
         def update_desc():
             display.set_description(
@@ -307,6 +325,7 @@ class BC:
         on_epoch_end: Callable[[], None] = None,
         on_batch_end: Callable[[], None] = None,
         log_interval: int = 100,
+        progress_bar: bool = True,
     ):
         """Train with supervised learning for some number of epochs.
 
@@ -323,6 +342,7 @@ class BC:
             on_batch_end: Optional callback with no parameters to run at the end of each
                 batch.
             log_interval: Log stats after every log_interval batches.
+            progress_bar: If True, then show a progress bar during training.
         """
         it = EpochOrBatchIteratorWithProgress(
             self.expert_data_loader,
@@ -330,6 +350,7 @@ class BC:
             n_batches=n_batches,
             on_epoch_end=on_epoch_end,
             on_batch_end=on_batch_end,
+            progress_bar_visible=progress_bar,
         )
 
         batch_num = 0

--- a/tests/test_bc.py
+++ b/tests/test_bc.py
@@ -155,3 +155,9 @@ def test_save_reload(trainer, tmpdir):
     assert len(var_values) == len(new_values)
     for old, new in zip(var_values, new_values):
         assert th.allclose(old, new)
+
+
+def test_train_progress_bar_visibility(trainer: bc.BC):
+    """Smoke test for toggling progress bar visibility"""
+    for visible in [True, False]:
+        trainer.train(n_batches=1, progress_bar=visible)


### PR DESCRIPTION
Add `progress_bar` parameter to `BC.train` which toggles
whether we show a tqdm progress bar.
