### PR TITLE
Make `n_rounds` integer

### DIFF
--- a/src/imitation/algorithms/adversarial/common.py
+++ b/src/imitation/algorithms/adversarial/common.py
@@ -425,7 +425,7 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
                 single argument, the round number. Round numbers are in
                 `range(total_timesteps // self.gen_train_timesteps)`.
         """
-        n_rounds = total_timesteps // self.gen_train_timesteps
+        n_rounds = int(total_timesteps // self.gen_train_timesteps)
         assert n_rounds >= 1, (
             "No updates (need at least "
             f"{self.gen_train_timesteps} timesteps, have only "


### PR DESCRIPTION
Fixes an issue with the default config of `imitation.scripts.train_adversarial`, which passes 1e6 for `total_timesteps`, causing `n_rounds` to become a float.