### PR TITLE
Copy to make arrays mutable for PyTorch

### DIFF
--- a/src/imitation/data/types.py
+++ b/src/imitation/data/types.py
@@ -109,7 +109,7 @@ def transitions_collate_fn(
     dicts.
     """
     batch_no_infos = [
-        {k: v for k, v in sample.items() if k != "infos"} for sample in batch
+        {k: np.array(v) for k, v in sample.items() if k != "infos"} for sample in batch
     ]
 
     result = th_data.dataloader.default_collate(batch_no_infos)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -64,15 +64,23 @@ def test_main_console(script_mod):
 
 
 def test_train_dagger_main(tmpdir):
-    run = train_dagger.train_dagger_ex.run(
-        named_configs=["cartpole", "fast"],
-        config_updates=dict(
-            log_root=tmpdir,
-            expert_data_src=CARTPOLE_TEST_ROLLOUT_PATH,
-            expert_policy_path=CARTPOLE_TEST_POLICY_PATH,
-            expert_policy_type="ppo",
-        ),
-    )
+    with pytest.warns(None) as record:
+        run = train_dagger.train_dagger_ex.run(
+            named_configs=["cartpole", "fast"],
+            config_updates=dict(
+                log_root=tmpdir,
+                expert_data_src=CARTPOLE_TEST_ROLLOUT_PATH,
+                expert_policy_path=CARTPOLE_TEST_POLICY_PATH,
+                expert_policy_type="ppo",
+            ),
+        )
+    for warning in record:
+        # PyTorch wants writeable arrays.
+        # See https://github.com/HumanCompatibleAI/imitation/issues/219
+        assert not (
+            warning.category == UserWarning
+            and "NumPy array is not writeable" in warning.message.args[0]
+        )
     assert run.status == "COMPLETED"
     assert isinstance(run.result, dict)
 


### PR DESCRIPTION
Fixes https://github.com/HumanCompatibleAI/imitation/issues/219

May introduce a slight performance overhead -- I've not tested. @shwang thought PyTorch was soft-copying anyway. I expect this to be insignificant for current workloads, we can do something smarter if/when profiling reveals this is an issue.