### PR TITLE
Changes to support dict_obs for BC

### DIFF
--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -289,7 +289,11 @@ class BC(algo_base.DemonstrationAlgorithm):
             stats_dict: Statistics about the learning process to be logged.
 
         """
-        obs = th.as_tensor(obs, device=self.device).detach()
+        if isinstance(obs, dict):
+            for key in obs:
+                obs[key] = th.as_tensor(obs[key], device=self.device).detach()
+        else:
+            obs = th.as_tensor(obs, device=self.device).detach()
         acts = th.as_tensor(acts, device=self.device).detach()
 
         _, log_prob, entropy = self.policy.evaluate_actions(obs, acts)


### PR DESCRIPTION
This PR aims to address data preprocessing of dictionary observation (like in gym fetch envs) for BC.

The function `transitions_collate_fn` in `types.py` fails to collate dictionary observation. This issue comes from: the `batch_no_infos` in `transitions_collate_fn` will turn obs (as dictionaries) into np.array(dict). This makes the type of `batch_no_infos["obs"]` as object, which is not supported by the `default_collate` function of the `DataLoader` of torch.

This incurs a further problem: when feed `batch["obs"]` into the `CombinedFeatureExtractor`, the supported type is `TensorDict` (Dictionary of tenser) defined in `sb3.common.type_aliases`. The reason we'd like to use such type is that we need `preprocess_obs` in `sb3`, with which TensorDict type obs is compatible.

I make some modifications to address the two points above when running BC. But I think there could be a more concise and general way to face up dict_obs. 