### PR TITLE
Make generate_trajectories more flexible

### DIFF
--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -237,9 +237,12 @@ def make_sample_until(
 
     return sample_until
 
+# A PolicyCallable is a function that takes an array of observations
+# and returns an array of corresponding actions.
+PolicyCallable = Callable[[np.ndarray], np.ndarray]
 
 def generate_trajectories(
-    policy,
+    policy: Union[BaseAlgorithm, BasePolicy, PolicyCallable, None],
     venv: VecEnv,
     sample_until: GenTrajTerminationFn,
     *,
@@ -265,7 +268,28 @@ def generate_trajectories(
       may be collected to avoid biasing process towards short episodes; the user
       should truncate if required.
     """
-    get_action = policy.predict
+    if policy is None:
+
+        def get_actions(states):
+            acts = []
+            for _ in range(len(states)):
+                acts.append(venv.action_space.sample())
+            return np.stack(acts, axis=0)
+
+    elif isinstance(policy, (BaseAlgorithm, BasePolicy)):
+
+        def get_actions(states):
+            acts, _ = policy.predict(states, deterministic=deterministic_policy)
+            return acts
+
+    elif isinstance(policy, Callable):
+        get_actions = policy
+    else:
+        raise TypeError(
+            "Policy must be None, a stable-baselines policy or algorithm, "
+            f"or a Callable, got {type(policy)} instead"
+        )
+
     if isinstance(policy, BaseAlgorithm):
         # check that the observation and action spaces of policy and environment match
         check_for_correct_spaces(venv, policy.observation_space, policy.action_space)
@@ -292,7 +316,7 @@ def generate_trajectories(
     # To start with, all environments are active.
     active = np.ones(venv.num_envs, dtype=bool)
     while np.any(active):
-        acts, _ = get_action(obs, deterministic=deterministic_policy)
+        acts = get_actions(obs)
         obs, rews, dones, infos = venv.step(acts)
 
         # If an environment is inactive, i.e. the episode completed for that

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -241,10 +241,42 @@ def make_sample_until(
 # A PolicyCallable is a function that takes an array of observations
 # and returns an array of corresponding actions.
 PolicyCallable = Callable[[np.ndarray], np.ndarray]
+AnyPolicy = Union[BaseAlgorithm, BasePolicy, PolicyCallable, None]
+
+
+def _policy_to_callable(
+    policy: AnyPolicy, venv: VecEnv, deterministic_policy: bool
+) -> PolicyCallable:
+    """Converts any policy-like object into a function from observations to actions."""
+    if policy is None:
+
+        def get_actions(states):
+            acts = [venv.action_space.sample() for _ in range(len(states))]
+            return np.stack(acts, axis=0)
+
+    elif isinstance(policy, Callable):
+        get_actions = policy
+    elif isinstance(policy, (BaseAlgorithm, BasePolicy)):
+
+        def get_actions(states):
+            acts, _ = policy.predict(states, deterministic=deterministic_policy)
+            return acts
+
+    else:
+        raise TypeError(
+            "Policy must be None, a stable-baselines policy or algorithm, "
+            f"or a Callable, got {type(policy)} instead"
+        )
+
+    if isinstance(policy, BaseAlgorithm):
+        # check that the observation and action spaces of policy and environment match
+        check_for_correct_spaces(venv, policy.observation_space, policy.action_space)
+
+    return get_actions
 
 
 def generate_trajectories(
-    policy: Union[BaseAlgorithm, BasePolicy, PolicyCallable, None],
+    policy: AnyPolicy,
     venv: VecEnv,
     sample_until: GenTrajTerminationFn,
     *,
@@ -273,33 +305,7 @@ def generate_trajectories(
       may be collected to avoid biasing process towards short episodes; the user
       should truncate if required.
     """
-    if policy is None:
-
-        def get_actions(states):
-            acts = []
-            for _ in range(len(states)):
-                acts.append(venv.action_space.sample())
-            return np.stack(acts, axis=0)
-
-    elif isinstance(policy, (BaseAlgorithm, BasePolicy)):
-
-        def get_actions(states):
-            acts, _ = policy.predict(  # pytype: disable=attribute-error
-                states, deterministic=deterministic_policy
-            )
-            return acts
-
-    elif isinstance(policy, Callable):
-        get_actions = policy
-    else:
-        raise TypeError(
-            "Policy must be None, a stable-baselines policy or algorithm, "
-            f"or a Callable, got {type(policy)} instead"
-        )
-
-    if isinstance(policy, BaseAlgorithm):
-        # check that the observation and action spaces of policy and environment match
-        check_for_correct_spaces(venv, policy.observation_space, policy.action_space)
+    get_actions = _policy_to_callable(policy, venv, deterministic_policy)
 
     # Collect rollout tuples.
     trajectories = []
@@ -476,13 +482,21 @@ def flatten_trajectories_with_rew(
 
 
 def generate_transitions(
-    policy, venv, n_timesteps: int, *, truncate: bool = True, **kwargs
+    policy: AnyPolicy,
+    venv: VecEnv,
+    n_timesteps: int,
+    *,
+    truncate: bool = True,
+    **kwargs,
 ) -> types.TransitionsWithRew:
     """Generate obs-action-next_obs-reward tuples.
 
     Args:
-      policy (BasePolicy or BaseAlgorithm): A stable_baselines3 policy or
-          algorithm, trained on the gym environment.
+      policy: Can be any of the following:
+          - A stable_baselines3 policy or algorithm trained on the gym environment
+          - A Callable that takes an ndarray of observations and returns an ndarray
+          of corresponding actions
+          - None, in which case actions will be sampled randomly
       venv: The vectorized environments to interact with.
       n_timesteps: The minimum number of timesteps to sample.
       truncate: If True, then drop any additional samples to ensure that exactly
@@ -507,7 +521,7 @@ def generate_transitions(
 
 def rollout_and_save(
     path: str,
-    policy: Union[BaseAlgorithm, BasePolicy],
+    policy: AnyPolicy,
     venv: VecEnv,
     sample_until: GenTrajTerminationFn,
     *,
@@ -522,6 +536,11 @@ def rollout_and_save(
 
     Args:
       path: Rollouts are saved to this path.
+      policy: Can be any of the following:
+          - A stable_baselines3 policy or algorithm trained on the gym environment
+          - A Callable that takes an ndarray of observations and returns an ndarray
+          of corresponding actions
+          - None, in which case actions will be sampled randomly
       venv: The vectorized environments.
       sample_until: End condition for rollout sampling.
       unwrap: If True, then save original observations and rewards (instead of
@@ -531,7 +550,7 @@ def rollout_and_save(
         this field to None. Excluding `infos` can save a lot of space during
         pickles.
       verbose: If True, then print out rollout stats before saving.
-      deterministic_policy: Argument from `generate_trajectories`.
+      **kwargs: Passed through to `generate_trajectories`.
     """
     trajs = generate_trajectories(policy, venv, sample_until, **kwargs)
     if unwrap:

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -261,7 +261,12 @@ def _policy_to_callable(
         # (which would call .forward()). So this elif clause must come first!
 
         def get_actions(states):
-            acts, _ = policy.predict(states, deterministic=deterministic_policy)
+            # pytype doesn't seem to understand that policy is a BaseAlgorithm
+            # or BasePolicy here, rather than a Callable
+            acts, _ = policy.predict(  # pytype: disable=attribute-error
+                states,
+                deterministic=deterministic_policy,
+            )
             return acts
 
     elif isinstance(policy, Callable):

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -237,9 +237,11 @@ def make_sample_until(
 
     return sample_until
 
+
 # A PolicyCallable is a function that takes an array of observations
 # and returns an array of corresponding actions.
 PolicyCallable = Callable[[np.ndarray], np.ndarray]
+
 
 def generate_trajectories(
     policy: Union[BaseAlgorithm, BasePolicy, PolicyCallable, None],
@@ -252,8 +254,11 @@ def generate_trajectories(
     """Generate trajectory dictionaries from a policy and an environment.
 
     Args:
-      policy (BasePolicy or BaseAlgorithm): A stable_baselines3 policy or algorithm
-          trained on the gym environment.
+      policy: Can be any of the following:
+        - A stable_baselines3 policy or algorithm trained on the gym environment
+        - A Callable that takes an ndarray of observations and returns an ndarray
+          of corresponding actions
+        - None, in which case actions will be sampled randomly
       venv: The vectorized environments to interact with.
       sample_until: A function determining the termination condition.
           It takes a sequence of trajectories, and returns a bool.
@@ -279,7 +284,9 @@ def generate_trajectories(
     elif isinstance(policy, (BaseAlgorithm, BasePolicy)):
 
         def get_actions(states):
-            acts, _ = policy.predict(states, deterministic=deterministic_policy)
+            acts, _ = policy.predict(  # pytype: disable=attribute-error
+                states, deterministic=deterministic_policy
+            )
             return acts
 
     elif isinstance(policy, Callable):

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -255,10 +255,10 @@ def generate_trajectories(
 
     Args:
       policy: Can be any of the following:
-        - A stable_baselines3 policy or algorithm trained on the gym environment
-        - A Callable that takes an ndarray of observations and returns an ndarray
+          - A stable_baselines3 policy or algorithm trained on the gym environment
+          - A Callable that takes an ndarray of observations and returns an ndarray
           of corresponding actions
-        - None, in which case actions will be sampled randomly
+          - None, in which case actions will be sampled randomly
       venv: The vectorized environments to interact with.
       sample_until: A function determining the termination condition.
           It takes a sequence of trajectories, and returns a bool.

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -254,13 +254,18 @@ def _policy_to_callable(
             acts = [venv.action_space.sample() for _ in range(len(states))]
             return np.stack(acts, axis=0)
 
-    elif isinstance(policy, Callable):
-        get_actions = policy
     elif isinstance(policy, (BaseAlgorithm, BasePolicy)):
+        # There's an important subtlety here: BaseAlgorithm and BasePolicy
+        # are themselves Callable (which we check next). But in their case,
+        # we want to use the .predict() method, rather than __call__()
+        # (which would call .forward()). So this elif clause must come first!
 
         def get_actions(states):
             acts, _ = policy.predict(states, deterministic=deterministic_policy)
             return acts
+
+    elif isinstance(policy, Callable):
+        get_actions = policy
 
     else:
         raise TypeError(

--- a/tests/data/test_rollout.py
+++ b/tests/data/test_rollout.py
@@ -44,9 +44,13 @@ def _sample_fixed_length_trajectories(
     if policy_type == "policy":
         policy = RandomPolicy(venv.observation_space, venv.action_space)
     elif policy_type == "callable":
+        random_policy = RandomPolicy(venv.observation_space, venv.action_space)
+
         # Simple way to get a valid callable: just use a policies .predict() method
         # (still tests another code path inside generate_trajectories)
-        policy = lambda x: RandomPolicy(venv.observation_space, venv.action_space).predict(x)[0]
+        def policy(x):
+            return random_policy.predict(x)[0]
+
     elif policy_type == "random":
         policy = None
     else:
@@ -232,10 +236,9 @@ def test_compute_returns(gamma):
     # polynomials
     assert abs(rollout.compute_returns(rewards, gamma) - returns) < 1e-8
 
+
 def test_generate_trajectories_type_error():
-    venv = vec_env.DummyVecEnv(
-        [functools.partial(TerminalSentinelEnv, 1)]
-    )
+    venv = vec_env.DummyVecEnv([functools.partial(TerminalSentinelEnv, 1)])
     sample_until = rollout.make_min_episodes(1)
     with pytest.raises(TypeError, match="Policy must be.*got <class 'str'> instead"):
         rollout.generate_trajectories(

--- a/tests/data/test_rollout.py
+++ b/tests/data/test_rollout.py
@@ -53,7 +53,7 @@ def _sample_fixed_length_trajectories(
 
     elif policy_type == "random":
         policy = None
-    else:
+    else:  # pragma: no cover
         raise ValueError(f"Unknown policy_type '{policy_type}'")
     sample_until = rollout.make_min_episodes(min_episodes)
     trajectories = rollout.generate_trajectories(


### PR DESCRIPTION
`generate_trajectories` currently needs an SB3 policy or algorithm. With this PR, it also accepts a `Callable` that generates actions from observations, or `policy=None` (in which case random actions are used). I don't have any plans to use this inside `imitation` itself, only in the reward preprocessing project, so if you don't think it belongs here, feel free to close this and I'll just implement it there. But #271 already wanted support for `Callable`s so maybe others will use that as well in the future, which is why I created the PR here.

