### PR TITLE
Refactored serialize.py to allow for de-serialization of normalized reward functions

### DIFF
--- a/experiments/transfer_learn_benchmark.sh
+++ b/experiments/transfer_learn_benchmark.sh
@@ -87,7 +87,7 @@ parallel -j 25% --header : --results "${LOG_ROOT}/parallel/" --colsep , --progre
   with \
   '{env_config_name}' seed='{seed}' \
   common.log_dir="${LOG_ROOT}/${ALGORITHM}/{env_config_name}_{seed}/n_expert_demos_{n_expert_demos}" \
-  reward_type="RewardNet_shaped" \
+  reward_type="RewardNet_unshaped" \
   reward_path="${REWARD_MODELS_DIR}/${ALGORITHM}/{env_config_name}_0/n_expert_demos_{n_expert_demos}/checkpoints/final/reward_test.pt" \
   "${extra_configs[@]}" \
   :::: ${CONFIG_CSV} \

--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -1,12 +1,18 @@
 """Load serialized reward functions of different types."""
 
-from typing import Callable
+from typing import Callable, List, Type
 
 import numpy as np
 import torch as th
 from stable_baselines3.common.vec_env import VecEnv
 
 from imitation.rewards import common
+from imitation.rewards.reward_nets import (
+    NormalizedRewardNet,
+    RewardNet,
+    RewardNetWrapper,
+    ShapedRewardNet,
+)
 from imitation.util import registry, util
 
 # TODO(sam): I suspect this whole file can be replaced with th.load calls. Try
@@ -17,33 +23,57 @@ RewardFnLoaderFn = Callable[[str, VecEnv], common.RewardFn]
 reward_registry: registry.Registry[RewardFnLoaderFn] = registry.Registry()
 
 
-def _load_reward_net_as_fn(shaped: bool) -> RewardFnLoaderFn:
-    def loader(path: str, venv: VecEnv) -> common.RewardFn:
-        """Load train (shaped) or test (not shaped) reward from path."""
-        del venv  # Unused.
-        net = th.load(str(path))
-        if not shaped and hasattr(net, "base"):
-            # If the "base" attribute exists, we are dealing with a ShapedRewardNet
-            # and will disable the potential shaping (if shaped is False).
-            # If no "base" attribute exists, we seem to use an unshaped RewardNet
-            # anyway, so we just use its predict() method directly.
-            reward = net.base.predict
-        else:
-            reward = net.predict
+def _validate_reward(reward: common.RewardFn) -> common.RewardFn:
+    """Add sanity check to the reward function for dealing with VecEnvs."""
 
-        def rew_fn(
-            obs: np.ndarray,
-            act: np.ndarray,
-            next_obs: np.ndarray,
-            dones: np.ndarray,
-        ) -> np.ndarray:
-            rew = reward(obs, act, next_obs, dones)
-            assert rew.shape == (len(obs),)
-            return rew
+    def rew_fn(
+        obs: np.ndarray,
+        act: np.ndarray,
+        next_obs: np.ndarray,
+        dones: np.ndarray,
+    ) -> np.ndarray:
+        rew = reward(obs, act, next_obs, dones)
+        assert rew.shape == (len(obs),)
+        return rew
 
-        return rew_fn
+    return rew_fn
 
-    return loader
+
+def _strip_wrappers(
+    net: RewardNet,
+    wrappers: List[Type[RewardNetWrapper]],
+) -> RewardNet:
+    """Attempts to remove provided wrappers.
+
+    wrappers until either it reaches a non-warper
+    reward net or it has removed all the listed wrappers.
+
+    Args:
+        net: an instance of a reward network that may be wrapped
+        wrappers: list of wrapper types to remove
+
+    Returns:
+        The reward network with the listed wrappers removed
+    """
+    for wrapper_type in wrappers:
+        if not isinstance(net, RewardNetWrapper):
+            # Reached base reward net
+            break
+
+        assert hasattr(net, "base")
+
+        if isinstance(net, wrapper_type):
+            net = net.base
+
+    return net
+
+
+def _make_functional(
+    net: RewardNet,
+    attr: str = "predict",
+    kwargs=dict(),
+) -> common.RewardFn:
+    return lambda *args: getattr(net, attr)(*args, **kwargs)
 
 
 def load_zero(path: str, venv: VecEnv) -> common.RewardFn:
@@ -62,14 +92,37 @@ def load_zero(path: str, venv: VecEnv) -> common.RewardFn:
 
 
 # TODO(adam): I think we can get rid of this and have just one RewardNet.
+
+# TODO figure out if you need to reset the input normalizationan)a)_and_update
 reward_registry.register(
     key="RewardNet_shaped",
-    value=_load_reward_net_as_fn(shaped=True),
+    value=lambda path, _: _validate_reward(_make_functional(th.load(str(path)))),
 )
 reward_registry.register(
     key="RewardNet_unshaped",
-    value=_load_reward_net_as_fn(shaped=False),
+    value=lambda path, _: _validate_reward(
+        _make_functional(_strip_wrappers(th.load(str(path)), [ShapedRewardNet])),
+    ),
 )
+
+reward_registry.register(
+    key="RewardNet_normalized",
+    value=lambda path, _: _validate_reward(
+        _make_functional(
+            th.load(str(path)),
+            attr="predict_processed",
+            kwargs={"update_stats": False},
+        ),
+    ),
+)
+
+reward_registry.register(
+    key="RewardNet_unnormalized",
+    value=lambda path, _: _validate_reward(
+        _make_functional(_strip_wrappers(th.load(str(path)), [NormalizedRewardNet])),
+    ),
+)
+
 reward_registry.register(key="zero", value=load_zero)
 
 

--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -78,7 +78,7 @@ def _make_functional(
 
 def _validate_type(net: RewardNet, type_: Type[RewardNet]):
     if not isinstance(net, type_):
-        raise TypeError("cannot load unnomralized reward as normalized")
+        raise TypeError(f"expected {type_} but found {type(net)}")
     return net
 
 

--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -45,7 +45,7 @@ def _strip_wrappers(
 ) -> RewardNet:
     """Attempts to remove provided wrappers.
 
-    wrappers until either it reaches a non-warper
+    Strips wrappers until either it reaches a non-warper
     reward net or it has removed all the listed wrappers.
 
     Args:

--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -60,8 +60,6 @@ def _strip_wrappers(
             # Reached base reward net
             break
 
-        assert hasattr(net, "base")
-
         if isinstance(net, wrapper_type):
             net = net.base
         else:
@@ -103,8 +101,11 @@ def load_zero(path: str, venv: VecEnv) -> common.RewardFn:
 
 reward_registry.register(
     key="RewardNet_shaped",
-    value=lambda path, _: _validate_reward(_make_functional(th.load(str(path)))),
+    value=lambda path, _: _validate_reward(
+        _make_functional(_validate_type(th.load(str(path)), ShapedRewardNet)),
+    ),
 )
+
 reward_registry.register(
     key="RewardNet_unshaped",
     value=lambda path, _: _validate_reward(

--- a/src/imitation/scripts/train_rl.py
+++ b/src/imitation/scripts/train_rl.py
@@ -55,8 +55,8 @@ def train_rl(
     Args:
         total_timesteps: Number of training timesteps in `model.learn()`.
         normalize_reward: Applies normalization and clipping to the reward function by
-            keeping a running average of training rewards. Note: this is not
-            recommended if using a learned reward that is already normalized.
+            keeping a running average of training rewards. Note: this is may be
+            redundant if using a learned reward that is already normalized.
         normalize_kwargs: kwargs for `VecNormalize`.
         reward_type: If provided, then load the serialized reward of this type,
             wrapping the environment in this reward. This is useful to test

--- a/src/imitation/scripts/train_rl.py
+++ b/src/imitation/scripts/train_rl.py
@@ -11,6 +11,7 @@ This can be used:
 import logging
 import os
 import os.path as osp
+import warnings
 from typing import Mapping, Optional
 
 import sacred.run
@@ -82,10 +83,6 @@ def train_rl(
 
     Returns:
         The return value of `rollout_stats()` using the final policy.
-
-    Raises:
-        ValueError: if you set normalize_reward to true and try to load a reward
-            function that is already normalized i.e. type "RewardNet_normalized".
     """
     custom_logger, log_dir = common.setup_logging()
     rollout_dir = osp.join(log_dir, "rollouts")
@@ -109,8 +106,10 @@ def train_rl(
         # observations here; use the `NormalizeFeaturesExtractor` instead.
         venv = VecNormalize(venv, norm_obs=False, **normalize_kwargs)
         if reward_type == "RewardNet_normalized":
-            raise ValueError(
-                "Applying normalization to already normalized reward function",
+            warnings.warn(
+                "Applying normalization to already normalized reward function. \
+                Consider removing the --normalize_reward flag",
+                RuntimeWarning,
             )
 
     if policy_save_interval > 0:

--- a/src/imitation/scripts/train_rl.py
+++ b/src/imitation/scripts/train_rl.py
@@ -11,6 +11,7 @@ This can be used:
 import logging
 import os
 import os.path as osp
+import warnings
 from typing import Mapping, Optional
 
 import sacred.run
@@ -53,7 +54,9 @@ def train_rl(
 
     Args:
         total_timesteps: Number of training timesteps in `model.learn()`.
-        normalize_reward: If True, then rescale and clip reward.
+        normalize_reward: Applies normalization and clipping to the reward function by
+            using keeping a running average of training rewards. Note: this is not
+            recommended if using a learned reward that is already normalized.
         normalize_kwargs: kwargs for `VecNormalize`.
         reward_type: If provided, then load the serialized reward of this type,
             wrapping the environment in this reward. This is useful to test
@@ -102,6 +105,11 @@ def train_rl(
         # so normalizing it makes training more stable. Note we do *not* normalize
         # observations here; use the `NormalizeFeaturesExtractor` instead.
         venv = VecNormalize(venv, norm_obs=False, **normalize_kwargs)
+        if reward_type == "RewardNet_normalized":
+            warnings.warn(
+                "Applying normalization to \
+            already normalized reward function",
+            )
 
     if policy_save_interval > 0:
         save_policy_callback = serialize.SavePolicyCallback(policy_dir)

--- a/src/imitation/scripts/train_rl.py
+++ b/src/imitation/scripts/train_rl.py
@@ -107,8 +107,7 @@ def train_rl(
         venv = VecNormalize(venv, norm_obs=False, **normalize_kwargs)
         if reward_type == "RewardNet_normalized":
             warnings.warn(
-                "Applying normalization to \
-            already normalized reward function",
+                "Applying normalization to already normalized reward function",
             )
 
     if policy_save_interval > 0:

--- a/src/imitation/scripts/train_rl.py
+++ b/src/imitation/scripts/train_rl.py
@@ -11,7 +11,6 @@ This can be used:
 import logging
 import os
 import os.path as osp
-import warnings
 from typing import Mapping, Optional
 
 import sacred.run
@@ -55,7 +54,7 @@ def train_rl(
     Args:
         total_timesteps: Number of training timesteps in `model.learn()`.
         normalize_reward: Applies normalization and clipping to the reward function by
-            using keeping a running average of training rewards. Note: this is not
+            keeping a running average of training rewards. Note: this is not
             recommended if using a learned reward that is already normalized.
         normalize_kwargs: kwargs for `VecNormalize`.
         reward_type: If provided, then load the serialized reward of this type,
@@ -83,6 +82,10 @@ def train_rl(
 
     Returns:
         The return value of `rollout_stats()` using the final policy.
+
+    Raises:
+        ValueError: if you set normalize_reward to true and try to load a reward function
+            that is already normalized i.e. type "RewardNet_normalized".
     """
     custom_logger, log_dir = common.setup_logging()
     rollout_dir = osp.join(log_dir, "rollouts")
@@ -106,7 +109,7 @@ def train_rl(
         # observations here; use the `NormalizeFeaturesExtractor` instead.
         venv = VecNormalize(venv, norm_obs=False, **normalize_kwargs)
         if reward_type == "RewardNet_normalized":
-            warnings.warn(
+            raise ValueError(
                 "Applying normalization to already normalized reward function",
             )
 

--- a/src/imitation/scripts/train_rl.py
+++ b/src/imitation/scripts/train_rl.py
@@ -108,7 +108,7 @@ def train_rl(
         if reward_type == "RewardNet_normalized":
             warnings.warn(
                 "Applying normalization to already normalized reward function. \
-                Consider removing the --normalize_reward flag",
+                Consider setting normalize_reward as False",
                 RuntimeWarning,
             )
 

--- a/src/imitation/scripts/train_rl.py
+++ b/src/imitation/scripts/train_rl.py
@@ -84,8 +84,8 @@ def train_rl(
         The return value of `rollout_stats()` using the final policy.
 
     Raises:
-        ValueError: if you set normalize_reward to true and try to load a reward function
-            that is already normalized i.e. type "RewardNet_normalized".
+        ValueError: if you set normalize_reward to true and try to load a reward
+            function that is already normalized i.e. type "RewardNet_normalized".
     """
     custom_logger, log_dir = common.setup_logging()
     rollout_dir = osp.join(log_dir, "rollouts")

--- a/tests/rewards/test_reward_nets.py
+++ b/tests/rewards/test_reward_nets.py
@@ -16,7 +16,7 @@ from imitation.rewards import reward_nets, serialize
 from imitation.util import networks, util
 
 ENVS = ["FrozenLake-v1", "CartPole-v1", "Pendulum-v1"]
-HARDCODED_TYPES = ["zero"]
+HARDCODED_TYPES = ["zero", "RewardNet_normalized", "RewardNet_unnormalized"]
 
 REWARD_NETS = [
     reward_nets.BasicRewardNet,
@@ -71,6 +71,16 @@ def test_reward_valid(env_name, reward_type):
 
     assert pred_reward.shape == (TRAJECTORY_LEN,)
     assert isinstance(pred_reward[0], numbers.Number)
+
+
+@pytest.mark.parametrize("env_name", ENVS)
+def test_serializing_normalization(env_name, tmpdir):
+    venv = util.make_vec_env(env_name, n_envs=1, parallel=False)
+    net = reward_nets.BasicRewardNet(venv.observation_space, venv.action_space)
+    net = reward_nets.NormalizedRewardNet(net, networks.RunningNorm(1))
+    save_path = os.path.join(tmpdir, "norm_reward.pt")
+    th.save(save_path)
+    net = serialize.load_reward("RewardNet_normalized", save_path, venv)
 
 
 @pytest.mark.parametrize("env_name", ENVS)

--- a/tests/rewards/test_reward_nets.py
+++ b/tests/rewards/test_reward_nets.py
@@ -68,7 +68,7 @@ def _potential(x):
     return th.zeros(1)
 
 
-def make_env_and_save_reward_net(env_name, reward_type, tmpdir):
+def _make_env_and_save_reward_net(env_name, reward_type, tmpdir):
     venv = util.make_vec_env(env_name, n_envs=1, parallel=False)
     net = reward_nets.BasicRewardNet(venv.observation_space, venv.action_space)
     if reward_type == "RewardNet_normalized":
@@ -85,7 +85,7 @@ def make_env_and_save_reward_net(env_name, reward_type, tmpdir):
 def test_reward_valid(env_name, reward_type, tmpdir):
     """Test output of reward function is appropriate shape and type."""
     venv = util.make_vec_env(env_name, n_envs=1, parallel=False)
-    venv, tmppath = make_env_and_save_reward_net(env_name, reward_type, tmpdir)
+    venv, tmppath = _make_env_and_save_reward_net(env_name, reward_type, tmpdir)
 
     TRAJECTORY_LEN = 10
     obs = _sample(venv.observation_space, TRAJECTORY_LEN)
@@ -134,7 +134,7 @@ def test_strip_wrappers_complex():
 
 @pytest.mark.parametrize("env_name", ENVS)
 def test_cant_load_unnorm_as_norm(env_name, tmpdir):
-    venv, tmppath = make_env_and_save_reward_net(
+    venv, tmppath = _make_env_and_save_reward_net(
         env_name,
         "RewardNet_unnomralized",
         tmpdir,

--- a/tests/rewards/test_reward_nets.py
+++ b/tests/rewards/test_reward_nets.py
@@ -63,8 +63,10 @@ def test_init_no_crash(
 def _sample(space, n):
     return np.array([space.sample() for _ in range(n)])
 
+
 def _potential(x):
     return th.zeros(1)
+
 
 def make_env_and_save_reward_net(env_name, reward_type, tmpdir):
     venv = util.make_vec_env(env_name, n_envs=1, parallel=False)

--- a/tests/rewards/test_reward_nets.py
+++ b/tests/rewards/test_reward_nets.py
@@ -34,9 +34,6 @@ REWARD_NET_KWARGS = [
 ]
 
 
-# TODO(lev) use fixtures to speed this all up
-
-
 @pytest.mark.parametrize("env_name", ENVS)
 @pytest.mark.parametrize("reward_net_cls", REWARD_NETS)
 @pytest.mark.parametrize("reward_net_kwargs", REWARD_NET_KWARGS)

--- a/tests/rewards/test_reward_nets.py
+++ b/tests/rewards/test_reward_nets.py
@@ -162,8 +162,11 @@ def test_serialize_identity(env_name, net_cls, tmpdir):
 
     transitions = rollout.generate_transitions(random, venv, n_timesteps=100)
 
-    unshaped_fn = serialize.load_reward("RewardNet_unshaped", tmppath, venv)
-    shaped_fn = serialize.load_reward("RewardNet_shaped", tmppath, venv)
+    test_rew_fn = serialize.load_reward("RewardNet_unshaped", tmppath, venv)
+    if isinstance(original, reward_nets.ShapedRewardNet):
+        train_rew_fn = serialize.load_reward("RewardNet_shaped", tmppath, venv)
+    else:
+        train_rew_fn = test_rew_fn
     rewards = {
         "train": [],
         "test": [],
@@ -187,8 +190,8 @@ def test_serialize_identity(env_name, net_cls, tmpdir):
         transitions.next_obs,
         transitions.dones,
     )
-    rewards["train"].append(shaped_fn(*args))
-    rewards["test"].append(unshaped_fn(*args))
+    rewards["train"].append(train_rew_fn(*args))
+    rewards["test"].append(test_rew_fn(*args))
 
     for key, predictions in rewards.items():
         assert len(predictions) == 3

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -376,7 +376,7 @@ def test_train_rl_double_normalization(tmpdir: str):
     th.save(net, tmppath)
 
     log_dir_data = os.path.join(tmpdir, "train_rl")
-    with pytest.raises(ValueError):
+    with pytest.warns(RuntimeWarning):
         train_rl.train_rl_ex.run(
             named_configs=["cartpole"] + ALGO_FAST_CONFIGS["rl"],
             config_updates=dict(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -369,7 +369,7 @@ def test_transfer_learning(tmpdir: str) -> None:
     _check_rollout_stats(run.result)
 
 
-def test_rl_train_warning(tmpdir: str):
+def test_rl_train_double_normalization(tmpdir: str):
     venv = util.make_vec_env("CartPole-v1", n_envs=1, parallel=False)
     net = reward_nets.BasicRewardNet(venv.observation_space, venv.action_space)
     net = reward_nets.NormalizedRewardNet(net, networks.RunningNorm)
@@ -377,7 +377,7 @@ def test_rl_train_warning(tmpdir: str):
     th.save(net, tmppath)
 
     log_dir_data = os.path.join(tmpdir, "train_rl")
-    with mock.patch("warnings.warn"):
+    with pytest.raises(ValueError):
         run = train_rl.train_rl_ex.run(
             named_configs=["cartpole"] + ALGO_FAST_CONFIGS["rl"],
             config_updates=dict(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -361,7 +361,7 @@ def test_transfer_learning(tmpdir: str) -> None:
         named_configs=["cartpole"] + ALGO_FAST_CONFIGS["rl"],
         config_updates=dict(
             common=dict(log_dir=log_dir_data),
-            reward_type="RewardNet_shaped",
+            reward_type="RewardNet_unshaped",
             reward_path=reward_path,
         ),
     )

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -13,7 +13,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import warnings
 from collections import Counter
 from typing import List, Optional
 from unittest import mock
@@ -369,7 +368,7 @@ def test_transfer_learning(tmpdir: str) -> None:
     _check_rollout_stats(run.result)
 
 
-def test_rl_train_double_normalization(tmpdir: str):
+def test_train_rl_double_normalization(tmpdir: str):
     venv = util.make_vec_env("CartPole-v1", n_envs=1, parallel=False)
     net = reward_nets.BasicRewardNet(venv.observation_space, venv.action_space)
     net = reward_nets.NormalizedRewardNet(net, networks.RunningNorm)
@@ -378,7 +377,7 @@ def test_rl_train_double_normalization(tmpdir: str):
 
     log_dir_data = os.path.join(tmpdir, "train_rl")
     with pytest.raises(ValueError):
-        run = train_rl.train_rl_ex.run(
+        train_rl.train_rl_ex.run(
             named_configs=["cartpole"] + ALGO_FAST_CONFIGS["rl"],
             config_updates=dict(
                 common=dict(log_dir=log_dir_data),
@@ -387,11 +386,6 @@ def test_rl_train_double_normalization(tmpdir: str):
                 reward_path=tmppath,
             ),
         )
-
-        warnings.warn.assert_called_with(
-            "Applying normalization to already normalized reward function",
-        )  # type: ignore
-        assert run.status == "COMPLETED"
 
 
 PARALLEL_CONFIG_UPDATES = [


### PR DESCRIPTION
Within `serialize.py`, I've broke down `_load_reward_net_as_fn` into a series of composable functions that should allow for more flexibility in loading reward functions in the future. I have maintained the public interface of `load_reward` to avoid a breaking change. Finally, I've added a new reward function type that can be de-serialized `RewarNet_normalized` and `RewardNet_unnormalized`.  The former allows the user to maintain the normalization learned during training while the latter strips off the normalization wrapper and returns the underlying unnormalized reward function. In both cases the reward function will stop updating its normalization statistics after it is de-serialized.

