### PR TITLE
Make type of PreferenceGatherer configurable

### DIFF
--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -394,12 +394,21 @@ class RandomFragmenter(Fragmenter):
 class PreferenceGatherer(abc.ABC):
     """Base class for gathering preference comparisons between trajectory fragments."""
 
-    def __init__(self, custom_logger: Optional[imit_logger.HierarchicalLogger] = None):
+    def __init__(
+        self,
+        seed: Optional[int] = None,
+        custom_logger: Optional[imit_logger.HierarchicalLogger] = None,
+    ):
         """Initializes the preference gatherer.
 
         Args:
+            seed: seed for the internal RNG, if applicable
             custom_logger: Where to log to; if None (default), creates a new logger.
         """
+        # The random seed isn't used here, but it's useful to have this
+        # as an argument nevertheless because that means we can always
+        # pass in a seed in training scripts (without worrying about whether
+        # the PreferenceGatherer we use needs one).
         self.logger = custom_logger or imit_logger.configure()
 
     @abc.abstractmethod

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -409,6 +409,7 @@ class PreferenceGatherer(abc.ABC):
         # as an argument nevertheless because that means we can always
         # pass in a seed in training scripts (without worrying about whether
         # the PreferenceGatherer we use needs one).
+        del seed
         self.logger = custom_logger or imit_logger.configure()
 
     @abc.abstractmethod

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -2,6 +2,7 @@
 
 import sacred
 
+from imitation.algorithms import preference_comparisons
 from imitation.scripts.common import common, reward, rl, train
 
 train_preference_comparisons_ex = sacred.Experiment(
@@ -34,6 +35,9 @@ def train_defaults():
     }
     save_preferences = False  # save preference dataset at the end?
     agent_path = None  # path to a (partially) trained agent to load at the beginning
+    # type of PreferenceGatherer to use
+    gatherer_cls = preference_comparisons.SyntheticGatherer
+    # arguments passed on to the PreferenceGatherer specified by gatherer_cls
     gatherer_kwargs = {}
     # path to a pickled sequence of trajectories used instead of training an agent
     trajectory_path = None

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -7,7 +7,7 @@ can be called directly.
 import os
 import pathlib
 import pickle
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Type
 
 import torch as th
 from sacred.observers import FileStorageObserver
@@ -41,6 +41,7 @@ def train_preference_comparisons(
     save_preferences: bool,
     agent_path: Optional[str],
     reward_trainer_kwargs: Mapping[str, Any],
+    gatherer_cls: Type[preference_comparisons.PreferenceGatherer],
     gatherer_kwargs: Mapping[str, Any],
     rl: Mapping[str, Any],
     allow_variable_horizon: bool,
@@ -78,7 +79,8 @@ def train_preference_comparisons(
         agent_path: if given, initialize the agent using this stored policy
             rather than randomly.
         reward_trainer_kwargs: passed to CrossEntropyRewardTrainer
-        gatherer_kwargs: passed to SyntheticGatherer
+        gatherer_cls: type of PreferenceGatherer to use (defaults to SyntheticGatherer)
+        gatherer_kwargs: passed to the PreferenceGatherer specified by gatherer_cls
         rl: parameters for RL training, used for restoring agents.
         allow_variable_horizon: If False (default), algorithm will raise an
             exception if it detects trajectories of different length during
@@ -201,7 +203,7 @@ def train_preference_comparisons(
         seed=_seed,
         custom_logger=custom_logger,
     )
-    gatherer = preference_comparisons.SyntheticGatherer(
+    gatherer = gatherer_cls(
         **gatherer_kwargs,
         seed=_seed,
         custom_logger=custom_logger,


### PR DESCRIPTION
This makes it easy to re-use the `train_preference_comparisons` script with only a very light wrapper while using externally defined `PreferenceGatherer`s (needed for the reward preprocessing project). If we ever implement human feedback, we'd need to make this configurable anyway.

We could similarly make the `RewardTrainer` and `Fragmenter` configurable, happy to do that if you think it makes sense. Held off for now because I don't have specific plans to use custom implementations for those and wasn't sure if we wanted to add the (slight) complexity without a concrete need.