### PR TITLE
Bump FrozenLake version to support new Gym

### DIFF
--- a/tests/test_discrim_net.py
+++ b/tests/test_discrim_net.py
@@ -77,7 +77,7 @@ DISCRIM_NET_SETUPS = {
     "GAIL_custom_network": _setup_gail_provide_discriminator,
 }
 
-ENV_NAMES = ["FrozenLake-v0", "CartPole-v1", "Pendulum-v0"]
+ENV_NAMES = ["FrozenLake-v1", "CartPole-v1", "Pendulum-v0"]
 
 
 @pytest.fixture(params=ENV_NAMES)

--- a/tests/test_reward_net.py
+++ b/tests/test_reward_net.py
@@ -12,7 +12,7 @@ from imitation.policies import base
 from imitation.rewards import reward_nets, serialize
 from imitation.util import util
 
-ENVS = ["FrozenLake-v0", "CartPole-v1", "Pendulum-v0"]
+ENVS = ["FrozenLake-v1", "CartPole-v1", "Pendulum-v0"]
 HARDCODED_TYPES = ["zero"]
 
 REWARD_NETS = [reward_nets.BasicRewardNet, reward_nets.BasicShapedRewardNet]


### PR DESCRIPTION
Gym has deprecated `FrozenLake-v0` that is used in some tests: https://github.com/openai/gym/pull/2315

Bump version number to stop test breakage.

@ejnnr this is responsible for (some of?) the test failures you were seeing in https://app.circleci.com/pipelines/github/HumanCompatibleAI/imitation/896/workflows/e7ecddc8-07a6-41cf-90c4-04d26ba05953/jobs/1867