### PR TITLE
Upgrade SB3 and migrate to local logger

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "torch>=1.4.0",
         "tqdm",
         "scikit-learn>=0.21.2",
-        "stable-baselines3~=0.10.0",
+        "stable-baselines3",
         "sacred~=0.8.1",
         "tensorboard>=1.14",
     ],

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "torch>=1.4.0",
         "tqdm",
         "scikit-learn>=0.21.2",
-        "stable-baselines3",
+        "stable-baselines3>=1.1.0",
         "sacred~=0.8.1",
         "tensorboard>=1.14",
     ],

--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -18,6 +18,7 @@ from imitation.data import rollout, types
 from imitation.policies import base
 from imitation.util import logger
 
+
 def reconstruct_policy(
     policy_path: str,
     device: Union[th.device, str] = "auto",

--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -428,4 +428,4 @@ class BC:
     def __setstate__(self, state):
         self.__dict__.update(state)
         # callee should call set_logger if they want to override this
-        self._logger = state.get("logger") or logger.configure()
+        self.logger = state.get("logger") or logger.configure()

--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -12,11 +12,11 @@ import numpy as np
 import torch as th
 import torch.utils.data as th_data
 import tqdm.autonotebook as tqdm
-from stable_baselines3.common import logger, policies, utils, vec_env
+from stable_baselines3.common import policies, utils, vec_env
 
 from imitation.data import rollout, types
 from imitation.policies import base
-
+from imitation.util import logger
 
 def reconstruct_policy(
     policy_path: str,
@@ -193,6 +193,7 @@ class BC:
         ent_weight: float = 1e-3,
         l2_weight: float = 0.0,
         device: Union[str, th.device] = "auto",
+        custom_logger: Optional[logger.HierarchicalLogger] = None,
     ):
         """Behavioral cloning (BC).
 
@@ -213,11 +214,13 @@ class BC:
             ent_weight: scaling applied to the policy's entropy regularization.
             l2_weight: scaling applied to the policy's L2 regularization.
             device: name/identity of device to place policy on.
+            custom_logger: Where to log to; if None (default), creates a new logger.
         """
         if optimizer_kwargs:
             if "weight_decay" in optimizer_kwargs:
                 raise ValueError("Use the parameter l2_weight instead of weight_decay.")
         self.tensorboard_step = 0
+        self.logger = custom_logger or logger.configure()
 
         self.action_space = action_space
         self.observation_space = observation_space
@@ -387,7 +390,7 @@ class BC:
             if batch_num % log_interval == 0:
                 for stats in [stats_dict_it, stats_dict_loss]:
                     for k, v in stats.items():
-                        logger.record(f"bc/{k}", v)
+                        self.logger.record(f"bc/{k}", v)
                 # TODO(shwang): Maybe instead use a callback that can be shared between
                 #   all algorithms' `.train()` for generating rollout stats.
                 #   EvalCallback could be a good fit:
@@ -399,11 +402,11 @@ class BC:
                         rollout.make_min_episodes(log_rollouts_n_episodes),
                     )
                     stats = rollout.rollout_stats(trajs)
-                    logger.record("batch_size", len(batch["obs"]))
+                    self.logger.record("batch_size", len(batch["obs"]))
                     for k, v in stats.items():
                         if "return" in k and "monitor" not in k:
-                            logger.record("rollout/" + k, v)
-                logger.dump(self.tensorboard_step)
+                            self.logger.record("rollout/" + k, v)
+                self.logger.dump(self.tensorboard_step)
             batch_num += 1
             self.tensorboard_step += 1
 

--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -418,3 +418,14 @@ class BC:
             policy_path: path to save policy to.
         """
         th.save(self.policy, policy_path)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # logger can't be pickled as it depends on open files
+        del state["logger"]
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        # callee should call set_logger if they want to override this
+        self._logger = state.get("logger") or logger.configure()

--- a/src/imitation/algorithms/dagger.py
+++ b/src/imitation/algorithms/dagger.py
@@ -15,12 +15,12 @@ from typing import Callable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch as th
-from stable_baselines3.common import logger, policies, utils, vec_env
+from stable_baselines3.common import policies, utils, vec_env
 from torch.utils import data as th_data
 
 from imitation.algorithms import bc
 from imitation.data import rollout, types
-from imitation.util import util
+from imitation.util import logger, util
 
 
 class BetaSchedule(abc.ABC):
@@ -287,6 +287,7 @@ class DAggerTrainer:
         beta_schedule: Callable[[int], float] = None,
         batch_size: int = 32,
         bc_kwargs: Optional[dict] = None,
+        custom_logger: Optional[logger.HierarchicalLogger] = None,
     ):
         """DaggerTrainer constructor.
 
@@ -314,9 +315,11 @@ class DAggerTrainer:
         self._last_loaded_round = -1
         self._all_demos = []
 
+        self.logger = custom_logger or logger.configure()
         self.bc_trainer = bc.BC(
             self.venv.observation_space,
             self.venv.action_space,
+            custom_logger=self.logger,
             **self.bc_kwargs,
         )
 
@@ -598,16 +601,16 @@ class SimpleDAggerTrainer(DAggerTrainer):
 
             for traj in trajectories:
                 _save_dagger_demo(traj, collector.save_dir)
-                logger.record_mean("dagger/mean_episode_reward", np.sum(traj.rews))
+                self.logger.record_mean("dagger/mean_episode_reward", np.sum(traj.rews))
                 round_timestep_count += len(traj)
                 total_timestep_count += len(traj)
 
             round_episode_count += len(trajectories)
 
-            logger.record("dagger/total_timesteps", total_timestep_count)
-            logger.record("dagger/round_num", round_num)
-            logger.record("dagger/round_episode_count", round_episode_count)
-            logger.record("dagger/round_timestep_count", round_timestep_count)
+            self.logger.record("dagger/total_timesteps", total_timestep_count)
+            self.logger.record("dagger/round_num", round_num)
+            self.logger.record("dagger/round_episode_count", round_episode_count)
+            self.logger.record("dagger/round_timestep_count", round_timestep_count)
 
             # `logger.dump` is called inside BC.train within the following fn call:
             self.extend_and_update(bc_train_kwargs)

--- a/src/imitation/data/types.py
+++ b/src/imitation/data/types.py
@@ -32,7 +32,7 @@ def dataclass_quick_asdict(dataclass_instance) -> dict:
 
 
 def path_to_str(path: AnyPath) -> str:
-    if isinstance(AnyPath, bytes):
+    if isinstance(path, bytes):
         return path.decode()
     else:
         return str(path)

--- a/src/imitation/data/types.py
+++ b/src/imitation/data/types.py
@@ -31,6 +31,13 @@ def dataclass_quick_asdict(dataclass_instance) -> dict:
     return d
 
 
+def path_to_str(path: AnyPath) -> str:
+    if isinstance(AnyPath, bytes):
+        return path.decode()
+    else:
+        return str(path)
+
+
 @dataclasses.dataclass(frozen=True)
 class Trajectory:
     """A trajectory, e.g. a one episode rollout from an expert policy."""

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -117,14 +117,10 @@ def rollouts_and_policy(
     os.makedirs(policy_dir, exist_ok=True)
 
     if init_tensorboard:
-        # sb_tensorboard_dir = osp.join(log_dir, "sb_tb")
+        sb_tensorboard_dir = osp.join(log_dir, "sb_tb")
         # Convert sacred's ReadOnlyDict to dict so we can modify on next line.
         init_rl_kwargs = dict(init_rl_kwargs)
-        # init_rl_kwargs["tensorboard_log"] = sb_tensorboard_dir
-        # FIXME(sam): this is another hack to prevent SB3 from configuring the
-        # logger on the first .learn() call. Remove it once SB3 issue #109 is
-        # fixed.
-        init_rl_kwargs["tensorboard_log"] = None
+        init_rl_kwargs["tensorboard_log"] = sb_tensorboard_dir
 
     venv = util.make_vec_env(
         env_name,

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -167,17 +167,10 @@ def train_adversarial(
         max_episode_steps=max_episode_steps,
     )
 
-    # if init_tensorboard:
-    #     tensorboard_log = osp.join(log_dir, "sb_tb")
-    # else:
-    #     tensorboard_log = None
-
+    tensorboard_log = osp.join(log_dir, "sb_tb") if init_tensorboard else None
     gen_algo = util.init_rl(
-        # FIXME(sam): ignoring tensorboard_log is a hack to prevent SB3 from
-        # re-configuring the logger (SB3 issue #109). See init_rl() for details.
-        # TODO(shwang): Let's get rid of init_rl after SB3 issue #109 is fixed?
-        # Besides sidestepping #109, init_rl is just a stub function.
         venv,
+        tensorboard_log=tensorboard_log,
         **init_rl_kwargs,
     )
 

--- a/src/imitation/util/logger.py
+++ b/src/imitation/util/logger.py
@@ -11,7 +11,7 @@ from imitation.data import types
 
 
 def _build_output_formats(
-    folder: types.AnyPath,
+    folder: str,
     format_strs: Sequence[str] = None,
 ) -> Sequence[sb_logger.KVWriter]:
     """Build output formats for initializing a Stable Baselines Logger.
@@ -83,6 +83,7 @@ class HierarchicalLogger(sb_logger.Logger):
         if subdir in self._cached_loggers:
             logger = self._cached_loggers[subdir]
         else:
+            subdir = types.path_to_str(subdir)
             folder = os.path.join(self.default_logger.dir, "raw", subdir)
             os.makedirs(folder, exist_ok=True)
             output_formats = _build_output_formats(folder, self.format_strs)
@@ -153,6 +154,8 @@ def configure(
         now = datetime.datetime.now()
         timestamp = now.strftime("imitation-%Y-%m-%d-%H-%M-%S-%f")
         folder = os.path.join(tempfile.gettempdir(), timestamp)
+    else:
+        folder = types.path_to_str(folder)
     logging.info("Logging to '%s'", folder)
     if format_strs is None:
         format_strs = ["stdout", "log", "csv"]

--- a/src/imitation/util/logger.py
+++ b/src/imitation/util/logger.py
@@ -146,7 +146,8 @@ def configure(
     """
     if folder is None:
         if folder is None:
-            timestamp = datetime.datetime.now().strftime("imitation-%Y-%m-%d-%H-%M-%S-%f")
+            now = datetime.datetime.now()
+            timestamp = now.strftime("imitation-%Y-%m-%d-%H-%M-%S-%f")
             folder = os.path.join(tempfile.gettempdir(), timestamp)
     logging.info("Logging to '%s'", folder)
     if format_strs is None:

--- a/src/imitation/util/logger.py
+++ b/src/imitation/util/logger.py
@@ -1,5 +1,8 @@
 import contextlib
+import datetime
+import logging
 import os
+import tempfile
 from typing import Optional, Sequence
 
 import stable_baselines3.common.logger as sb_logger
@@ -129,8 +132,8 @@ class HierarchicalLogger(sb_logger.Logger):
 
 
 def configure(
-    folder: types.AnyPath, format_strs: Optional[Sequence[str]] = None
-) -> sb_logger.Logger:
+    folder: Optional[types.AnyPath] = None, format_strs: Optional[Sequence[str]] = None
+) -> HierarchicalLogger:
     """Configure Stable Baselines logger to be `accumulate_means()`-compatible.
 
     After this function is called, `stable_baselines3.logger.{configure,reset}()`
@@ -141,6 +144,11 @@ def configure(
         format_strs: An list of output format strings. For details on available
           output formats see `stable_baselines3.logger.make_output_format`.
     """
+    if folder is None:
+        if folder is None:
+            timestamp = datetime.datetime.now().strftime("imitation-%Y-%m-%d-%H-%M-%S-%f")
+            folder = os.path.join(tempfile.gettempdir(), timestamp)
+    logging.info("Logging to '%s'", folder)
     if format_strs is None:
         format_strs = ["stdout", "log", "csv"]
     output_formats = _build_output_formats(folder, format_strs)

--- a/src/imitation/util/logger.py
+++ b/src/imitation/util/logger.py
@@ -1,6 +1,6 @@
 import contextlib
 import os
-from typing import ContextManager, Optional, Sequence
+from typing import Optional, Sequence
 
 import stable_baselines3.common.logger as sb_logger
 
@@ -23,7 +23,7 @@ def _build_output_formats(
     return output_formats
 
 
-class _HierarchicalLogger(sb_logger.Logger):
+class HierarchicalLogger(sb_logger.Logger):
     def __init__(
         self,
         default_logger: sb_logger.Logger,
@@ -128,28 +128,9 @@ class _HierarchicalLogger(sb_logger.Logger):
         raise NotImplementedError
 
 
-def _sb_logger_configure_replacement(*args, **kwargs):
-    raise RuntimeError(
-        "Shouldn't call stable_baselines3.logger.configure "
-        "once imitation.logger.configure() has been called"
-    )
-
-
-def _sb_logger_reset_replacement():
-    raise RuntimeError(
-        "Shouldn't call stable_baselines3.logger.reset "
-        "once imitation.logger.configure() has been called"
-    )
-
-
-def is_configured() -> bool:
-    """Return True if the custom logger is active."""
-    return isinstance(sb_logger.Logger.CURRENT, _HierarchicalLogger)
-
-
 def configure(
     folder: types.AnyPath, format_strs: Optional[Sequence[str]] = None
-) -> None:
+) -> sb_logger.Logger:
     """Configure Stable Baselines logger to be `accumulate_means()`-compatible.
 
     After this function is called, `stable_baselines3.logger.{configure,reset}()`
@@ -160,55 +141,9 @@ def configure(
         format_strs: An list of output format strings. For details on available
           output formats see `stable_baselines3.logger.make_output_format`.
     """
-    # Replace `stable_baselines3.logger` methods with erroring stubs to
-    # prevent unexpected logging state from mixed logging configuration.
-    sb_logger.configure = _sb_logger_configure_replacement
-    sb_logger.reset = _sb_logger_reset_replacement
-
     if format_strs is None:
         format_strs = ["stdout", "log", "csv"]
     output_formats = _build_output_formats(folder, format_strs)
     default_logger = sb_logger.Logger(folder, output_formats)
-    hier_logger = _HierarchicalLogger(default_logger, format_strs)
-    sb_logger.Logger.CURRENT = hier_logger
-    sb_logger.log("Logging to %s" % folder)
-    assert is_configured()
-
-
-def record(key, val, exclude=None) -> None:
-    """Alias for `stable_baselines3.logger.record`."""
-    sb_logger.record(key, val, exclude)
-
-
-def dump(step=0) -> None:
-    """Alias for `stable_baselines3.logger.dump`."""
-    sb_logger.dump(step)
-
-
-def accumulate_means(subdir_name: types.AnyPath) -> ContextManager:
-    """Temporarily redirect record() to a different logger and auto-track kvmeans.
-
-    Within this context, the original logger is swapped out for a special logger
-    in directory `"{current_logging_dir}/raw/{subdir_name}"`.
-
-    The special logger's `stable_baselines3.logger.record(key, val)`, in addition
-    to tracking its own logs, also forwards the log to the original logger's
-    `.record_mean()` under the key `mean/{subdir_name}/{key}`.
-
-    After the context exits, these means can be dumped as usual using
-    `stable_baselines3.logger.dump()` or `imitation.util.logger.dump()`.
-
-    Note that the behavior of other logging methods, `log` and `record_mean`
-    are unmodified and will go straight to the original logger.
-
-    This context cannot be nested.
-
-    Args:
-      subdir_name: A string key for building the logger, as described above.
-
-    Returns:
-      A context manager.
-    """
-    assert is_configured()
-    hier_logger = sb_logger.Logger.CURRENT  # type: _HierarchicalLogger
-    return hier_logger.accumulate_means(subdir_name)
+    hier_logger = HierarchicalLogger(default_logger, format_strs)
+    return hier_logger

--- a/src/imitation/util/util.py
+++ b/src/imitation/util/util.py
@@ -112,6 +112,8 @@ def make_vec_env(
         return DummyVecEnv(env_fns)
 
 
+# TODO(adam): this is a very simple function; convenient given how Sacred config
+# currently works, but we should maybe refactor to avoid needing that.
 def init_rl(
     env: Union[gym.Env, VecEnv],
     model_class: Type[BaseAlgorithm] = stable_baselines3.PPO,
@@ -131,17 +133,8 @@ def init_rl(
     Returns:
       An RL algorithm.
     """
-    # FIXME(sam): verbose=1 and tensorboard_log=None is a hack to prevent SB3
-    # from reconfiguring the logger after we've already configured it. Should
-    # remove once SB3 issue #109 is fixed (there are also >=2 other comments to
-    # this effect elsewhere; worth grepping for "#109").
-    all_kwargs = {
-        "verbose": 1,
-        "tensorboard_log": None,
-    }
-    all_kwargs.update(model_kwargs)
     return model_class(
-        policy_class, env, **all_kwargs
+        policy_class, env, **model_kwargs
     )  # pytype: disable=not-instantiable
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -322,3 +322,14 @@ def test_zero_length_fails():
     empty = np.array([])
     with pytest.raises(ValueError, match=r"Degenerate trajectory.*"):
         types.Trajectory(obs=np.array([42]), acts=empty, infos=None)
+
+
+def test_path_to_str():
+    assert types.path_to_str("") == ""
+    assert types.path_to_str(b"") == ""
+    assert types.path_to_str("foo") == "foo"
+    assert types.path_to_str(b"foo") == "foo"
+    assert types.path_to_str(pathlib.Path("foo")) == "foo"
+    assert types.path_to_str("/foo/bar") == "/foo/bar"
+    assert types.path_to_str(b"/foo/bar") == "/foo/bar"
+    assert types.path_to_str(pathlib.Path("/foo", "bar"))

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -49,7 +49,7 @@ def test_reentry_fails(tmpdir):
 
     with hier_logger.accumulate_means("foo"):
         with pytest.raises(RuntimeError, match=r"Nested.*"):
-            with hier_logger.accumulate_means("bar"):
+            with hier_logger.accumulate_means("bar"):  # pragma: no cover
                 pass
 
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -2,8 +2,6 @@ import csv
 import os.path as osp
 from collections import defaultdict
 
-import stable_baselines3.common.logger as sb_logger
-
 import imitation.util.logger as logger
 
 
@@ -24,49 +22,49 @@ def _compare_csv_lines(csv_path: str, expect: dict):
 
 
 def test_no_accum(tmpdir):
-    logger.configure(tmpdir, ["csv"])
+    hier_logger = logger.configure(tmpdir, ["csv"])
 
     # Check that the recorded "A": -1 is overwritten by "A": 1 in the next line.
     # Previously, the observed value would be the mean of these two values (0) instead.
-    sb_logger.record("A", -1)
-    sb_logger.record("A", 1)
-    sb_logger.record("B", 1)
-    sb_logger.dump()
+    hier_logger.record("A", -1)
+    hier_logger.record("A", 1)
+    hier_logger.record("B", 1)
+    hier_logger.dump()
 
-    sb_logger.record("A", 2)
-    sb_logger.dump()
-    sb_logger.record("B", 3)
-    sb_logger.dump()
+    hier_logger.record("A", 2)
+    hier_logger.dump()
+    hier_logger.record("B", 3)
+    hier_logger.dump()
     expect = {"A": [1, 2, ""], "B": [1, "", 3]}
     _compare_csv_lines(osp.join(tmpdir, "progress.csv"), expect)
 
 
 def test_hard(tmpdir):
-    logger.configure(tmpdir)
+    hier_logger = logger.configure(tmpdir)
 
     # Part One: Test logging outside of the accumulating scope, and within scopes
     # with two different different logging keys (including a repeat).
 
-    sb_logger.record("no_context", 1)
+    hier_logger.record("no_context", 1)
 
-    with logger.accumulate_means("disc"):
-        sb_logger.record("C", 2)
-        sb_logger.record("D", 2)
-        sb_logger.dump()
-        sb_logger.record("C", 4)
-        sb_logger.dump()
+    with hier_logger.accumulate_means("disc"):
+        hier_logger.record("C", 2)
+        hier_logger.record("D", 2)
+        hier_logger.dump()
+        hier_logger.record("C", 4)
+        hier_logger.dump()
 
-    with logger.accumulate_means("gen"):
-        sb_logger.record("E", 2)
-        sb_logger.dump()
-        sb_logger.record("E", 0)
-        sb_logger.dump()
+    with hier_logger.accumulate_means("gen"):
+        hier_logger.record("E", 2)
+        hier_logger.dump()
+        hier_logger.record("E", 0)
+        hier_logger.dump()
 
-    with logger.accumulate_means("disc"):
-        sb_logger.record("C", 3)
-        sb_logger.dump()
+    with hier_logger.accumulate_means("disc"):
+        hier_logger.record("C", 3)
+        hier_logger.dump()
 
-    sb_logger.dump()  # Writes 1 mean each from "gen" and "disc".
+    hier_logger.dump()  # Writes 1 mean each from "gen" and "disc".
 
     expect_raw_gen = {"raw/gen/E": [2, 0]}
     expect_raw_disc = {
@@ -87,13 +85,13 @@ def test_hard(tmpdir):
     # Part Two:
     # Check that we append to the same logs after the first dump to "means/*".
 
-    with logger.accumulate_means("disc"):
-        sb_logger.record("D", 100)
-        sb_logger.dump()
+    with hier_logger.accumulate_means("disc"):
+        hier_logger.record("D", 100)
+        hier_logger.dump()
 
-    sb_logger.record("no_context", 2)
+    hier_logger.record("no_context", 2)
 
-    sb_logger.dump()  # Writes 1 mean from "disc". "gen" is blank.
+    hier_logger.dump()  # Writes 1 mean from "disc". "gen" is blank.
 
     expect_raw_gen = {"raw/gen/E": [2, 0]}
     expect_raw_disc = {

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -73,8 +73,7 @@ def test_serialize_identity(env_name, model_cfg, normalize, tmpdir):
     model_name, model_cls_name = model_cfg
     model_cls = registry.load_attr(model_cls_name)
 
-    # FIXME(sam): verbose=1 is a hack to stop it from setting up SB logger
-    model = model_cls("MlpPolicy", venv, verbose=1)
+    model = model_cls("MlpPolicy", venv)
     model.learn(1000)
 
     venv.env_method("seed", 0)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -478,4 +478,4 @@ def test_analyze_gather_tb(tmpdir: str):
     )
     assert run.status == "COMPLETED"
     assert isinstance(run.result, dict)
-    assert run.result["n_tb_dirs"] == 2
+    assert run.result["n_tb_dirs"] == 4


### PR DESCRIPTION
Move from SB3 0.10.0 to latest version, currently 1.1.0.

SB3 moved from a global logger instance to a local logger for each algorithm. This PR switches to the same style.

I've also tidied up some hacks that we had to make things work with the global logger previously. I'm not sure I've caught all of them though. In particular there were some cases where `verbose=1` was flagged with a FIXME as being a workaround, but `verbose=1` also appears elsewhere in the codebase. I'm not sure whether these were introduced as a workaround or because we actually want that verbosity.

Overall I think this PR should be LOC negative :)

@qxcv: one tricky thing that came up here was that DAgger is pickled to save it (as is, indirectly, BC), but the Logger is not pickleable. I've just removed the Logger from pickle, and setup a default logger on restore. This feels a bit clunky though. I think you've got a better sense than me when DAgger needs to be saved/restored, so if you have a better idea for this let me know.

Fixes #325 and #327.