### PR TITLE
Refactored serialize.py to allow for dezerialization of normalized reward functions

### DIFF
--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -1,12 +1,18 @@
 """Load serialized reward functions of different types."""
 
-from typing import Callable
+from typing import Callable, List, Type
 
 import numpy as np
 import torch as th
 from stable_baselines3.common.vec_env import VecEnv
 
 from imitation.rewards import common
+from imitation.rewards.reward_nets import (
+    NormalizedRewardNet,
+    RewardNet,
+    RewardNetWrapper,
+    ShapedRewardNet,
+)
 from imitation.util import registry, util
 
 # TODO(sam): I suspect this whole file can be replaced with th.load calls. Try
@@ -17,33 +23,57 @@ RewardFnLoaderFn = Callable[[str, VecEnv], common.RewardFn]
 reward_registry: registry.Registry[RewardFnLoaderFn] = registry.Registry()
 
 
-def _load_reward_net_as_fn(shaped: bool) -> RewardFnLoaderFn:
-    def loader(path: str, venv: VecEnv) -> common.RewardFn:
-        """Load train (shaped) or test (not shaped) reward from path."""
-        del venv  # Unused.
-        net = th.load(str(path))
-        if not shaped and hasattr(net, "base"):
-            # If the "base" attribute exists, we are dealing with a ShapedRewardNet
-            # and will disable the potential shaping (if shaped is False).
-            # If no "base" attribute exists, we seem to use an unshaped RewardNet
-            # anyway, so we just use its predict() method directly.
-            reward = net.base.predict
-        else:
-            reward = net.predict
+def _validate_reward(reward: common.RewardFn) -> common.RewardFn:
+    """Add sanity check to the reward function for dealing with VecEnvs."""
 
-        def rew_fn(
-            obs: np.ndarray,
-            act: np.ndarray,
-            next_obs: np.ndarray,
-            dones: np.ndarray,
-        ) -> np.ndarray:
-            rew = reward(obs, act, next_obs, dones)
-            assert rew.shape == (len(obs),)
-            return rew
+    def rew_fn(
+        obs: np.ndarray,
+        act: np.ndarray,
+        next_obs: np.ndarray,
+        dones: np.ndarray,
+    ) -> np.ndarray:
+        rew = reward(obs, act, next_obs, dones)
+        assert rew.shape == (len(obs),)
+        return rew
 
-        return rew_fn
+    return rew_fn
 
-    return loader
+
+def _strip_wrappers(
+    net: RewardNet,
+    wrappers: List[Type[RewardNetWrapper]],
+) -> RewardNet:
+    """Attempts to remove provided wrappers.
+
+    wrappers until either it reaches a non-warper
+    reward net or it has removed all the listed wrappers.
+
+    Args:
+        net: an instance of a reward network that may be wrapped
+        wrappers: list of wrapper types to remove
+
+    Returns:
+        The reward network with the listed wrappers removed
+    """
+    for wrapper_type in wrappers:
+        if not isinstance(net, RewardNetWrapper):
+            # Reached base reward net
+            break
+
+        assert hasattr(net, "base")
+
+        if isinstance(net, wrapper_type):
+            net = net.base
+
+    return net
+
+
+def _make_functional(
+    net: RewardNet,
+    attr: str = "predict",
+    kwargs=dict(),
+) -> common.RewardFn:
+    return lambda *args: getattr(net, attr)(*args, **kwargs)
 
 
 def load_zero(path: str, venv: VecEnv) -> common.RewardFn:
@@ -62,14 +92,37 @@ def load_zero(path: str, venv: VecEnv) -> common.RewardFn:
 
 
 # TODO(adam): I think we can get rid of this and have just one RewardNet.
+
+# TODO figure out if you need to reset the input normalizationan)a)_and_update
 reward_registry.register(
     key="RewardNet_shaped",
-    value=_load_reward_net_as_fn(shaped=True),
+    value=lambda path, _: _validate_reward(_make_functional(th.load(str(path)))),
 )
 reward_registry.register(
     key="RewardNet_unshaped",
-    value=_load_reward_net_as_fn(shaped=False),
+    value=lambda path, _: _validate_reward(
+        _make_functional(_strip_wrappers(th.load(str(path)), [ShapedRewardNet])),
+    ),
 )
+
+reward_registry.register(
+    key="RewardNet_normalized",
+    value=lambda path, _: _validate_reward(
+        _make_functional(
+            th.load(str(path)),
+            attr="predict_processed",
+            kwargs={"update_stats": False},
+        ),
+    ),
+)
+
+reward_registry.register(
+    key="RewardNet_unnormalized",
+    value=lambda path, _: _validate_reward(
+        _make_functional(_strip_wrappers(th.load(str(path)), [NormalizedRewardNet])),
+    ),
+)
+
 reward_registry.register(key="zero", value=load_zero)
 
 

--- a/tests/rewards/test_reward_nets.py
+++ b/tests/rewards/test_reward_nets.py
@@ -16,7 +16,7 @@ from imitation.rewards import reward_nets, serialize
 from imitation.util import networks, util
 
 ENVS = ["FrozenLake-v1", "CartPole-v1", "Pendulum-v1"]
-HARDCODED_TYPES = ["zero"]
+HARDCODED_TYPES = ["zero", "RewardNet_normalized", "RewardNet_unnormalized"]
 
 REWARD_NETS = [
     reward_nets.BasicRewardNet,
@@ -71,6 +71,16 @@ def test_reward_valid(env_name, reward_type):
 
     assert pred_reward.shape == (TRAJECTORY_LEN,)
     assert isinstance(pred_reward[0], numbers.Number)
+
+
+@pytest.mark.parametrize("env_name", ENVS)
+def test_serializing_normalization(env_name, tmpdir):
+    venv = util.make_vec_env(env_name, n_envs=1, parallel=False)
+    net = reward_nets.BasicRewardNet(venv.observation_space, venv.action_space)
+    net = reward_nets.NormalizedRewardNet(net, networks.RunningNorm(1))
+    save_path = os.path.join(tmpdir, "norm_reward.pt")
+    th.save(save_path)
+    net = serialize.load_reward("RewardNet_normalized", save_path, venv)
 
 
 @pytest.mark.parametrize("env_name", ENVS)


### PR DESCRIPTION
Within `serialize.py`, I've broke down `_load_reward_net_as_fn` into a series of composable functions that should allow for more flexibility in loading reward functions in the future. I have maintained the public interface of `load_reward` to avoid a breaking change. Finally, I've added a new reward function type that can be de-serialized `RewarNet_normalized` and `RewardNet_unnormalized`.  The former allows the user to maintain the normalization learned during training while the latter strips off the normalization wrapper and returns the underlying unnormalized reward function. In both cases the reward function will stop updating its normalization statistics after it is de-serialized.