### PR TITLE
MCE IRL: fix sample-based occupancy measure computation

### DIFF
--- a/src/imitation/algorithms/mce_irl.py
+++ b/src/imitation/algorithms/mce_irl.py
@@ -356,7 +356,7 @@ class MCEIRL(base.DemonstrationAlgorithm[types.TransitionsMinimal]):
                         # TODO(adam): vectorize?
                         cum_discount = 1.0
                         # TODO(adam): do we want to omit last state?
-                        for obs in traj.obs[:-1]:
+                        for obs in traj.obs:
                             self.demo_state_om[obs] += cum_discount
                             cum_discount *= self.discount
                         num_demos += 1

--- a/src/imitation/algorithms/mce_irl.py
+++ b/src/imitation/algorithms/mce_irl.py
@@ -5,7 +5,7 @@ Follows the description in chapters 9 and 10 of Brian Ziebart's `PhD thesis`_.
 .. _PhD thesis:
     http://www.cs.cmu.edu/~bziebart/publications/thesis-bziebart.pdf
 """
-
+import warnings
 from typing import Any, Iterable, Mapping, Optional, Tuple, Type, Union
 
 import gym
@@ -109,9 +109,9 @@ def mce_occupancy_measures(
     if pi is None:
         _, _, pi = mce_partition_fh(env, reward=reward)
 
-    D = np.zeros((horizon, n_states))
+    D = np.zeros((horizon + 1, n_states))
     D[0, :] = env.initial_state_dist
-    for t in range(1, horizon):
+    for t in range(1, horizon + 1):
         for a in range(n_actions):
             E = D[t - 1] * pi[t - 1, :, a]
             D[t, :] += E @ T[:, a, :]
@@ -321,57 +321,92 @@ class MCEIRL(base.DemonstrationAlgorithm[types.TransitionsMinimal]):
             rng=self.rng,
         )
 
-    def _set_demo_from_obs(self, obses: np.ndarray) -> None:
-        if self.discount != 1.0:
-            raise ValueError(
-                "Cannot compute discounted OM from timeless Transitions.",
-            )
+    def _set_demo_from_trajectories(self, trajs: Iterable[types.Trajectory]) -> None:
+        num_demos = 0
+        for traj in trajs:
+            cum_discount = 1.0
+            for obs in traj.obs:
+                self.demo_state_om[obs] += cum_discount
+                cum_discount *= self.discount
+            num_demos += 1
+        self.demo_state_om /= num_demos
+
+    def _update_demo_from_obs(
+        self,
+        obses: np.ndarray,
+        dones: Optional[np.ndarray],
+        next_obses: Optional[np.ndarray],
+    ) -> None:
         for obs in obses:
             if isinstance(obs, th.Tensor):
                 obs = obs.numpy()
             self.demo_state_om[obs] += 1.0
 
-        discounted_horizon = rollout.discounted_sum(
-            np.ones(self.env.horizon),
-            gamma=self.discount,
-        )
-        self.demo_state_om *= discounted_horizon / self.demo_state_om.sum()  # normalize
+        # We assume the transitions were flattened from some trajectories,
+        # then possibly shuffled. So add next observations for terminal states,
+        # as they will not appear anywhere else; but ignore next observations
+        # for all other states as they occur elsewhere in dataset.
+        if next_obses is not None:
+            for done, obs in zip(dones, next_obses):
+                if isinstance(done, th.Tensor):
+                    done = done.numpy()
+                    obs = obs.numpy()
+                if done:
+                    self.demo_state_om[obs] += 1.0
+        else:
+            warnings.warn(
+                "Training MCEIRL with transitions that lack next observation."
+                "This will result in systematically wrong occupancy measure estimates.",
+            )
 
     def set_demonstrations(self, demonstrations: MCEDemonstrations) -> None:
         if isinstance(demonstrations, np.ndarray):
             # Demonstrations are an occupancy measure
             assert demonstrations.ndim == 1
             self.demo_state_om = demonstrations
-        else:
-            # Demonstrations are either trajectories or transitions;
-            # we must compute occupancy measure from this.
-            self.demo_state_om = np.zeros((self.env.n_states,))
+            return
 
-            if isinstance(demonstrations, Iterable):
-                first_item = next(iter(demonstrations))
-                if isinstance(first_item, types.Trajectory):
-                    # Demonstrations are trajectories.
-                    num_demos = 0
-                    for traj in demonstrations:
-                        # TODO(adam): vectorize?
-                        cum_discount = 1.0
-                        # TODO(adam): do we want to omit last state?
-                        for obs in traj.obs:
-                            self.demo_state_om[obs] += cum_discount
-                            cum_discount *= self.discount
-                        num_demos += 1
-                    self.demo_state_om /= num_demos
-                else:
-                    # Demonstrations are a Torch DataLoader or other Mapping iterable
-                    for batch in demonstrations:
-                        self._set_demo_from_obs(batch["obs"])
+        # Demonstrations are either trajectories or transitions;
+        # we must compute occupancy measure from this.
+        self.demo_state_om = np.zeros((self.env.n_states,))
 
-            elif isinstance(demonstrations, types.TransitionsMinimal):
-                self._set_demo_from_obs(demonstrations.obs)
-            else:
-                raise TypeError(
-                    f"Unsupported demonstration type {type(demonstrations)}",
+        if isinstance(demonstrations, Iterable):
+            first_item = next(iter(demonstrations))
+            if isinstance(first_item, types.Trajectory):
+                self._set_demo_from_trajectories(demonstrations)
+                return
+
+        # Demonstrations are from some kind of transitions-like object. This does
+        # not contain timesteps, so can only compute OM when undiscounted.
+        if self.discount != 1.0:
+            raise ValueError(
+                "Cannot compute discounted OM from timeless Transitions.",
+            )
+
+        if isinstance(demonstrations, types.Transitions):
+            self._update_demo_from_obs(
+                demonstrations.obs,
+                demonstrations.dones,
+                demonstrations.next_obs,
+            )
+        elif isinstance(demonstrations, types.TransitionsMinimal):
+            self._update_demo_from_obs(demonstrations.obs, None, None)
+        elif isinstance(demonstrations, Iterable):
+            # Demonstrations are a Torch DataLoader or other Mapping iterable
+            for batch in demonstrations:
+                assert isinstance(batch, Mapping)
+                self._update_demo_from_obs(
+                    batch["obs"],
+                    batch.get("dones"),
+                    batch.get("next_obs"),
                 )
+        else:
+            raise TypeError(
+                f"Unsupported demonstration type {type(demonstrations)}",
+            )
+
+        # Normalize occupancy measure estimates
+        self.demo_state_om *= (self.env.horizon + 1) / self.demo_state_om.sum()
 
     def _train_step(self, obs_mat: th.Tensor):
         self.optimizer.zero_grad()

--- a/src/imitation/algorithms/mce_irl.py
+++ b/src/imitation/algorithms/mce_irl.py
@@ -112,10 +112,10 @@ def mce_occupancy_measures(
 
     D = np.zeros((horizon + 1, n_states))
     D[0, :] = env.initial_state_dist
-    for t in range(1, horizon + 1):
+    for t in range(horizon):
         for a in range(n_actions):
-            E = D[t - 1] * pi[t - 1, :, a]
-            D[t, :] += E @ T[:, a, :]
+            E = D[t] * pi[t, :, a]
+            D[t + 1, :] += E @ T[:, a, :]
 
     Dcum = rollout.discounted_sum(D, discount)
     assert isinstance(Dcum, np.ndarray)

--- a/src/imitation/envs/resettable_env.py
+++ b/src/imitation/envs/resettable_env.py
@@ -130,8 +130,8 @@ class ResettableEnv(gym.Env, abc.ABC):
         self.cur_state = self.transition(self.cur_state, action)
         obs = self.obs_from_state(self.cur_state)
         rew = self.reward(old_state, action, self.cur_state)
-        done = self.terminal(self.cur_state, self._n_actions_taken)
         self._n_actions_taken += 1
+        done = self.terminal(self.cur_state, self._n_actions_taken)
 
         infos = {"old_state": old_state, "new_state": self.cur_state}
         combined_obs = {"obs": obs, "state": self.cur_state}

--- a/tests/algorithms/test_mce_irl.py
+++ b/tests/algorithms/test_mce_irl.py
@@ -317,7 +317,11 @@ def test_mce_irl_demo_formats():
     demonstrations = {
         "trajs": trajs,
         "trans": rollout.flatten_trajectories(trajs),
-        "data_loader": base.make_data_loader(trajs, batch_size=32),
+        "data_loader": base.make_data_loader(
+            trajs,
+            batch_size=32,
+            data_loader_kwargs=dict(drop_last=False),
+        ),
     }
 
     final_counts = {}

--- a/tests/algorithms/test_mce_irl.py
+++ b/tests/algorithms/test_mce_irl.py
@@ -393,4 +393,4 @@ def test_mce_irl_reasonable_mdp(
         )
         stats = rollout.rollout_stats(trajs)
         if discount > 0.0:  # skip check when discount==0.0 (random policy)
-            assert stats["return_mean"] >= mdp.horizon * 2 * 0.8
+            assert stats["return_mean"] >= (mdp.horizon - 1) * 2 * 0.8

--- a/tests/algorithms/test_mce_irl.py
+++ b/tests/algorithms/test_mce_irl.py
@@ -104,14 +104,15 @@ def test_policy_om_random_mdp(discount: float):
     assert np.allclose(np.sum(pi, axis=-1), 1)
 
     Dt, D = mce_occupancy_measures(mdp, pi=pi, discount=discount)
+    assert len(Dt) == mdp.horizon + 1
     assert np.all(np.isfinite(D))
     assert np.any(D > 0)
     # expected number of state visits (over all states) should be equal to the
     # horizon
     if discount == 1.0:
-        expected_sum = mdp.horizon
+        expected_sum = mdp.horizon + 1
     else:
-        expected_sum = (1 - discount**mdp.horizon) / (1 - discount)
+        expected_sum = (1 - discount ** (mdp.horizon + 1)) / (1 - discount)
     assert np.allclose(np.sum(D), expected_sum)
 
 
@@ -333,14 +334,14 @@ def test_mce_irl_demo_formats():
                 hid_sizes=[],
             )
             mce_irl = MCEIRL(demo, mdp, reward_net, linf_eps=1e-3)
-            assert np.allclose(mce_irl.demo_state_om.sum(), 1.0)
+            assert np.allclose(mce_irl.demo_state_om.sum(), mdp.horizon + 1)
             final_counts[kind] = mce_irl.train(max_iter=5)
 
             # make sure weights have non-insane norm
             assert tensor_iter_norm(mce_irl.reward_net.parameters()) < 1000
 
-    for cts in final_counts.values():
-        assert np.allclose(cts, final_counts["trajs"], atol=1e-3, rtol=1e-3)
+    for k, cts in final_counts.items():
+        assert np.allclose(cts, final_counts["trajs"], atol=1e-3, rtol=1e-3), k
 
 
 @pytest.mark.expensive


### PR DESCRIPTION
`MCEIRL` either takes the occupancy measure directly, or estimates it from a finite number of demonstrations. `mce_occupancy_measure` computes occupancy measure by summing discounted occupancies over an episode. For sample-based approximations, we were normalizing everything to sum to 1, when it should instead sum to `sum([gamma**t for t in range(horizon)])`.

This PR adjusts the sample-based approximation to match that of `mce_occupancy_measures`.