### PR TITLE
Configure logger in training scripts

### DIFF
--- a/docs/guide/gettingstarted.rst
+++ b/docs/guide/gettingstarted.rst
@@ -77,28 +77,35 @@ AIRL models on that data.
     # Train BC on expert data.
     # BC also accepts as `expert_data` any PyTorch-style DataLoader that iterates over
     # dictionaries containing observations and actions.
-    logger.configure(tempdir_path / "BC/")
-    bc_trainer = bc.BC(venv.observation_space, venv.action_space, expert_data=transitions)
+    bc_logger = logger.configure(tempdir_path / "BC/")
+    bc_trainer = bc.BC(
+        venv.observation_space,
+        venv.action_space,
+        expert_data=transitions,
+        custom_logger=bc_logger,
+    )
     bc_trainer.train(n_epochs=1)
 
     # Train GAIL on expert data.
     # GAIL, and AIRL also accept as `expert_data` any Pytorch-style DataLoader that
     # iterates over dictionaries containing observations, actions, and next_observations.
-    logger.configure(tempdir_path / "GAIL/")
+    gail_logger = logger.configure(tempdir_path / "GAIL/")
     gail_trainer = adversarial.GAIL(
         venv,
         expert_data=transitions,
         expert_batch_size=32,
         gen_algo=sb3.PPO("MlpPolicy", venv, verbose=1, n_steps=1024),
+        custom_logger=gail_logger,
     )
     gail_trainer.train(total_timesteps=2048)
 
     # Train AIRL on expert data.
-    logger.configure(tempdir_path / "AIRL/")
+    airl_logger = logger.configure(tempdir_path / "AIRL/")
     airl_trainer = adversarial.AIRL(
         venv,
         expert_data=transitions,
         expert_batch_size=32,
         gen_algo=sb3.PPO("MlpPolicy", venv, verbose=1, n_steps=1024),
+        custom_logger=airl_logger,
     )
     airl_trainer.train(total_timesteps=2048)

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -32,28 +32,35 @@ print(f"All Tensorboards and logging are being written inside {tempdir_path}/.")
 # Train BC on expert data.
 # BC also accepts as `expert_data` any PyTorch-style DataLoader that iterates over
 # dictionaries containing observations and actions.
-logger.configure(tempdir_path / "BC/")
-bc_trainer = bc.BC(venv.observation_space, venv.action_space, expert_data=transitions)
+bc_logger = logger.configure(tempdir_path / "BC/")
+bc_trainer = bc.BC(
+    venv.observation_space,
+    venv.action_space,
+    expert_data=transitions,
+    custom_logger=bc_logger,
+)
 bc_trainer.train(n_epochs=1)
 
 # Train GAIL on expert data.
 # GAIL, and AIRL also accept as `expert_data` any Pytorch-style DataLoader that
 # iterates over dictionaries containing observations, actions, and next_observations.
-logger.configure(tempdir_path / "GAIL/")
+gail_logger = logger.configure(tempdir_path / "GAIL/")
 gail_trainer = adversarial.GAIL(
     venv,
     expert_data=transitions,
     expert_batch_size=32,
     gen_algo=sb3.PPO("MlpPolicy", venv, verbose=1, n_steps=1024),
+    custom_logger=gail_logger,
 )
 gail_trainer.train(total_timesteps=2048)
 
 # Train AIRL on expert data.
-logger.configure(tempdir_path / "AIRL/")
+airl_logger = logger.configure(tempdir_path / "AIRL/")
 airl_trainer = adversarial.AIRL(
     venv,
     expert_data=transitions,
     expert_batch_size=32,
     gen_algo=sb3.PPO("MlpPolicy", venv, verbose=1, n_steps=1024),
+    custom_logger=airl_logger,
 )
 airl_trainer.train(total_timesteps=2048)

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -362,9 +362,13 @@ def rollout_stats(trajectories: Sequence[types.TrajectoryWithRew]) -> Dict[str, 
     for t in trajectories:
         if t.infos is not None:
             ep_return = t.infos[-1].get("episode", {}).get("r")
-            if ep_return:
+            if ep_return is not None:
                 monitor_ep_returns.append(ep_return)
     if monitor_ep_returns:
+        # Note monitor_ep_returns[i] may be from a different episode than ep_return[i]
+        # since we skip episodes with None infos. This is OK as we only return summary
+        # statistics, but you cannot e.g. compute the correlation between ep_return and
+        # monitor_ep_returns.
         traj_descriptors["monitor_return"] = np.asarray(monitor_ep_returns)
         # monitor_return_len may be < n_traj when infos is sometimes missing
         out_stats["monitor_return_len"] = len(traj_descriptors["monitor_return"])

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -358,10 +358,16 @@ def rollout_stats(trajectories: Sequence[types.TrajectoryWithRew]) -> Dict[str, 
         "len": np.asarray([len(t.rews) for t in trajectories]),
     }
 
-    infos_peek = trajectories[0].infos
-    if infos_peek is not None and "episode" in infos_peek[-1]:
-        monitor_ep_returns = [t.infos[-1]["episode"]["r"] for t in trajectories]
+    monitor_ep_returns = []
+    for t in trajectories:
+        if t.infos is not None:
+            ep_return = t.infos[-1].get("episode", {}).get("r")
+            if ep_return:
+                monitor_ep_returns.append(ep_return)
+    if monitor_ep_returns:
         traj_descriptors["monitor_return"] = np.asarray(monitor_ep_returns)
+        # monitor_return_len may be < n_traj when infos is sometimes missing
+        out_stats["monitor_return_len"] = len(traj_descriptors["monitor_return"])
 
     stat_names = ["min", "mean", "std", "max"]
     for desc_name, desc_vals in traj_descriptors.items():

--- a/src/imitation/scripts/config/expert_demos.py
+++ b/src/imitation/scripts/config/expert_demos.py
@@ -32,8 +32,6 @@ def expert_demos_defaults():
     policy_save_interval = 10000  # Num timesteps between saves (<=0 disables)
     policy_save_final = True  # If True, save after training is finished.
 
-    init_tensorboard = False  # If True, then write Tensorboard logs.
-
     log_root = os.path.join("output", "expert_demos")  # output directory
 
 

--- a/src/imitation/scripts/config/parallel.py
+++ b/src/imitation/scripts/config/parallel.py
@@ -71,7 +71,6 @@ def generate_test_data():
     }
     base_named_configs = ["cartpole", "fast"]
     base_config_updates = {
-        "init_tensorboard": True,
         "rollout_save_final": False,
     }
 
@@ -90,7 +89,6 @@ def example_cartpole_rl():
         }
     }
     base_named_configs = ["cartpole"]
-    base_config_updates = {"init_tensorboard": True}
     resources_per_trial = dict(cpu=4)
 
 
@@ -111,7 +109,6 @@ def example_rl_easy():
             },
         },
     }
-    base_config_updates = {"init_tensorboard": True}
     resources_per_trial = dict(cpu=4)
 
 
@@ -132,6 +129,5 @@ def example_gail_easy():
         },
     }
     base_config_updates = {
-        "init_tensorboard": True,
         "init_trainer_kwargs": {"use_gail": True},
     }

--- a/src/imitation/scripts/config/parallel.py
+++ b/src/imitation/scripts/config/parallel.py
@@ -56,8 +56,8 @@ def debug_log_root():
 def generate_test_data():
     """Used by tests/generate_test_data.sh to generate tests/data/gather_tb/.
 
-    "tests/data/gather_tb/" should contain 4 Tensorboard run directories ("sb_tb/" and
-    "tb/" for each of two trials in the search space below).
+    "tests/data/gather_tb/" should contain 2 Tensorboard run directories, one for each
+     of the trials in the search space below.
     """
     sacred_ex_name = "expert_demos"
     run_name = "TEST"

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -50,7 +50,6 @@ def train_defaults():
 
     log_root = os.path.join("output", "train_adversarial")  # output directory
     checkpoint_interval = 0  # Num epochs between checkpoints (<0 disables)
-    init_tensorboard = False  # If True, then write Tensorboard logs
     rollout_hint = None  # Used to generate default rollout_path
     data_dir = "data/"  # Default data directory
 

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -38,7 +38,6 @@ def rollouts_and_policy(
     rollout_save_n_episodes: Optional[int],
     policy_save_interval: int,
     policy_save_final: bool,
-    init_tensorboard: bool,
 ) -> dict:
     """Trains an expert policy from scratch and saves the rollouts and policy.
 
@@ -92,9 +91,6 @@ def rollouts_and_policy(
         policy_save_final: If True, then save the policy right after training is
             finished.
 
-        init_tensorboard: If True, then write tensorboard logs to {log_dir}/sb_tb
-            and "output/summary/...".
-
     Returns:
       The return value of `rollout_stats()` using the final policy.
     """
@@ -115,12 +111,6 @@ def rollouts_and_policy(
     policy_dir = osp.join(log_dir, "policies")
     os.makedirs(rollout_dir, exist_ok=True)
     os.makedirs(policy_dir, exist_ok=True)
-
-    if init_tensorboard:
-        sb_tensorboard_dir = osp.join(log_dir, "sb_tb")
-        # Convert sacred's ReadOnlyDict to dict so we can modify on next line.
-        init_rl_kwargs = dict(init_rl_kwargs)
-        init_rl_kwargs["tensorboard_log"] = sb_tensorboard_dir
 
     venv = util.make_vec_env(
         env_name,

--- a/src/imitation/scripts/expert_demos.py
+++ b/src/imitation/scripts/expert_demos.py
@@ -107,7 +107,7 @@ def rollouts_and_policy(
     eval_sample_until = rollout.make_min_episodes(n_episodes_eval)
 
     logging.basicConfig(level=logging.INFO)
-    logger.configure(
+    custom_logger = logger.configure(
         folder=osp.join(log_dir, "rl"), format_strs=["tensorboard", "stdout"]
     )
 
@@ -152,6 +152,7 @@ def rollouts_and_policy(
     callback = callbacks.CallbackList(callback_objs)
 
     policy = util.init_rl(venv, verbose=1, **init_rl_kwargs)
+    policy.set_logger(custom_logger)
     policy.learn(total_timesteps, callback=callback)
 
     # Save final artifacts after training is complete.

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -153,7 +153,6 @@ def train_adversarial(
 
     total_timesteps = int(total_timesteps)
 
-    logging.info("Logging to %s", log_dir)
     custom_logger = logger.configure(log_dir, ["tensorboard", "stdout"])
     os.makedirs(log_dir, exist_ok=True)
     sacred_util.build_sacred_symlink(log_dir, _run)
@@ -171,7 +170,6 @@ def train_adversarial(
     gen_algo = util.init_rl(
         venv,
         tensorboard_log=tensorboard_log,
-        custom_logger=custom_logger,
         **init_rl_kwargs,
     )
 

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -154,7 +154,7 @@ def train_adversarial(
     total_timesteps = int(total_timesteps)
 
     logging.info("Logging to %s", log_dir)
-    logger.configure(log_dir, ["tensorboard", "stdout"])
+    custom_logger = logger.configure(log_dir, ["tensorboard", "stdout"])
     os.makedirs(log_dir, exist_ok=True)
     sacred_util.build_sacred_symlink(log_dir, _run)
 
@@ -171,6 +171,7 @@ def train_adversarial(
     gen_algo = util.init_rl(
         venv,
         tensorboard_log=tensorboard_log,
+        custom_logger=custom_logger,
         **init_rl_kwargs,
     )
 
@@ -198,6 +199,7 @@ def train_adversarial(
         gen_algo=gen_algo,
         log_dir=log_dir,
         discrim_kwargs=final_discrim_kwargs,
+        custom_logger=custom_logger,
         **final_algorithm_kwargs,
     )
 

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -49,7 +49,6 @@ def train_adversarial(
     log_dir: str,
     total_timesteps: int,
     n_episodes_eval: int,
-    init_tensorboard: bool,
     checkpoint_interval: int,
     gen_batch_size: int,
     init_rl_kwargs: Mapping,
@@ -88,7 +87,6 @@ def train_adversarial(
             during training.
         n_episodes_eval: The number of episodes to average over when calculating
             the average episode reward of the imitation policy for return.
-        init_tensorboard: If True, then write tensorboard logs to `{log_dir}/sb_tb`.
         checkpoint_interval: Save the discriminator and generator models every
             `checkpoint_interval` rounds and after training is complete. If 0,
             then only save weights after training is complete. If <0, then don't
@@ -166,10 +164,8 @@ def train_adversarial(
         max_episode_steps=max_episode_steps,
     )
 
-    tensorboard_log = osp.join(log_dir, "sb_tb") if init_tensorboard else None
     gen_algo = util.init_rl(
         venv,
-        tensorboard_log=tensorboard_log,
         **init_rl_kwargs,
     )
 

--- a/src/imitation/scripts/train_bc.py
+++ b/src/imitation/scripts/train_bc.py
@@ -83,7 +83,7 @@ def train_bc(
     log_dir.mkdir(parents=True, exist_ok=True)
     logging.info("Logging to %s", log_dir)
 
-    logger.configure(log_dir, ["tensorboard", "stdout"])
+    custom_logger = logger.configure(log_dir, ["tensorboard", "stdout"])
     sacred_util.build_sacred_symlink(log_dir, _run)
 
     if expert_data_src_format == "path":
@@ -120,6 +120,7 @@ def train_bc(
         l2_weight=l2_weight,
         optimizer_cls=optimizer_cls,
         optimizer_kwargs=optimizer_kwargs,
+        custom_logger=custom_logger,
     )
     model.train(
         n_epochs=n_epochs,

--- a/src/imitation/scripts/train_dagger.py
+++ b/src/imitation/scripts/train_dagger.py
@@ -78,7 +78,7 @@ def train_dagger(
     log_dir.mkdir(parents=True, exist_ok=True)
     logging.info("Logging to %s", log_dir)
 
-    logger.configure(log_dir, ["tensorboard", "stdout"])
+    custom_logger = logger.configure(log_dir, ["tensorboard", "stdout"])
     sacred_util.build_sacred_symlink(log_dir, _run)
 
     if expert_policy_path is None:
@@ -128,6 +128,7 @@ def train_dagger(
             optimizer_cls=optimizer_cls,
             optimizer_kwargs=optimizer_kwargs,
         ),
+        custom_logger=custom_logger,
     )
     model.train(
         total_timesteps=int(total_timesteps),

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -23,7 +23,7 @@ def _algorithm_cls(request):
 
 
 def test_train_disc_small_expert_data_warning(tmpdir, _algorithm_cls):
-    logger.configure(tmpdir, ["tensorboard", "stdout"])
+    custom_logger = logger.configure(tmpdir, ["tensorboard", "stdout"])
     venv = util.make_vec_env(
         "CartPole-v1",
         n_envs=2,
@@ -40,6 +40,7 @@ def test_train_disc_small_expert_data_warning(tmpdir, _algorithm_cls):
             expert_batch_size=21,
             gen_algo=gen_algo,
             log_dir=tmpdir,
+            custom_logger=custom_logger,
         )
 
     with pytest.raises(ValueError, match="expert_batch_size.*positive"):
@@ -49,6 +50,7 @@ def test_train_disc_small_expert_data_warning(tmpdir, _algorithm_cls):
             expert_batch_size=-1,
             gen_algo=gen_algo,
             log_dir=tmpdir,
+            custom_logger=custom_logger,
         )
 
 
@@ -89,7 +91,6 @@ def trainer(
     expert_batch_size: int,
     expert_transitions: types.Transitions,
 ):
-    logger.configure(tmpdir, ["tensorboard", "stdout"])
     if _convert_dataset:
         expert_data = th_data.DataLoader(
             expert_transitions,
@@ -109,13 +110,14 @@ def trainer(
     )
 
     gen_algo = util.init_rl(venv, verbose=1)
-
+    custom_logger = logger.configure(tmpdir, ["tensorboard", "stdout"])
     trainer = _algorithm_cls(
         venv=venv,
         expert_data=expert_data,
         expert_batch_size=expert_batch_size,
         gen_algo=gen_algo,
         log_dir=tmpdir,
+        custom_logger=custom_logger,
     )
 
     try:

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -166,7 +166,6 @@ def test_train_adversarial(tmpdir):
     config_updates = {
         "log_root": tmpdir,
         "rollout_path": CARTPOLE_TEST_ROLLOUT_PATH,
-        "init_tensorboard": True,
     }
     run = train_adversarial.train_adversarial_ex.run(
         named_configs=named_configs,
@@ -478,4 +477,4 @@ def test_analyze_gather_tb(tmpdir: str):
     )
     assert run.status == "COMPLETED"
     assert isinstance(run.result, dict)
-    assert run.result["n_tb_dirs"] == 4
+    assert run.result["n_tb_dirs"] == 2


### PR DESCRIPTION
Hotfix for https://github.com/HumanCompatibleAI/imitation/pull/328

I forgot to update the scripts to use the new log configuration, which requires passing in the logger to the algorithm. Updates `train_{adversarial,bc,dagger}` to do this.

I also started seeing some unrelated unit test breakage in DAgger due to a mixture of trajectories that do and don't have `infos` (online demos have them, offline expert demos don't since they were stripped to save space). So I patched `rollouts` to handle this.