### PR TITLE
Remove redundant component of Xdummy-entrypoint.py

### DIFF
--- a/ci/Xdummy-entrypoint.py
+++ b/ci/Xdummy-entrypoint.py
@@ -30,11 +30,6 @@ if __name__ == "__main__":
             ":0",
         ]
     )
-    subprocess.Popen(
-        ["nohup", "Xdummy"],
-        stdout=open("/dev/null", "w"),
-        stderr=open("/dev/null", "w"),
-    )
     os.environ["DISPLAY"] = ":0"
 
     if not extra_args:


### PR DESCRIPTION
`Xdummy-entrypoint.py` tried to launch Xdummy in two ways: via a shell script (which no longer exists, and fails silently as output redirected to /dev/null) and directly via `Xorg` (which succeeds). This PR removes the silently failing part of it.