### PR TITLE
Refactor `stay_prob` to `switch_prob` in `ExplorationWrapper`

### DIFF
--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -174,7 +174,6 @@ class AgentTrainer(TrajectoryGenerator):
             seed=seed,
         )
 
-
     def train(self, steps: int, **kwargs) -> None:
         """Train the agent using the reward function specified during instantiation.
 

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -113,7 +113,7 @@ class AgentTrainer(TrajectoryGenerator):
         algorithm: base_class.BaseAlgorithm,
         reward_fn: Union[rewards_common.RewardFn, reward_nets.RewardNet],
         exploration_frac: float = 0.0,
-        stay_prob: float = 0.5,
+        switch_prob: float = 0.5,
         random_prob: float = 0.5,
         seed: Optional[int] = None,
         custom_logger: Optional[imit_logger.HierarchicalLogger] = None,
@@ -127,7 +127,7 @@ class AgentTrainer(TrajectoryGenerator):
                 the rewards used for training the agent.
             exploration_frac: fraction of the trajectories that will be generated
                 partially randomly rather than only by the agent when sampling.
-            stay_prob: the probability of staying with the current policy at each
+            switch_prob: the probability of switching the current policy at each
                 step for the exploratory samples.
             random_prob: the probability of picking the random policy when switching
                 during exploration.
@@ -170,9 +170,10 @@ class AgentTrainer(TrajectoryGenerator):
             policy=policy,
             venv=self.venv,
             random_prob=random_prob,
-            stay_prob=stay_prob,
+            switch_prob=switch_prob,
             seed=seed,
         )
+
 
     def train(self, steps: int, **kwargs) -> None:
         """Train the agent using the reward function specified during instantiation.
@@ -254,7 +255,6 @@ class AgentTrainer(TrajectoryGenerator):
             )
             exploration_trajs, _ = self.buffering_wrapper.pop_finished_trajectories()
             exploration_trajs = _get_trajectories(exploration_trajs, exploration_steps)
-
         # We call _get_trajectories separately on agent_trajs and exploration_trajs
         # and then just concatenate. This could mean we return slightly too many
         # transitions, but it gets the proportion of exploratory and agent transitions

--- a/src/imitation/policies/exploration_wrapper.py
+++ b/src/imitation/policies/exploration_wrapper.py
@@ -33,7 +33,7 @@ class ExplorationWrapper:
             policy: The policy to randomize.
             venv: The environment to use (needed for sampling random actions).
             random_prob: The probability of picking the random policy when switching.
-            switch_prob: The probability of switch away from the current policy.
+            switch_prob: The probability of switching away from the current policy.
             seed: The random seed to use.
         """
         self.wrapped_policy = policy

--- a/src/imitation/policies/exploration_wrapper.py
+++ b/src/imitation/policies/exploration_wrapper.py
@@ -24,7 +24,7 @@ class ExplorationWrapper:
         policy: rollout.PolicyCallable,
         venv: vec_env.VecEnv,
         random_prob: float,
-        stay_prob: float,
+        switch_prob: float,
         seed: Optional[int] = None,
     ):
         """Initializes the ExplorationWrapper.
@@ -33,12 +33,12 @@ class ExplorationWrapper:
             policy: The policy to randomize.
             venv: The environment to use (needed for sampling random actions).
             random_prob: The probability of picking the random policy when switching.
-            stay_prob: The probability of staying with the current policy.
+            switch_prob: The probability of switch away from the current policy.
             seed: The random seed to use.
         """
         self.wrapped_policy = policy
         self.random_prob = random_prob
-        self.stay_prob = stay_prob
+        self.switch_prob = switch_prob
         self.venv = venv
 
         self.rng = np.random.RandomState(seed)
@@ -61,6 +61,6 @@ class ExplorationWrapper:
 
     def __call__(self, obs: np.ndarray) -> np.ndarray:
         acts = self.current_policy(obs)
-        if self.rng.rand() < self.stay_prob:
+        if self.rng.rand() < self.switch_prob:
             self._switch()
         return acts

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -44,6 +44,7 @@ def train_defaults():
     }
     # path to a pickled sequence of trajectories used instead of training an agent
     trajectory_path = None
+    trajectory_generator_kwargs = {}  # kwargs to pass to trajectory generator
     allow_variable_horizon = False
 
     checkpoint_interval = 0  # Num epochs between saving (<0 disables, =0 final only)

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -64,6 +64,7 @@ def train_preference_comparisons(
     initial_comparison_frac: float,
     exploration_frac: float,
     trajectory_path: Optional[str],
+    trajectory_generator_kwargs: Mapping[str, Any],
     save_preferences: bool,
     agent_path: Optional[str],
     reward_trainer_kwargs: Mapping[str, Any],
@@ -100,7 +101,8 @@ def train_preference_comparisons(
             reward.
         trajectory_path: either None, in which case an agent will be trained
             and used to sample trajectories on the fly, or a path to a pickled
-            sequence of TrajectoryWithRew to be trained on
+            sequence of TrajectoryWithRew to be trained on.
+        trajectory_generator_kwargs: kwargs to pass to the trajectory generator.
         save_preferences: if True, store the final dataset of preferences to disk.
         agent_path: if given, initialize the agent using this stored policy
             rather than randomly.
@@ -152,6 +154,7 @@ def train_preference_comparisons(
             exploration_frac=exploration_frac,
             seed=_seed,
             custom_logger=custom_logger,
+            **trajectory_generator_kwargs,
         )
     else:
         if exploration_frac > 0:
@@ -162,6 +165,7 @@ def train_preference_comparisons(
             trajectories=types.load(trajectory_path),
             seed=_seed,
             custom_logger=custom_logger,
+            **trajectory_generator_kwargs,
         )
 
     fragmenter = preference_comparisons.RandomFragmenter(

--- a/tests/algorithms/test_mce_irl.py
+++ b/tests/algorithms/test_mce_irl.py
@@ -111,7 +111,7 @@ def test_policy_om_random_mdp(discount: float):
     if discount == 1.0:
         expected_sum = mdp.horizon
     else:
-        expected_sum = (1 - discount**mdp.horizon) / (1 - discount)
+        expected_sum = (1 - discount ** mdp.horizon) / (1 - discount)
     assert np.allclose(np.sum(D), expected_sum)
 
 

--- a/tests/algorithms/test_mce_irl.py
+++ b/tests/algorithms/test_mce_irl.py
@@ -111,7 +111,7 @@ def test_policy_om_random_mdp(discount: float):
     if discount == 1.0:
         expected_sum = mdp.horizon
     else:
-        expected_sum = (1 - discount ** mdp.horizon) / (1 - discount)
+        expected_sum = (1 - discount**mdp.horizon) / (1 - discount)
     assert np.allclose(np.sum(D), expected_sum)
 
 

--- a/tests/policies/test_exploration_wrapper.py
+++ b/tests/policies/test_exploration_wrapper.py
@@ -29,6 +29,16 @@ def make_wrapper(random_prob, switch_prob):
 
 
 def test_random_prob():
+    """Test that `random_prob` produces right behaviors of policy switching.
+
+    The policy always makes an initial switch when ExplorationWrapper is applied.
+    Then the policy makes switches according to `switch_prob`.
+
+    This test fixes `switch_prob` to 0.5 and sets `random_prob` to 0.0, 1.0 and 0.5.
+    (1) `random_prob=0.0`: Initial and following policies are always constant policies.
+    (2) `random_prob=1.0`: Initial and following policies are always random policies.
+    (3) `random_prob=0.5`: Around half-half for constant and random policies.
+    """
     wrapper, _ = make_wrapper(random_prob=0.0, switch_prob=0.5)
     assert wrapper.current_policy == constant_policy
     for _ in range(100):
@@ -58,8 +68,16 @@ def test_random_prob():
 
 
 def test_switch_prob():
-    # Ensure that we test both the random and the wrapped policy
-    # at least once:
+    """Test that `switch_prob` produces right behaviors of policy switching.
+
+    The policy always makes an initial switch when ExplorationWrapper is applied.
+    Then the policy makes switches according to `switch_prob`.
+
+    This test set includes the following:
+    (1) `switch_prob=0.0`: The policy never switches after initial switch.
+    (2) `switch_prob=1.0`: The policy always switches and the distribution of
+        policies is determined by `random_prob`.
+    """
     wrapper, venv = make_wrapper(random_prob=0.5, switch_prob=0.0)
     policy = wrapper.current_policy
     np.random.seed(0)
@@ -93,8 +111,7 @@ def test_switch_prob():
 
 
 def test_valid_output():
-    # Ensure that we test both the random and the wrapped policy
-    # at least once:
+    """Ensure that we test both the random and the wrapped policy at least once."""
     for random_prob in [0.0, 0.5, 1.0]:
         wrapper, venv = make_wrapper(random_prob=random_prob, switch_prob=0.5)
         np.random.seed(0)

--- a/tests/policies/test_exploration_wrapper.py
+++ b/tests/policies/test_exploration_wrapper.py
@@ -11,7 +11,7 @@ def constant_policy(obs):
     return np.zeros(len(obs), dtype=int)
 
 
-def make_wrapper(random_prob, stay_prob):
+def make_wrapper(random_prob, switch_prob):
     venv = util.make_vec_env(
         "seals/CartPole-v0",
         n_envs=1,
@@ -21,27 +21,27 @@ def make_wrapper(random_prob, stay_prob):
             policy=constant_policy,
             venv=venv,
             random_prob=random_prob,
-            stay_prob=stay_prob,
+            switch_prob=switch_prob,
             seed=0,
         ),
         venv,
     )
 
 
-def test_switch():
-    wrapper, _ = make_wrapper(random_prob=0.0, stay_prob=0.5)
+def test_random_prob():
+    wrapper, _ = make_wrapper(random_prob=0.0, switch_prob=0.5)
     assert wrapper.current_policy == constant_policy
     for _ in range(100):
         wrapper._switch()
         assert wrapper.current_policy == constant_policy
 
-    wrapper, _ = make_wrapper(random_prob=1.0, stay_prob=0.5)
+    wrapper, _ = make_wrapper(random_prob=1.0, switch_prob=0.5)
     assert wrapper.current_policy == wrapper._random_policy
     for _ in range(100):
         wrapper._switch()
         assert wrapper.current_policy == wrapper._random_policy
 
-    wrapper, _ = make_wrapper(random_prob=0.5, stay_prob=0.5)
+    wrapper, _ = make_wrapper(random_prob=0.5, switch_prob=0.5)
     num_random = 0
     num_constant = 0
     for _ in range(1000):
@@ -61,7 +61,7 @@ def test_valid_output():
     # Ensure that we test both the random and the wrapped policy
     # at least once:
     for random_prob in [0.0, 0.5, 1.0]:
-        wrapper, venv = make_wrapper(random_prob=random_prob, stay_prob=0.5)
+        wrapper, venv = make_wrapper(random_prob=random_prob, switch_prob=0.5)
         np.random.seed(0)
         obs = np.random.rand(100, 2)
         for action in wrapper(obs):

--- a/tests/policies/test_exploration_wrapper.py
+++ b/tests/policies/test_exploration_wrapper.py
@@ -38,6 +38,9 @@ def test_random_prob():
     (1) `random_prob=0.0`: Initial and following policies are always constant policies.
     (2) `random_prob=1.0`: Initial and following policies are always random policies.
     (3) `random_prob=0.5`: Around half-half for constant and random policies.
+
+    Raises:
+        ValueError: Unknown policy type to switch.
     """
     wrapper, _ = make_wrapper(random_prob=0.0, switch_prob=0.5)
     assert wrapper.current_policy == constant_policy

--- a/tests/policies/test_exploration_wrapper.py
+++ b/tests/policies/test_exploration_wrapper.py
@@ -57,6 +57,41 @@ def test_random_prob():
     assert num_constant > 450
 
 
+def test_switch_prob():
+    # Ensure that we test both the random and the wrapped policy
+    # at least once:
+    wrapper, venv = make_wrapper(random_prob=0.5, switch_prob=0.0)
+    policy = wrapper.current_policy
+    np.random.seed(0)
+    obs = np.random.rand(100, 2)
+    for action in wrapper(obs):
+        assert venv.action_space.contains(action)
+        assert wrapper.current_policy == policy
+
+    for random_prob in [0.0, 0.5]:
+        wrapper, venv = make_wrapper(random_prob=random_prob, switch_prob=1.0)
+        num_random = 0
+        num_constant = 0
+
+        np.random.seed(0)
+        for _ in range(1000):
+            obs = np.random.rand(1, 2)
+            for action in wrapper(obs):
+                if wrapper.current_policy == wrapper._random_policy:
+                    num_random += 1
+                elif wrapper.current_policy == constant_policy:
+                    num_constant += 1
+                else:  # pragma: no cover
+                    raise ValueError("Unknown policy")
+        if random_prob == 0.5:
+            # Holds with very high probability (and seeding means it's deterministic)
+            assert num_random > 450
+            assert num_constant > 450
+        else:
+            assert num_random == 0
+            assert num_constant == 1000
+
+
 def test_valid_output():
     # Ensure that we test both the random and the wrapped policy
     # at least once:

--- a/tests/policies/test_exploration_wrapper.py
+++ b/tests/policies/test_exploration_wrapper.py
@@ -96,7 +96,7 @@ def test_switch_prob():
         num_constant = 0
         for _ in range(num_steps):
             obs = np.random.rand(1, 2)
-            _ = wrapper(obs)
+            wrapper(obs)
             if wrapper.current_policy == wrapper._random_policy:
                 num_random += 1
             elif wrapper.current_policy == constant_policy:


### PR DESCRIPTION
This PR aims to address #410. It refactors `stay_prob` to `switch_prob` in `ExplorationWrapper`.