### PR TITLE
Add support for off-policy RL algorithms to `AdversarialTrainer` (GAIL/AIRL)

### DIFF
--- a/tests/algorithms/test_adversarial.py
+++ b/tests/algorithms/test_adversarial.py
@@ -174,7 +174,7 @@ def test_train_disc_step_no_crash(trainer, expert_batch_size):
 
 
 def test_train_gen_train_disc_no_crash(trainer, n_updates=2):
-    trainer.train_gen(n_updates * trainer.gen_batch_size)
+    trainer.train_gen(n_updates * trainer.gen_train_timesteps)
     trainer.train_disc()
 
 


### PR DESCRIPTION
`AdversarialTrainer` required an `OnPolicyAlgorithm`. There are two things that need this: 
  1. There's a fairly mundane implementation reason for wanting to extract the batch size from the RL algorithm, and off-policy algorithms don't have a relevant attribute. To fix this, I do the naive thing of just letting the user specify the batch size, and defaulting to the minimum number of timesteps one can train that RL algorithm for if unspecified.
  2. More fundamentally, AIRL needs a stochastic policy. In principle one could have an on-policy algorithm with deterministic policy, or an off-policy algorithm with stochastic policy, but currently in SB3 it seems all on-policy algos have stochastic policies and all off-policy algos have deterministic policies. However, GAIL doesn't need this. So I've added a check specifically in AIRL for stochastic policies (or, more precisely, `evaluate_actions` being defined which is how we actually get the policy probs).

I've left the `train_adversarial` code using on-policy algorithms and `gen_batch_size`. It wouldn't be that hard to generalize that, but I think we can wait until we have a concrete use-case to do that, especially since we may want to shake up that code anyway by unifying different reward learning algorithms into one training script.