### PR TITLE
Use Darglint release now flag added

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,7 @@ TESTS_REQUIRE = [
     "coverage",
     "codecov",
     "codespell",
-    # TODO(adam): switch back to PyPi release once PR incorporated:
-    # https://github.com/terrencepreilly/darglint/pull/176
-    "darglint @ git+"
-    "https://github.com/AdamGleave/darglint.git@flake8-ignore#egg=darglint",
+    "darglint",
     "flake8",
     "flake8-blind-except",
     "flake8-builtins",


### PR DESCRIPTION
Now that https://github.com/terrencepreilly/darglint/pull/176 has made its way into PyPi release, migrate off our custom branch