### PR TITLE
CodeCov: add flag for core part of project

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -34,3 +34,12 @@ coverage:
         target: 100%
         paths:
           - "tests/"
+
+flags:
+  core:
+    paths:
+      # Everything except examples and scripts that we're less strict about
+      - "src/imitation/"
+      - "!src/imitation/envs/examples/"
+      - "!src/imitation/scripts/"
+      - "tests/"


### PR DESCRIPTION
We'd like to track and report headline code coverage for core parts of the project: the library itself and tests. We want to exclude example code and scripts. This adds a CodeCov flag to enable that.

One thing I'm unsure about is maybe we should actually pay close attention to script code coverage? A lot of users will interact with the scripts. But code coverage for scripts tends to be a bit meaningless... if we add more configs, the code coverage goes down, but having fewer example configs is not desirable. So I'm inclined to continue to exclude it.