### PR TITLE
Remove mean_return helper and replace by evaluate_policy in SB3

### DIFF
--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -462,20 +462,6 @@ def rollout_stats(
     return out_stats
 
 
-def mean_return(*args, **kwargs) -> float:
-    """Find the mean return of a policy.
-
-    Args:
-        *args: Passed through to `generate_trajectories`.
-        **kwargs: Passed through to `generate_trajectories`.
-
-    Returns:
-        The mean return of the generated trajectories.
-    """
-    trajectories = generate_trajectories(*args, **kwargs)
-    return rollout_stats(trajectories)["return_mean"]
-
-
 def flatten_trajectories(
     trajectories: Sequence[types.Trajectory],
 ) -> types.Transitions:

--- a/tests/algorithms/test_bc.py
+++ b/tests/algorithms/test_bc.py
@@ -5,7 +5,7 @@ import os
 
 import pytest
 import torch as th
-from stable_baselines3.common import vec_env
+from stable_baselines3.common import evaluation, vec_env
 from torch.utils import data as th_data
 
 from imitation.algorithms import bc
@@ -94,15 +94,15 @@ def test_train_end_cond_error(trainer: bc.BC):
 
 
 def test_bc(trainer: bc.BC, cartpole_venv):
-    sample_until = rollout.make_min_episodes(15)
-    novice_ret_mean = rollout.mean_return(trainer.policy, cartpole_venv, sample_until)
+    novice_ret_mean, _ = evaluation.evaluate_policy(trainer.policy, cartpole_venv, 15)
+
     trainer.train(
         n_epochs=1,
         on_epoch_end=lambda: print("epoch end"),
         on_batch_end=lambda: print("batch end"),
     )
     trainer.train(n_batches=10)
-    trained_ret_mean = rollout.mean_return(trainer.policy, cartpole_venv, sample_until)
+    trained_ret_mean, _ = evaluation.evaluate_policy(trainer.policy, cartpole_venv, 15)
     # Typically <80 score is bad, >350 is okay. We want an improvement of at
     # least 50 points, which seems like it's not noise.
     assert trained_ret_mean - novice_ret_mean > 50

--- a/tests/algorithms/test_dagger.py
+++ b/tests/algorithms/test_dagger.py
@@ -11,7 +11,7 @@ import gym
 import numpy as np
 import pytest
 import torch.random
-from stable_baselines3.common import policies
+from stable_baselines3.common import evaluation, policies
 
 from imitation.algorithms import bc, dagger
 from imitation.data import rollout
@@ -264,11 +264,11 @@ def test_trainer_makes_progress(init_trainer_fn, pendulum_venv, pendulum_expert_
         pendulum_venv.action_space.seed(42)
 
         trainer = init_trainer_fn()
-        pre_train_rew_mean = rollout.mean_return(
+        pre_train_rew_mean, _ = evaluation.evaluate_policy(
             trainer.policy,
             pendulum_venv,
-            sample_until=rollout.make_min_episodes(15),
-            deterministic_policy=False,
+            15,
+            deterministic=False,
         )
         # note a randomly initialised policy does well for some seeds -- so may
         # want to adjust this check if changing seed. Pendulum return can range
@@ -290,11 +290,10 @@ def test_trainer_makes_progress(init_trainer_fn, pendulum_venv, pendulum_expert_
                     obs, _, dones, _ = collector.step(expert_actions)
             trainer.extend_and_update(dict(n_epochs=1))
         # make sure we're doing better than a random policy would
-        post_train_rew_mean = rollout.mean_return(
+        post_train_rew_mean, _ = evaluation.evaluate_policy(
             trainer.policy,
             pendulum_venv,
-            sample_until=rollout.make_min_episodes(15),
-            deterministic_policy=True,
+            15,
         )
 
     assert post_train_rew_mean - pre_train_rew_mean > 300, (


### PR DESCRIPTION
Just a small PR to gradually reduce the number of helpers and utils that we have to maintain ourselves.