### PR TITLE
Run Darglint on CI (accidentally disabled)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,10 +73,7 @@ jobs:
       - dependencies
       - run:
           name: flake8
-          command: |
-            cp ci/.darglint .  # enable darglint
-            flake8 --version && flake8 -j "${NUM_CPUS}" ${SRC_FILES}
-            rm .darglint
+          command: flake8 --version && flake8 -j "${NUM_CPUS}" ${SRC_FILES}
 
       - run:
           name: black

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,14 @@ executors:
       NUM_CPUS: 8
   lint:
     <<: *defaults
-    # darglint is slow enough that we benefit from large even for linting.
+    # darglint is slow enough that we benefit from xlarge even for linting.
     # However, there's little benefit from larger parallelization (I think there's
     # a handful of files with long docstrings causing the bulk of the time).
-    resource_class: large
+    resource_class: xlarge
     environment:
       # If you change these, also change ci/code_checks.sh
       SRC_FILES: src/ tests/ experiments/ examples/ docs/conf.py setup.py
-      NUM_CPUS: 4
+      NUM_CPUS: 8
   type:
     <<: *defaults
     resource_class: medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,15 +16,17 @@ executors:
     <<: *defaults
     resource_class: xlarge
     environment:
-      # We actually have 8 CPUs, but only use 4 since some tests are resource intensive.
+      # more CPUs visible but we're throttled to 8, which breaks auto-detect
       NUM_CPUS: 8
   lintandtype:
     <<: *defaults
-    resource_class: medium
+    # We do actually benefit from xlarge even for linting because pytype
+    # and darglint are both quite slow but parallelizable.
+    resource_class: xlarge
     environment:
       # If you change these, also change ci/code_checks.sh
       SRC_FILES: src/ tests/ experiments/ examples/ docs/conf.py setup.py
-      NUM_CPUS: 2  # more CPUs visible but we're throttled to 2, which breaks auto-detect
+      NUM_CPUS: 8
 
 commands:
   dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,15 +18,23 @@ executors:
     environment:
       # more CPUs visible but we're throttled to 8, which breaks auto-detect
       NUM_CPUS: 8
-  lintandtype:
+  lint:
     <<: *defaults
-    # We do actually benefit from xlarge even for linting because pytype
-    # and darglint are both quite slow but parallelizable.
-    resource_class: xlarge
+    # darglint is slow enough that we benefit from large even for linting.
+    # However, there's little benefit from larger parallelization (I think there's
+    # a handful of files with long docstrings causing the bulk of the time).
+    resource_class: large
     environment:
       # If you change these, also change ci/code_checks.sh
       SRC_FILES: src/ tests/ experiments/ examples/ docs/conf.py setup.py
-      NUM_CPUS: 8
+      NUM_CPUS: 4
+  type:
+    <<: *defaults
+    resource_class: medium
+    environment:
+      # If you change these, also change ci/code_checks.sh
+      SRC_FILES: src/ tests/ experiments/ examples/ docs/conf.py setup.py
+      NUM_CPUS: 2
 
 commands:
   dependencies:
@@ -68,8 +76,8 @@ commands:
           command: pip freeze --all
 
 jobs:
-  lintandtype:
-    executor: lintandtype
+  lint:
+    executor: lint
 
     steps:
       - dependencies
@@ -86,12 +94,18 @@ jobs:
           command: codespell -I .codespell.skip --skip='*.pyc,tests/testdata/*,*.ipynb,*.csv' ${SRC_FILES}
 
       - run:
+          name: sphinx
+          command: pushd docs/ && make clean && make html && popd
+
+  type:
+    executor: type
+    steps:
+      - dependencies
+
+      - run:
           name: pytype
           command: pytype --version && pytype -j "${NUM_CPUS}" ${SRC_FILES[@]}
 
-      - run:
-          name: sphinx
-          command: pushd docs/ && make clean && make html && popd
 
   unit-test:
     executor: unit-test
@@ -135,7 +149,11 @@ workflows:
   version: 2
   test:
     jobs:
-      - lintandtype:
+      - lint:
+          context:
+          - MuJoCo
+          - docker-hub-creds
+      - type:
           context:
           - MuJoCo
           - docker-hub-creds

--- a/ci/.darglint
+++ b/ci/.darglint
@@ -1,2 +1,0 @@
-[darglint]
-strictness=short

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -7,7 +7,7 @@ set -x  # echo commands
 set -e  # quit immediately on error
 
 echo "Source format checking"
-flake8 --darglint-disable ${SRC_FILES[@]}
+flake8 --disable-darglint ${SRC_FILES[@]}
 black --check --diff ${SRC_FILES[@]}
 codespell -I .codespell.skip --skip='*.pyc,tests/testdata/*,*.ipynb,*.csv' ${SRC_FILES[@]}
 

--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -7,7 +7,7 @@ set -x  # echo commands
 set -e  # quit immediately on error
 
 echo "Source format checking"
-flake8 ${SRC_FILES[@]}
+flake8 --darglint-disable ${SRC_FILES[@]}
 black --check --diff ${SRC_FILES[@]}
 codespell -I .codespell.skip --skip='*.pyc,tests/testdata/*,*.ipynb,*.csv' ${SRC_FILES[@]}
 
@@ -29,13 +29,12 @@ if [ "$skipexpensive" != "true" ]; then
   popd
 
   echo "Darglint on diff"
-  pushd ci/  # darglint will read config from ci/.darglint, enabling it
   # We run flake8 rather than darglint directly to work around:
   # https://github.com/terrencepreilly/darglint/issues/21
   # so noqa's are respected outside docstring.
   # If we got to this point, flake8 already passed, so this should
   # only find new darglint-specific errors.
-  files=$(git diff --cached --name-only --diff-filter=AMR ${against} | sed -e s'/^/..\//' | xargs -I'{}' find '{}' -name '*.py'$)
+  files=$(git diff --cached --name-only --diff-filter=AMR ${against} | xargs -I'{}' find '{}' -name '*.py'$)
   if [[ ${files} -ne "" ]]; then
     flake8 ${files}
   fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,11 +10,7 @@ per-file-ignores =
   src/imitation/envs/examples/airl_envs/*.py:D
 
 [darglint]
-# This section just disables darglint when run with flake8.
-# This is because darglint is slow, so we don't want to run
-# it by default. We have a separate config in ci/.darglint
-# that enables it when run from that directory. 
-ignore=*
+strictness=short
 
 [isort]
 known_first_party=imitation

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ TESTS_REQUIRE = [
     "coverage",
     "codecov",
     "codespell",
-    "darglint",
+    # TODO(adam): switch back to PyPi release once PR incorporated:
+    # https://github.com/terrencepreilly/darglint/pull/176
+    "darglint @ "
+    "git+https://github.com/AdamGleave/darglint.git@flake8-ignore#egg=darglint",
     "flake8",
     "flake8-blind-except",
     "flake8-builtins",


### PR DESCRIPTION
Darglint config hierarchy didn't work as I expected, so Darglint was not actually running on CI. This PR enables it, and switches us to a Darglint fork temporarily so we can still disable Darglint when running `flake8` for other reasons.