### PR TITLE
Rename key of original environment reward in `RewardVecEnvWrapper` info dict

### DIFF
--- a/src/imitation/rewards/reward_wrapper.py
+++ b/src/imitation/rewards/reward_wrapper.py
@@ -41,7 +41,7 @@ class RewardVecEnvWrapper(vec_env.VecEnvWrapper):
     environment.
 
     Will also include the previous reward given by the inner VecEnv in the
-    returned info dict under the `wrapped_env_rew` key.
+    returned info dict under the `original_env_rew` key.
     """
 
     def __init__(
@@ -113,5 +113,5 @@ class RewardVecEnvWrapper(vec_env.VecEnvWrapper):
         # trajectory, not the last observation of the old trajectory
         self._old_obs = obs
         for info_dict, old_rew in zip(infos, old_rews):
-            info_dict["wrapped_env_rew"] = old_rew
+            info_dict["original_env_rew"] = old_rew
         return obs, rews, dones, infos

--- a/tests/rewards/test_reward_wrapper.py
+++ b/tests/rewards/test_reward_wrapper.py
@@ -45,4 +45,4 @@ def test_reward_overwrite():
     rand_act, _ = policy.predict(wrapped_env.reset())
     _, rew, _, infos = wrapped_env.step(rand_act)
     assert np.all(rew >= 0)
-    assert np.all([info_dict["wrapped_env_rew"] < 0 for info_dict in infos])
+    assert np.all([info_dict["original_env_rew"] < 0 for info_dict in infos])


### PR DESCRIPTION
In the logs, `ep_rew_wrapped_mean` refers to the reward model rewards, while `ep_rew_mean` reports original environment rewards from `Monitor`, which is applied to the environment immediately after creation.

In `RewardVecEnvWrapper`, we return an info dict with the original environment rewards under the key `wrapped_env_rew`. This is inconsistent with the logs where "wrapped" refers to reward model rewards.

As such, this PR changes the `wrapped_env_rew` key of the info dict to `original_env_rew`.