### PR TITLE
Eliminate duplicate saving of DAgger demonstrations

### DIFF
--- a/src/imitation/algorithms/dagger.py
+++ b/src/imitation/algorithms/dagger.py
@@ -632,7 +632,6 @@ class SimpleDAggerTrainer(DAggerTrainer):
             )
 
             for traj in trajectories:
-                _save_dagger_demo(traj, collector.save_dir)
                 self._logger.record_mean(
                     "dagger/mean_episode_reward",
                     np.sum(traj.rews),

--- a/tests/algorithms/test_dagger.py
+++ b/tests/algorithms/test_dagger.py
@@ -56,6 +56,8 @@ def expert_policy(env_name, venv):
     if env_name in EXPERT_POLICY_PATH:
         return serialize.load_policy("ppo", EXPERT_POLICY_PATH[env_name], venv)
     else:
+        # TODO(adam): this is misleading as this is not an "expert".
+        # Should be able to delete this code after PR#405 is merged
         return serialize.load_policy("random", "dummy", venv)
 
 

--- a/tests/algorithms/test_dagger.py
+++ b/tests/algorithms/test_dagger.py
@@ -271,7 +271,9 @@ def test_trainer_makes_progress(init_trainer_fn, pendulum_venv, pendulum_expert_
             deterministic_policy=False,
         )
         # note a randomly initialised policy does well for some seeds -- so may
-        # want to adjust this check if changing seed.
+        # want to adjust this check if changing seed. Pendulum return can range
+        # from -1,200 to -130 (approx.), per Figure 3 in this PDF (on page 3):
+        # https://arxiv.org/pdf/2106.09556.pdf
         assert pre_train_rew_mean < -1000
         # Train for 6 iterations. (5 or less causes test to fail on some configs.)
         for i in range(6):

--- a/tests/algorithms/test_dagger.py
+++ b/tests/algorithms/test_dagger.py
@@ -112,7 +112,7 @@ def test_traj_collector(tmpdir, venv):
     assert not np.any(dones)
     for info in infos:
         assert isinstance(info, dict)
-    # roll out 5 * venv.num_envs episodes (Pendulum-v0 has 200 timestep episodes)
+    # roll out 5 * venv.num_envs episodes (Pendulum-v1 has 200 timestep episodes)
     for i in range(1000):
         _, _, dones, _ = collector.step(zero_acts)
         num_episodes += np.sum(dones)


### PR DESCRIPTION
Fixes #402. One-line change in DAgger to remove line duplicated from `InteractiveTrajectoryCollector`. Some more involved changes to the tests to let us check number of demo episodes saved is correct. In particular, needed to switch to `Pendulum-v1` from `CartPole-v0` to benefit from fixed length episodes letting us back out expected number of episodes from total timesteps.