### PR TITLE
Remove dependency on global sb3 logger

### DIFF
--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -12,10 +12,12 @@ import numpy as np
 import torch as th
 import torch.utils.data as th_data
 import tqdm.autonotebook as tqdm
-from stable_baselines3.common import logger, policies, utils, vec_env
+from stable_baselines3.common import policies, utils, vec_env
 
 from imitation.data import rollout, types
 from imitation.policies import base
+
+from imitation.util import logger
 
 
 def reconstruct_policy(

--- a/src/imitation/algorithms/dagger.py
+++ b/src/imitation/algorithms/dagger.py
@@ -15,12 +15,12 @@ from typing import Callable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch as th
-from stable_baselines3.common import logger, policies, utils, vec_env
+from stable_baselines3.common import policies, utils, vec_env
 from torch.utils import data as th_data
 
 from imitation.algorithms import bc
 from imitation.data import rollout, types
-from imitation.util import util
+from imitation.util import util, logger
 
 
 class BetaSchedule(abc.ABC):

--- a/src/imitation/util/logger.py
+++ b/src/imitation/util/logger.py
@@ -6,6 +6,7 @@ import stable_baselines3.common.logger as sb_logger
 
 from imitation.data import types
 
+logger = None
 
 def _build_output_formats(
     folder: types.AnyPath,
@@ -144,7 +145,7 @@ def _sb_logger_reset_replacement():
 
 def is_configured() -> bool:
     """Return True if the custom logger is active."""
-    return isinstance(sb_logger.Logger.CURRENT, _HierarchicalLogger)
+    return isinstance(logger, _HierarchicalLogger)
 
 
 def configure(
@@ -170,19 +171,20 @@ def configure(
     output_formats = _build_output_formats(folder, format_strs)
     default_logger = sb_logger.Logger(folder, output_formats)
     hier_logger = _HierarchicalLogger(default_logger, format_strs)
-    sb_logger.Logger.CURRENT = hier_logger
-    sb_logger.log("Logging to %s" % folder)
+    global logger
+    logger = hier_logger
+    logger.log("Logging to %s" % folder)
     assert is_configured()
 
 
 def record(key, val, exclude=None) -> None:
     """Alias for `stable_baselines3.logger.record`."""
-    sb_logger.record(key, val, exclude)
+    logger.record(key, val, exclude)
 
 
 def dump(step=0) -> None:
     """Alias for `stable_baselines3.logger.dump`."""
-    sb_logger.dump(step)
+    logger.dump(step)
 
 
 def accumulate_means(subdir_name: types.AnyPath) -> ContextManager:
@@ -210,5 +212,4 @@ def accumulate_means(subdir_name: types.AnyPath) -> ContextManager:
       A context manager.
     """
     assert is_configured()
-    hier_logger = sb_logger.Logger.CURRENT  # type: _HierarchicalLogger
-    return hier_logger.accumulate_means(subdir_name)
+    return logger.accumulate_means(subdir_name)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -2,8 +2,6 @@ import csv
 import os.path as osp
 from collections import defaultdict
 
-import stable_baselines3.common.logger as sb_logger
-
 import imitation.util.logger as logger
 
 
@@ -28,15 +26,15 @@ def test_no_accum(tmpdir):
 
     # Check that the recorded "A": -1 is overwritten by "A": 1 in the next line.
     # Previously, the observed value would be the mean of these two values (0) instead.
-    sb_logger.record("A", -1)
-    sb_logger.record("A", 1)
-    sb_logger.record("B", 1)
-    sb_logger.dump()
+    logger.record("A", -1)
+    logger.record("A", 1)
+    logger.record("B", 1)
+    logger.dump()
 
-    sb_logger.record("A", 2)
-    sb_logger.dump()
-    sb_logger.record("B", 3)
-    sb_logger.dump()
+    logger.record("A", 2)
+    logger.dump()
+    logger.record("B", 3)
+    logger.dump()
     expect = {"A": [1, 2, ""], "B": [1, "", 3]}
     _compare_csv_lines(osp.join(tmpdir, "progress.csv"), expect)
 
@@ -47,26 +45,26 @@ def test_hard(tmpdir):
     # Part One: Test logging outside of the accumulating scope, and within scopes
     # with two different different logging keys (including a repeat).
 
-    sb_logger.record("no_context", 1)
+    logger.record("no_context", 1)
 
     with logger.accumulate_means("disc"):
-        sb_logger.record("C", 2)
-        sb_logger.record("D", 2)
-        sb_logger.dump()
-        sb_logger.record("C", 4)
-        sb_logger.dump()
+        logger.record("C", 2)
+        logger.record("D", 2)
+        logger.dump()
+        logger.record("C", 4)
+        logger.dump()
 
     with logger.accumulate_means("gen"):
-        sb_logger.record("E", 2)
-        sb_logger.dump()
-        sb_logger.record("E", 0)
-        sb_logger.dump()
+        logger.record("E", 2)
+        logger.dump()
+        logger.record("E", 0)
+        logger.dump()
 
     with logger.accumulate_means("disc"):
-        sb_logger.record("C", 3)
-        sb_logger.dump()
+        logger.record("C", 3)
+        logger.dump()
 
-    sb_logger.dump()  # Writes 1 mean each from "gen" and "disc".
+    logger.dump()  # Writes 1 mean each from "gen" and "disc".
 
     expect_raw_gen = {"raw/gen/E": [2, 0]}
     expect_raw_disc = {
@@ -88,12 +86,12 @@ def test_hard(tmpdir):
     # Check that we append to the same logs after the first dump to "means/*".
 
     with logger.accumulate_means("disc"):
-        sb_logger.record("D", 100)
-        sb_logger.dump()
+        logger.record("D", 100)
+        logger.dump()
 
-    sb_logger.record("no_context", 2)
+    logger.record("no_context", 2)
 
-    sb_logger.dump()  # Writes 1 mean from "disc". "gen" is blank.
+    logger.dump()  # Writes 1 mean from "disc". "gen" is blank.
 
     expect_raw_gen = {"raw/gen/E": [2, 0]}
     expect_raw_disc = {


### PR DESCRIPTION
Related to #325

I tried to keep the code changes minimal. Tests in `test_logger.py` pass, and `quickstart.py` as well as `quickstart.sh` seem to be functional.