### PR TITLE
Small improvements to preference comparisons

### DIFF
--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -394,12 +394,22 @@ class RandomFragmenter(Fragmenter):
 class PreferenceGatherer(abc.ABC):
     """Base class for gathering preference comparisons between trajectory fragments."""
 
-    def __init__(self, custom_logger: Optional[imit_logger.HierarchicalLogger] = None):
+    def __init__(
+        self,
+        seed: Optional[int] = None,
+        custom_logger: Optional[imit_logger.HierarchicalLogger] = None,
+    ):
         """Initializes the preference gatherer.
 
         Args:
+            seed: seed for the internal RNG, if applicable
             custom_logger: Where to log to; if None (default), creates a new logger.
         """
+        # The random seed isn't used here, but it's useful to have this
+        # as an argument nevertheless because that means we can always
+        # pass in a seed in training scripts (without worrying about whether
+        # the PreferenceGatherer we use needs one).
+        del seed
         self.logger = custom_logger or imit_logger.configure()
 
     @abc.abstractmethod

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -594,11 +594,13 @@ class RewardTrainer(abc.ABC):
         self.logger = custom_logger or imit_logger.configure()
 
     @abc.abstractmethod
-    def train(self, dataset: PreferenceDataset):
+    def train(self, dataset: PreferenceDataset, epoch_multiplier: float = 1.0):
         """Train the reward model on a batch of fragment pairs and preferences.
 
         Args:
             dataset: the dataset of preference comparisons to train on.
+            epoch_multiplier: how much longer to train for than usual
+                (measured relatively).
         """
 
 
@@ -624,7 +626,9 @@ class CrossEntropyRewardTrainer(RewardTrainer):
                 is uniformly random (used for the model of preference generation
                 that is used for the loss)
             batch_size: number of fragment pairs per batch
-            epochs: number of epochs on each training iteration
+            epochs: number of epochs on each training iteration (can be adjusted
+                on the fly by specifying an `epoch_multiplier` in `self.train()`
+                if longer training is desired in specific cases).
             lr: the learning rate
             discount_factor: the model of preference generation uses a softmax
                 of returns as the probability that a fragment is preferred.
@@ -721,8 +725,8 @@ class CrossEntropyRewardTrainer(RewardTrainer):
         model_probability = 1 / (1 + returns_diff.exp())
         return self.noise_prob * 0.5 + (1 - self.noise_prob) * model_probability
 
-    def train(self, dataset: PreferenceDataset):
-        """Trains for `self.epochs` epochs over `dataset`."""
+    def train(self, dataset: PreferenceDataset, epoch_multiplier: float = 1.0):
+        """Trains for `epoch_multiplier * self.epochs` epochs over `dataset`."""
         # TODO(ejnnr): This isn't specific to the loss function or probability model.
         # In general, it might be best to split the probability model, the loss and
         # the optimization procedure a bit more cleanly so that different versions
@@ -734,7 +738,8 @@ class CrossEntropyRewardTrainer(RewardTrainer):
             shuffle=True,
             collate_fn=preference_collate_fn,
         )
-        for _ in range(self.epochs):
+        epochs = round(self.epochs * epoch_multiplier)
+        for _ in range(epochs):
             for fragment_pairs, preferences in dataloader:
                 self.optim.zero_grad()
                 loss = self._loss(fragment_pairs, preferences)
@@ -909,9 +914,16 @@ class PreferenceComparisons(base.BaseImitationAlgorithm):
             ##########################
             # Train the reward model #
             ##########################
+            # Usually, num_pairs is the same as comparisons_per_iteration,
+            # but on the first iteration, we might have additional pairs
+            # (i.e. num_pairs > comparisons_per_iteration). In that case,
+            # we want to train the reward model for correspondingly more
+            # epochs.
+            epoch_multiplier = num_pairs / self.comparisons_per_iteration
+
             with self.logger.accumulate_means("reward"):
                 self.logger.log("Training reward model")
-                self.reward_trainer.train(self.dataset)
+                self.reward_trainer.train(self.dataset, epoch_multiplier)
             reward_loss = self.logger.name_to_value["mean/reward/loss"]
             reward_accuracy = self.logger.name_to_value["mean/reward/accuracy"]
 

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -114,6 +114,7 @@ class AgentTrainer(TrajectoryGenerator):
         exploration_frac: float = 0.0,
         stay_prob: float = 0.5,
         random_prob: float = 0.5,
+        seed: Optional[int] = None,
         custom_logger: Optional[imit_logger.HierarchicalLogger] = None,
     ):
         """Initialize the agent trainer.
@@ -129,6 +130,7 @@ class AgentTrainer(TrajectoryGenerator):
                 step for the exploratory samples.
             random_prob: the probability of picking the random policy when switching
                 during exploration.
+            seed: random seed for exploratory trajectories.
             custom_logger: Where to log to; if None (default), creates a new logger.
 
         Raises:
@@ -166,6 +168,7 @@ class AgentTrainer(TrajectoryGenerator):
             venv=self.venv,
             random_prob=random_prob,
             stay_prob=stay_prob,
+            seed=seed,
         )
 
     def train(self, steps: int, **kwargs) -> None:

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -211,6 +211,9 @@ def _get_trajectories(
     steps: int,
 ) -> Sequence[TrajectoryWithRew]:
     """Get enough trajectories to have at least `steps` transitions in total."""
+    if steps == 0:
+        return []
+
     available_steps = sum(len(traj) for traj in trajectories)
     if available_steps < steps:
         raise RuntimeError(

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -749,7 +749,7 @@ class PreferenceComparisons(base.BaseImitationAlgorithm):
         comparisons_per_iteration: int = 50,
         fragment_length: int = 50,
         transition_oversampling: float = 10,
-        initial_comparison_fraction: float = 0.1,
+        initial_comparison_frac: float = 0.1,
         custom_logger: Optional[imit_logger.HierarchicalLogger] = None,
         allow_variable_horizon: bool = False,
         seed: Optional[int] = None,
@@ -785,7 +785,7 @@ class PreferenceComparisons(base.BaseImitationAlgorithm):
                 creating fragments. Since fragments are sampled with replacement,
                 this is usually chosen > 1 to avoid having the same transition
                 in too many fragments.
-            initial_comparison_fraction: fraction of the total_comparisons argument
+            initial_comparison_frac: fraction of the total_comparisons argument
                 to train() that will be sampled before the rest of training begins
                 (using the randomly initialized agent). This can be used to pretrain
                 the reward model before the agent is trained on the learned reward.
@@ -838,7 +838,7 @@ class PreferenceComparisons(base.BaseImitationAlgorithm):
         self.comparisons_per_iteration = comparisons_per_iteration
         self.fragment_length = fragment_length
         self.transition_oversampling = transition_oversampling
-        self.initial_comparison_fraction = initial_comparison_fraction
+        self.initial_comparison_frac = initial_comparison_frac
 
         self.dataset = PreferenceDataset()
 
@@ -856,7 +856,7 @@ class PreferenceComparisons(base.BaseImitationAlgorithm):
         Raises:
             ValueError: `total_comparisons < self.comparisons_per_iteration`.
         """
-        initial_comparisons = int(total_comparisons * self.initial_comparison_fraction)
+        initial_comparisons = int(total_comparisons * self.initial_comparison_frac)
         total_comparisons -= initial_comparisons
         iterations, extra_comparisons = divmod(
             total_comparisons,

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -186,7 +186,7 @@ class AgentTrainer(TrajectoryGenerator):
         if avail_steps < agent_steps:
             self.logger.log(
                 f"Requested {agent_steps} transitions but only {avail_steps} in buffer."
-                f" Sampling {agent_steps - avail_steps} additional transitions."
+                f" Sampling {agent_steps - avail_steps} additional transitions.",
             )
             sample_until = rollout.make_sample_until(
                 min_timesteps=agent_steps - avail_steps,
@@ -211,7 +211,8 @@ class AgentTrainer(TrajectoryGenerator):
         if random_steps > 0:
             self.logger.log(f"Sampling {random_steps} random transitions.")
             sample_until = rollout.make_sample_until(
-                min_timesteps=random_steps, min_episodes=None
+                min_timesteps=random_steps,
+                min_episodes=None,
             )
             rollout.generate_trajectories(
                 policy=None,

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -799,9 +799,9 @@ class PreferenceComparisons(base.BaseImitationAlgorithm):
                 in too many fragments.
             initial_comparison_frac: fraction of the total_comparisons argument
                 to train() that will be sampled before the rest of training begins
-                (using the randomly initialized agent). This can be used to pretrain
-                the reward model before the agent is trained on the learned reward,
-                to help avoid irreversibly learning a bad policy from an untrained reward.
+                (using a randomly initialized agent). This can be used to pretrain the
+                reward model before the agent is trained on the learned reward, to
+                help avoid irreversibly learning a bad policy from an untrained reward.
             custom_logger: Where to log to; if None (default), creates a new logger.
             allow_variable_horizon: If False (default), algorithm will raise an
                 exception if it detects trajectories of different length during

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -189,7 +189,8 @@ class AgentTrainer(TrajectoryGenerator):
                 f" Sampling {agent_steps - avail_steps} additional transitions."
             )
             sample_until = rollout.make_sample_until(
-                min_timesteps=agent_steps, min_episodes=None
+                min_timesteps=agent_steps - avail_steps,
+                min_episodes=None,
             )
             # Important note: we don't want to use the trajectories returned
             # here because 1) they might miss initial timesteps taken by the RL agent
@@ -218,7 +219,12 @@ class AgentTrainer(TrajectoryGenerator):
                 sample_until=sample_until,
             )
             random_trajs, _ = self.buffering_wrapper.pop_finished_trajectories()
+            random_trajs = _get_trajectories(random_trajs, random_steps)
 
+        # We call _get_trajectories separately on agent_trajs and random_trajs
+        # and then just concatenate. This could mean we return slightly too many
+        # transitions, but it gets the proportion of random and non-random transitions
+        # roughly right.
         return list(agent_trajs) + list(random_trajs)
 
     @TrajectoryGenerator.logger.setter

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -931,16 +931,10 @@ class PreferenceComparisons(base.BaseImitationAlgorithm):
             ##########################
             # Train the reward model #
             ##########################
-            # Usually, num_pairs is the same as comparisons_per_iteration,
-            # but on the first iteration, we might have additional pairs
-            # (i.e. num_pairs > comparisons_per_iteration). In that case,
-            # we want to train the reward model for correspondingly more
-            # epochs.
-            epoch_multiplier = num_pairs / self.comparisons_per_iteration
 
             with self.logger.accumulate_means("reward"):
                 self.logger.log("Training reward model")
-                self.reward_trainer.train(self.dataset, epoch_multiplier)
+                self.reward_trainer.train(self.dataset)
             reward_loss = self.logger.name_to_value["mean/reward/loss"]
             reward_accuracy = self.logger.name_to_value["mean/reward/accuracy"]
 

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -800,7 +800,8 @@ class PreferenceComparisons(base.BaseImitationAlgorithm):
             initial_comparison_frac: fraction of the total_comparisons argument
                 to train() that will be sampled before the rest of training begins
                 (using the randomly initialized agent). This can be used to pretrain
-                the reward model before the agent is trained on the learned reward.
+                the reward model before the agent is trained on the learned reward,
+                to help avoid irreversibly learning a bad policy from an untrained reward.
             custom_logger: Where to log to; if None (default), creates a new logger.
             allow_variable_horizon: If False (default), algorithm will raise an
                 exception if it detects trajectories of different length during

--- a/src/imitation/policies/exploration_wrapper.py
+++ b/src/imitation/policies/exploration_wrapper.py
@@ -46,18 +46,18 @@ class ExplorationWrapper:
         # Choose the initial policy at random
         self._switch()
 
-    def _random_policy(self, states):
+    def _random_policy(self, states: np.ndarray) -> np.ndarray:
         acts = [self.venv.action_space.sample() for _ in range(len(states))]
         return np.stack(acts, axis=0)
 
-    def _switch(self):
+    def _switch(self) -> None:
         """Pick a new policy at random."""
         if self.rng.rand() < self.random_prob:
             self.current_policy = self._random_policy
         else:
             self.current_policy = self.wrapped_policy
 
-    def __call__(self, obs: np.ndarray):
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
         acts = self.current_policy(obs)
         if self.rng.rand() < self.stay_prob:
             self._switch()

--- a/src/imitation/policies/exploration_wrapper.py
+++ b/src/imitation/policies/exploration_wrapper.py
@@ -12,9 +12,11 @@ class ExplorationWrapper:
     """Wraps a PolicyCallable to create a partially randomized version.
 
     This wrapper randomly switches between two policies: the wrapped policy,
-    and a uniformly random one. After each action, the current policy is kept
+    and a random one. After each action, the current policy is kept
     with a certain probability. Otherwise, one of these two policies is chosen
     at random (without any dependence on what the current policy is).
+
+    The random policy uses the `action_space.sample()` method.
     """
 
     def __init__(
@@ -46,8 +48,8 @@ class ExplorationWrapper:
         # Choose the initial policy at random
         self._switch()
 
-    def _random_policy(self, states: np.ndarray) -> np.ndarray:
-        acts = [self.venv.action_space.sample() for _ in range(len(states))]
+    def _random_policy(self, obs: np.ndarray) -> np.ndarray:
+        acts = [self.venv.action_space.sample() for _ in range(len(obs))]
         return np.stack(acts, axis=0)
 
     def _switch(self) -> None:

--- a/src/imitation/policies/exploration_wrapper.py
+++ b/src/imitation/policies/exploration_wrapper.py
@@ -1,0 +1,57 @@
+"""Wrapper to turn a policy into a more exploratory version."""
+
+import numpy as np
+from stable_baselines3.common import vec_env
+
+from imitation.data import rollout
+
+
+class ExplorationWrapper:
+    """Wraps a PolicyCallable to create a partially randomized version.
+
+    This wrapper randomly switches between two policies: the wrapped policy,
+    and a uniformly random one. After each action, the current policy is kept
+    with a certain probability. Otherwise, one of these two policies is chosen
+    at random (without any dependence on what the current policy is).
+    """
+
+    def __init__(
+        self,
+        policy: rollout.PolicyCallable,
+        venv: vec_env.VecEnv,
+        random_prob: float,
+        stay_prob: float,
+    ):
+        """Initializes the ExplorationWrapper.
+
+        Args:
+            policy: The policy to randomize.
+            venv: The environment to use (needed for sampling random actions).
+            random_prob: The probability of picking the random policy when switching.
+            stay_prob: The probability of staying with the current policy.
+        """
+        self.wrapped_policy = policy
+        self.random_prob = random_prob
+        self.stay_prob = stay_prob
+        self.venv = venv
+
+        self.current_policy = policy
+        # Choose the initial policy at random
+        self._switch()
+
+    def _random_policy(self, states):
+        acts = [self.venv.action_space.sample() for _ in range(len(states))]
+        return np.stack(acts, axis=0)
+
+    def _switch(self):
+        """Pick a new policy at random."""
+        if np.random.rand() < self.random_prob:
+            self.current_policy = self._random_policy
+        else:
+            self.current_policy = self.wrapped_policy
+
+    def __call__(self, obs: np.ndarray):
+        acts = self.current_policy(obs)
+        if np.random.rand() < self.stay_prob:
+            self._switch()
+        return acts

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -27,8 +27,8 @@ def train_defaults():
     transition_oversampling = 1
     # fraction of total_comparisons that will be sampled right at the beginning
     initial_comparison_frac = 0.1
-    # fraction of sampled trajectories that will use random actions rather than policy
-    random_frac = 0.0
+    # fraction of sampled trajectories that will include some random actions
+    exploration_frac = 0.0
 
     reward_trainer_kwargs = {
         "epochs": 3,

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -25,6 +25,7 @@ def train_defaults():
     # factor by which to oversample transitions before creating fragments
     transition_oversampling = 10
     initial_comparison_fraction = 0.1
+    random_frac = 0.0
 
     reward_trainer_kwargs = {
         "epochs": 3,

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -19,12 +19,14 @@ train_preference_comparisons_ex = sacred.Experiment(
 def train_defaults():
     fragment_length = 100  # timesteps per fragment used for comparisons
     total_timesteps = int(1e6)  # total number of environment timesteps
-    total_comparisons = 1000  # total number of comparisons to elicit
+    total_comparisons = 5000  # total number of comparisons to elicit
     # comparisons to gather before switching back to agent training
-    comparisons_per_iteration = 50
+    comparisons_per_iteration = 100
     # factor by which to oversample transitions before creating fragments
-    transition_oversampling = 10
+    transition_oversampling = 1
+    # fraction of total_comparisons that will be sampled right at the beginning
     initial_comparison_fraction = 0.1
+    # fraction of sampled trajectories that will use random actions rather than policy
     random_frac = 0.0
 
     reward_trainer_kwargs = {

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -2,6 +2,7 @@
 
 import sacred
 
+from imitation.algorithms import preference_comparisons
 from imitation.scripts.common import common, reward, rl, train
 
 train_preference_comparisons_ex = sacred.Experiment(
@@ -34,6 +35,9 @@ def train_defaults():
     }
     save_preferences = False  # save preference dataset at the end?
     agent_path = None  # path to a (partially) trained agent to load at the beginning
+    # type of PreferenceGatherer to use
+    gatherer_cls = preference_comparisons.SyntheticGatherer
+    # arguments passed on to the PreferenceGatherer specified by gatherer_cls
     gatherer_kwargs = {}
     fragmenter_kwargs = {
         "warning_threshold": 0,

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -35,6 +35,9 @@ def train_defaults():
     save_preferences = False  # save preference dataset at the end?
     agent_path = None  # path to a (partially) trained agent to load at the beginning
     gatherer_kwargs = {}
+    fragmenter_kwargs = {
+        "warning_threshold": 0,
+    }
     # path to a pickled sequence of trajectories used instead of training an agent
     trajectory_path = None
     allow_variable_horizon = False

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -24,6 +24,7 @@ def train_defaults():
     comparisons_per_iteration = 50
     # factor by which to oversample transitions before creating fragments
     transition_oversampling = 10
+    initial_comparison_fraction = 0.1
 
     reward_trainer_kwargs = {
         "epochs": 3,

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -25,7 +25,7 @@ def train_defaults():
     # factor by which to oversample transitions before creating fragments
     transition_oversampling = 1
     # fraction of total_comparisons that will be sampled right at the beginning
-    initial_comparison_fraction = 0.1
+    initial_comparison_frac = 0.1
     # fraction of sampled trajectories that will use random actions rather than policy
     random_frac = 0.0
 

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -189,7 +189,7 @@ def train_preference_comparisons(
     else:
         if random_frac > 0:
             raise ValueError(
-                "random_frac can't be set when a trajectory dataset is used"
+                "random_frac can't be set when a trajectory dataset is used",
             )
         trajectory_generator = preference_comparisons.TrajectoryDataset(
             trajectory_path,

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -227,6 +227,7 @@ def train_preference_comparisons(
             algorithm=agent,
             reward_fn=reward_net,
             exploration_frac=exploration_frac,
+            seed=_seed,
             custom_logger=custom_logger,
         )
     else:

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -7,7 +7,7 @@ can be called directly.
 import os
 import pathlib
 import pickle
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Type
 
 import torch as th
 from sacred.observers import FileStorageObserver
@@ -41,6 +41,7 @@ def train_preference_comparisons(
     save_preferences: bool,
     agent_path: Optional[str],
     reward_trainer_kwargs: Mapping[str, Any],
+    gatherer_cls: Type[preference_comparisons.PreferenceGatherer],
     gatherer_kwargs: Mapping[str, Any],
     fragmenter_kwargs: Mapping[str, Any],
     rl: Mapping[str, Any],
@@ -79,7 +80,8 @@ def train_preference_comparisons(
         agent_path: if given, initialize the agent using this stored policy
             rather than randomly.
         reward_trainer_kwargs: passed to CrossEntropyRewardTrainer
-        gatherer_kwargs: passed to SyntheticGatherer
+        gatherer_cls: type of PreferenceGatherer to use (defaults to SyntheticGatherer)
+        gatherer_kwargs: passed to the PreferenceGatherer specified by gatherer_cls
         fragmenter_kwargs: passed to RandomFragmenter
         rl: parameters for RL training, used for restoring agents.
         allow_variable_horizon: If False (default), algorithm will raise an
@@ -204,7 +206,7 @@ def train_preference_comparisons(
         seed=_seed,
         custom_logger=custom_logger,
     )
-    gatherer = preference_comparisons.SyntheticGatherer(
+    gatherer = gatherer_cls(
         **gatherer_kwargs,
         seed=_seed,
         custom_logger=custom_logger,

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -42,6 +42,7 @@ def train_preference_comparisons(
     agent_path: Optional[str],
     reward_trainer_kwargs: Mapping[str, Any],
     gatherer_kwargs: Mapping[str, Any],
+    fragmenter_kwargs: Mapping[str, Any],
     rl: Mapping[str, Any],
     allow_variable_horizon: bool,
 ) -> Mapping[str, Any]:
@@ -79,6 +80,7 @@ def train_preference_comparisons(
             rather than randomly.
         reward_trainer_kwargs: passed to CrossEntropyRewardTrainer
         gatherer_kwargs: passed to SyntheticGatherer
+        fragmenter_kwargs: passed to RandomFragmenter
         rl: parameters for RL training, used for restoring agents.
         allow_variable_horizon: If False (default), algorithm will raise an
             exception if it detects trajectories of different length during
@@ -198,6 +200,7 @@ def train_preference_comparisons(
         )
 
     fragmenter = preference_comparisons.RandomFragmenter(
+        **fragmenter_kwargs,
         seed=_seed,
         custom_logger=custom_logger,
     )

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -35,7 +35,7 @@ def train_preference_comparisons(
     comparisons_per_iteration: int,
     fragment_length: int,
     transition_oversampling: float,
-    initial_comparison_fraction: float,
+    initial_comparison_frac: float,
     random_frac: float,
     trajectory_path: Optional[str],
     save_preferences: bool,
@@ -63,7 +63,7 @@ def train_preference_comparisons(
             creating fragments. Since fragments are sampled with replacement,
             this is usually chosen > 1 to avoid having the same transition
             in too many fragments.
-        initial_comparison_fraction: fraction of total_comparisons that will be
+        initial_comparison_frac: fraction of total_comparisons that will be
             sampled before the rest of training begins (using the randomly initialized
             agent). This can be used to pretrain the reward model before the agent
             is trained on the learned reward.
@@ -217,7 +217,7 @@ def train_preference_comparisons(
         comparisons_per_iteration=comparisons_per_iteration,
         fragment_length=fragment_length,
         transition_oversampling=transition_oversampling,
-        initial_comparison_fraction=initial_comparison_fraction,
+        initial_comparison_frac=initial_comparison_frac,
         custom_logger=custom_logger,
         allow_variable_horizon=allow_variable_horizon,
         seed=_seed,

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -70,7 +70,7 @@ def train_preference_comparisons(
     fragment_length: int,
     transition_oversampling: float,
     initial_comparison_frac: float,
-    random_frac: float,
+    exploration_frac: float,
     trajectory_path: Optional[str],
     save_preferences: bool,
     agent_path: Optional[str],
@@ -104,8 +104,8 @@ def train_preference_comparisons(
             sampled before the rest of training begins (using the randomly initialized
             agent). This can be used to pretrain the reward model before the agent
             is trained on the learned reward.
-        random_frac: fraction of trajectory samples that will be created using
-            random actions, rather than the current trained policy. Might be helpful
+        exploration_frac: fraction of trajectory samples that will be created using
+            partially random actions, rather than the current policy. Might be helpful
             if the learned policy explores too little and gets stuck with a wrong
             reward.
         trajectory_path: either None, in which case an agent will be trained
@@ -226,13 +226,13 @@ def train_preference_comparisons(
         trajectory_generator = preference_comparisons.AgentTrainer(
             algorithm=agent,
             reward_fn=reward_net,
-            random_frac=random_frac,
+            exploration_frac=exploration_frac,
             custom_logger=custom_logger,
         )
     else:
-        if random_frac > 0:
+        if exploration_frac > 0:
             raise ValueError(
-                "random_frac can't be set when a trajectory dataset is used",
+                "exploration_frac can't be set when a trajectory dataset is used",
             )
         trajectory_generator = preference_comparisons.TrajectoryDataset(
             path=trajectory_path,

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -35,6 +35,7 @@ def train_preference_comparisons(
     comparisons_per_iteration: int,
     fragment_length: int,
     transition_oversampling: float,
+    initial_comparison_fraction: float,
     trajectory_path: Optional[str],
     save_preferences: bool,
     agent_path: Optional[str],
@@ -61,6 +62,10 @@ def train_preference_comparisons(
             creating fragments. Since fragments are sampled with replacement,
             this is usually chosen > 1 to avoid having the same transition
             in too many fragments.
+        initial_comparison_fraction: fraction of total_comparisons that will be
+            sampled before the rest of training begins (using the randomly initialized
+            agent). This can be used to pretrain the reward model before the agent
+            is trained on the learned reward.
         trajectory_path: either None, in which case an agent will be trained
             and used to sample trajectories on the fly, or a path to a pickled
             sequence of TrajectoryWithRew to be trained on
@@ -205,6 +210,7 @@ def train_preference_comparisons(
         comparisons_per_iteration=comparisons_per_iteration,
         fragment_length=fragment_length,
         transition_oversampling=transition_oversampling,
+        initial_comparison_fraction=initial_comparison_fraction,
         custom_logger=custom_logger,
         allow_variable_horizon=allow_variable_horizon,
         seed=_seed,

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -181,7 +181,10 @@ def train_preference_comparisons(
         # Setting the logger here is not really necessary (PreferenceComparisons
         # takes care of that automatically) but it avoids creating unnecessary loggers
         trajectory_generator = preference_comparisons.AgentTrainer(
-            agent, reward_net, random_frac=random_frac, custom_logger=custom_logger
+            agent,
+            reward_net,
+            random_frac=random_frac,
+            custom_logger=custom_logger,
         )
     else:
         if random_frac > 0:

--- a/tests/algorithms/test_preference_comparisons.py
+++ b/tests/algorithms/test_preference_comparisons.py
@@ -245,3 +245,21 @@ def test_store_and_load_preference_dataset(agent_trainer, fragmenter, tmp_path):
 
         assert preference == loaded_preference
         _check_trajs_equal(fragments, loaded_fragments)
+
+
+def test_exploration_no_crash(agent, reward_net, fragmenter, custom_logger):
+    agent_trainer = preference_comparisons.AgentTrainer(
+        agent,
+        reward_net,
+        exploration_frac=0.5,
+    )
+    main_trainer = preference_comparisons.PreferenceComparisons(
+        agent_trainer,
+        reward_net,
+        transition_oversampling=2,
+        fragment_length=5,
+        comparisons_per_iteration=2,
+        fragmenter=fragmenter,
+        custom_logger=custom_logger,
+    )
+    main_trainer.train(10, 3)

--- a/tests/policies/test_exploration_wrapper.py
+++ b/tests/policies/test_exploration_wrapper.py
@@ -1,0 +1,68 @@
+"""Tests ExplorationWrapper."""
+
+import numpy as np
+import seals  # noqa: F401
+
+from imitation.policies import exploration_wrapper
+from imitation.util import util
+
+
+def constant_policy(obs):
+    return np.zeros(len(obs), dtype=int)
+
+
+def make_wrapper(random_prob, stay_prob):
+    venv = util.make_vec_env(
+        "seals/CartPole-v0",
+        n_envs=1,
+    )
+    return (
+        exploration_wrapper.ExplorationWrapper(
+            policy=constant_policy,
+            venv=venv,
+            random_prob=random_prob,
+            stay_prob=stay_prob,
+            seed=0,
+        ),
+        venv,
+    )
+
+
+def test_switch():
+    wrapper, _ = make_wrapper(random_prob=0.0, stay_prob=0.5)
+    assert wrapper.current_policy == constant_policy
+    for _ in range(100):
+        wrapper._switch()
+        assert wrapper.current_policy == constant_policy
+
+    wrapper, _ = make_wrapper(random_prob=1.0, stay_prob=0.5)
+    assert wrapper.current_policy == wrapper._random_policy
+    for _ in range(100):
+        wrapper._switch()
+        assert wrapper.current_policy == wrapper._random_policy
+
+    wrapper, _ = make_wrapper(random_prob=0.5, stay_prob=0.5)
+    num_random = 0
+    num_constant = 0
+    for _ in range(1000):
+        wrapper._switch()
+        if wrapper.current_policy == wrapper._random_policy:
+            num_random += 1
+        elif wrapper.current_policy == constant_policy:
+            num_constant += 1
+        else:  # pragma: no cover
+            raise ValueError("Unknown policy")
+    # Holds with very high probability (and seeding means it's deterministic)
+    assert num_random > 450
+    assert num_constant > 450
+
+
+def test_valid_output():
+    # Ensure that we test both the random and the wrapped policy
+    # at least once:
+    for random_prob in [0.0, 0.5, 1.0]:
+        wrapper, venv = make_wrapper(random_prob=random_prob, stay_prob=0.5)
+        np.random.seed(0)
+        obs = np.random.rand(100, 2)
+        for action in wrapper(obs):
+            assert venv.action_space.contains(action)


### PR DESCRIPTION
These are some changes I made for the reward preprocessing project but hadn't merged so far:
- One small bug fix
- Allow sampling some comparisons at the beginning for pertaining the reward model before training the agent
- Slightly different default configs
- Allow using random actions for some fraction of the sampled trajectories

The last point adds a bit of complexity to the code, so we could also remove that until we actually need it (I used it during debugging and it seems plausible that it could sometimes be helpful, but I don't actually have an example environment where it's needed).