### PR TITLE
Use permutations tests when comparing episode rewards

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ TESTS_REQUIRE = [
     "pytest-xdist",
     "pytype",
     "ray[debug,tune]~=0.8.5",
-    "scipy",
+    "scipy>=1.8.0",
     "wandb",
 ]
 DOCS_REQUIRE = [

--- a/src/imitation/testing/reward_improvement.py
+++ b/src/imitation/testing/reward_improvement.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy import stats
 
 
-def rewards_improved(
+def is_significant_reward_improvement(
     old_rewards: Iterable[float],
     new_rewards: Iterable[float],
     p_value: float = 0.05,
@@ -25,13 +25,13 @@ def rewards_improved(
         For this, the probability, that the old rewards are just as good as the new
         rewards must be below `p_value`.
 
-    >>> rewards_improved((5, 6, 7, 4, 4), (7, 5, 9, 9, 12))
+    >>> is_significant_reward_improvement((5, 6, 7, 4, 4), (7, 5, 9, 9, 12))
     True
 
-    >>> rewards_improved((5, 6, 7, 4, 4), (7, 5, 9, 7, 4))
+    >>> is_significant_reward_improvement((5, 6, 7, 4, 4), (7, 5, 9, 7, 4))
     False
 
-    >>> rewards_improved((5, 6, 7, 4, 4), (7, 5, 9, 7, 4), p_value=0.3)
+    >>> is_significant_reward_improvement((5, 6, 7, 4, 4), (7, 5, 9, 7, 4), p_value=0.3)
     True
     """
     permutation_test_result = stats.permutation_test(

--- a/src/imitation/testing/reward_improvement.py
+++ b/src/imitation/testing/reward_improvement.py
@@ -1,4 +1,4 @@
-"""Utility functions used to write tests."""
+"""Utility functions used to check if rewards improved wrt to previous rewards."""
 from typing import Iterable
 
 import numpy as np

--- a/src/imitation/testing/reward_improvement.py
+++ b/src/imitation/testing/reward_improvement.py
@@ -42,3 +42,28 @@ def is_significant_reward_improvement(
     )
 
     return permutation_test_result.pvalue < p_value
+
+
+def mean_reward_improved_by(
+    old_rewards: Iterable[float],
+    new_rewards: Iterable[float],
+    min_improvement: float,
+):
+    """Checks if mean rewards improved wrt. to old rewards by a certain amount.
+
+    Args:
+        old_rewards: Iterable of "old" trajectory rewards (e.g. before training).
+        new_rewards: Iterable of "new" trajectory rewards (e.g. after training).
+        min_improvement: The minimum amount of improvement that we expect.
+
+    Returns:
+        True if the mean of the new rewards is larger than the mean of the old rewards
+        by min_improvement.
+
+    >>> mean_reward_improved_by([5, 8, 7], [8, 9, 10], 2)
+    True
+
+    >>> mean_reward_improved_by([5, 8, 7], [8, 9, 10], 5)
+    False
+    """
+    return np.mean(new_rewards) - np.mean(old_rewards) >= min_improvement

--- a/src/imitation/testing/reward_improvement.py
+++ b/src/imitation/testing/reward_improvement.py
@@ -18,7 +18,7 @@ def is_significant_reward_improvement(
         old_rewards: Iterable of "old" trajectory rewards (e.g. before training).
         new_rewards: Iterable of "new" trajectory rewards (e.g. after training).
         p_value: The maximum probability, that the old rewards are just as good as the
-            new reawards, that we tolerate.
+            new rewards, that we tolerate.
 
     Returns:
         True, if the new rewards are most probably better than the old rewards.

--- a/tests/algorithms/test_bc.py
+++ b/tests/algorithms/test_bc.py
@@ -118,6 +118,11 @@ def test_bc(trainer: bc.BC, cartpole_venv):
         novice_rewards,
         rewards_after_training,
     )
+    assert reward_improvement.mean_reward_improved_by(
+        novice_rewards,
+        rewards_after_training,
+        50,
+    )
 
 
 def test_bc_log_rollouts(trainer: bc.BC, cartpole_venv):

--- a/tests/algorithms/test_bc.py
+++ b/tests/algorithms/test_bc.py
@@ -5,12 +5,12 @@ import os
 
 import pytest
 import torch as th
-import utils
 from stable_baselines3.common import evaluation, vec_env
 from torch.utils import data as th_data
 
 from imitation.algorithms import bc
 from imitation.data import rollout, types
+from imitation.testing import reward_improvement
 from imitation.util import logger
 
 
@@ -114,7 +114,7 @@ def test_bc(trainer: bc.BC, cartpole_venv):
         15,
         return_episode_rewards=True,
     )
-    assert utils.rewards_improved(novice_rewards, rewards_after_training)
+    assert reward_improvement.rewards_improved(novice_rewards, rewards_after_training)
 
 
 def test_bc_log_rollouts(trainer: bc.BC, cartpole_venv):

--- a/tests/algorithms/test_bc.py
+++ b/tests/algorithms/test_bc.py
@@ -114,7 +114,10 @@ def test_bc(trainer: bc.BC, cartpole_venv):
         15,
         return_episode_rewards=True,
     )
-    assert reward_improvement.rewards_improved(novice_rewards, rewards_after_training)
+    assert reward_improvement.is_significant_reward_improvement(
+        novice_rewards,
+        rewards_after_training,
+    )
 
 
 def test_bc_log_rollouts(trainer: bc.BC, cartpole_venv):

--- a/tests/algorithms/test_dagger.py
+++ b/tests/algorithms/test_dagger.py
@@ -299,7 +299,10 @@ def test_trainer_makes_progress(init_trainer_fn, pendulum_venv, pendulum_expert_
             return_episode_rewards=True,
         )
 
-    assert reward_improvement.rewards_improved(novice_rewards, rewards_after_training)
+    assert reward_improvement.is_significant_reward_improvement(
+        novice_rewards,
+        rewards_after_training,
+    )
 
 
 def test_trainer_save_reload(tmpdir, init_trainer_fn, pendulum_venv):

--- a/tests/algorithms/test_dagger.py
+++ b/tests/algorithms/test_dagger.py
@@ -11,13 +11,13 @@ import gym
 import numpy as np
 import pytest
 import torch.random
-import utils
 from stable_baselines3.common import evaluation, policies
 
 from imitation.algorithms import bc, dagger
 from imitation.data import rollout
 from imitation.data.types import TrajectoryWithRew
 from imitation.policies import base
+from imitation.testing import reward_improvement
 from imitation.util import util
 
 
@@ -299,7 +299,7 @@ def test_trainer_makes_progress(init_trainer_fn, pendulum_venv, pendulum_expert_
             return_episode_rewards=True,
         )
 
-    assert utils.rewards_improved(novice_rewards, rewards_after_training)
+    assert reward_improvement.rewards_improved(novice_rewards, rewards_after_training)
 
 
 def test_trainer_save_reload(tmpdir, init_trainer_fn, pendulum_venv):

--- a/tests/algorithms/test_dagger.py
+++ b/tests/algorithms/test_dagger.py
@@ -303,6 +303,11 @@ def test_trainer_makes_progress(init_trainer_fn, pendulum_venv, pendulum_expert_
         novice_rewards,
         rewards_after_training,
     )
+    assert reward_improvement.mean_reward_improved_by(
+        novice_rewards,
+        rewards_after_training,
+        300,
+    )
 
 
 def test_trainer_save_reload(tmpdir, init_trainer_fn, pendulum_venv):

--- a/tests/algorithms/test_density_baselines.py
+++ b/tests/algorithms/test_density_baselines.py
@@ -5,13 +5,13 @@ from typing import Sequence
 import numpy as np
 import pytest
 import stable_baselines3
-import utils
 from stable_baselines3.common import policies
 
 from imitation.algorithms.density import DensityAlgorithm, DensityType
 from imitation.data import rollout, types
 from imitation.data.types import TrajectoryWithRew
 from imitation.policies.base import RandomPolicy
+from imitation.testing import reward_improvement
 
 parametrize_density_stationary = pytest.mark.parametrize(
     "density_type,is_stationary",
@@ -75,7 +75,7 @@ def test_density_reward(
     expert_trajectories_test = expert_trajectories_all[n_experts // 2 :]
     random_returns = score_trajectories(random_trajectories, reward_fn)
     expert_returns = score_trajectories(expert_trajectories_test, reward_fn)
-    assert utils.rewards_improved(random_returns, expert_returns)
+    assert reward_improvement.rewards_improved(random_returns, expert_returns)
 
 
 @pytest.mark.expensive

--- a/tests/algorithms/test_density_baselines.py
+++ b/tests/algorithms/test_density_baselines.py
@@ -5,6 +5,7 @@ from typing import Sequence
 import numpy as np
 import pytest
 import stable_baselines3
+import utils
 from stable_baselines3.common import policies
 
 from imitation.algorithms.density import DensityAlgorithm, DensityType
@@ -32,7 +33,7 @@ def score_trajectories(
         rewards = density_reward(traj.obs[:-1], traj.acts, traj.obs[1:], dones, steps)
         ret = np.sum(rewards)
         returns.append(ret)
-    return np.mean(returns)
+    return returns
 
 
 # test on Pendulum rather than Cartpole because I don't handle episodes that
@@ -72,9 +73,9 @@ def test_density_reward(
         sample_until=sample_until,
     )
     expert_trajectories_test = expert_trajectories_all[n_experts // 2 :]
-    random_score = score_trajectories(random_trajectories, reward_fn)
-    expert_score = score_trajectories(expert_trajectories_test, reward_fn)
-    assert expert_score > random_score
+    random_returns = score_trajectories(random_trajectories, reward_fn)
+    expert_returns = score_trajectories(expert_trajectories_test, reward_fn)
+    assert utils.rewards_improved(random_returns, expert_returns)
 
 
 @pytest.mark.expensive

--- a/tests/algorithms/test_density_baselines.py
+++ b/tests/algorithms/test_density_baselines.py
@@ -75,7 +75,10 @@ def test_density_reward(
     expert_trajectories_test = expert_trajectories_all[n_experts // 2 :]
     random_returns = score_trajectories(random_trajectories, reward_fn)
     expert_returns = score_trajectories(expert_trajectories_test, reward_fn)
-    assert reward_improvement.rewards_improved(random_returns, expert_returns)
+    assert reward_improvement.is_significant_reward_improvement(
+        random_returns,
+        expert_returns,
+    )
 
 
 @pytest.mark.expensive

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,44 @@
+"""Utility functions used to write tests."""
+from typing import Iterable
+
+import numpy as np
+from scipy import stats
+
+
+def rewards_improved(
+    old_rewards: Iterable[float],
+    new_rewards: Iterable[float],
+    p_value: float = 0.05,
+) -> bool:
+    """Checks if that the new rewards are really better than the old rewards.
+
+    Ensures, that this is not just due to lucky sampling by a permutation test.
+
+    Args:
+        old_rewards: Iterable of "old" trajectory rewards (e.g. before training).
+        new_rewards: Iterable of "new" trajectory rewards (e.g. after training).
+        p_value: The maximum probabliity, that the old rewards are just as good as the
+            new reawards, that we tolerate.
+
+    Returns:
+        True, if the new rewards are most probably better than the old rewards.
+        For this, the probability, that the old rewards are just as good as the new
+        rewards must be below `p_value`.
+
+    >>> rewards_improved((5, 6, 7, 4, 4), (7, 5, 9, 9, 12))
+    True
+
+    >>> rewards_improved((5, 6, 7, 4, 4), (7, 5, 9, 7, 4))
+    False
+
+    >>> rewards_improved((5, 6, 7, 4, 4), (7, 5, 9, 7, 4), p_value=0.3)
+    True
+    """
+    permutation_test_result = stats.permutation_test(
+        (old_rewards, new_rewards),
+        statistic=lambda x, y, axis: np.mean(x, axis=axis) - np.mean(y, axis=axis),
+        vectorized=True,
+        alternative="less",
+    )
+
+    return permutation_test_result.pvalue < p_value

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,14 +10,14 @@ def rewards_improved(
     new_rewards: Iterable[float],
     p_value: float = 0.05,
 ) -> bool:
-    """Checks if that the new rewards are really better than the old rewards.
+    """Checks if the new rewards are really better than the old rewards.
 
-    Ensures, that this is not just due to lucky sampling by a permutation test.
+    Ensures that this is not just due to lucky sampling by a permutation test.
 
     Args:
         old_rewards: Iterable of "old" trajectory rewards (e.g. before training).
         new_rewards: Iterable of "new" trajectory rewards (e.g. after training).
-        p_value: The maximum probabliity, that the old rewards are just as good as the
+        p_value: The maximum probability, that the old rewards are just as good as the
             new reawards, that we tolerate.
 
     Returns:


### PR DESCRIPTION
Right now we are comparing just the mean episode rewards between episodes from untrained and from trained policies to ensure that training is successful.
This is not a proper statistical test to ensure, that there was a certain training effect.
This PR introduces a proper permutation test to compute and ensure the significance of the change induced by training.

Note: right now this branch starts off the `remove_mean_return_helper`. It will be rebased on master as soon as that PR is merged.