### PR TITLE
Add Soft Actor Critic to imitation experiments

### DIFF
--- a/runners/launch_docker-dev.sh
+++ b/runners/launch_docker-dev.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e # Exit immediately if a command exits with a non-zero status.
+set -x # echo on
 
 __usage="launch_docker-dev.sh - Launching humancompatibleai/imitation:python-req
 
@@ -51,6 +52,7 @@ if [[ $PULL == 1 ]]; then
   echo "Pulling ${DOCKER_IMAGE} from DockerHub"
   docker pull ${DOCKER_IMAGE}
 fi
+
 
 docker run -it --rm --init \
   -v "${IMIT_LOCAL_MNT}:/imitation" \

--- a/runners/launch_docker-dev.sh
+++ b/runners/launch_docker-dev.sh
@@ -10,8 +10,8 @@ Usage: launch_docker-dev.sh [options]
 options:
   -p, --pull                pull the image to DockerHub
 
-Note: You can specify IMIT_LOCAL_MNT and IMIT_MJKEY_MNT environment variables to mount
-  local repository and MuJoCo license key respectively.
+Note: You can specify IMIT_LOCAL_MNT environment variables to mount local
+  repository and MuJoCo license key respectively.
 "
 
 PULL=0
@@ -39,11 +39,6 @@ if [[ ${IMIT_LOCAL_MNT} == "" ]]; then
   IMIT_LOCAL_MNT="${HOME}/imitation"
 fi
 
-# Pass your own mjkey.txt
-if [[ ${IMIT_MJKEY_MNT} == "" ]]; then
-  IMIT_MJKEY_MNT="${HOME}/mnt/mjkey.txt"
-fi
-
 # install imitation in developer mode
 CMD="pip install -e .[docs,parallel,test] gym[mujoco]" # copied from ci/build_and_activate_venv.sh
 
@@ -56,6 +51,5 @@ fi
 
 docker run -it --rm --init \
   -v "${IMIT_LOCAL_MNT}:/imitation" \
-  -v "${IMIT_MJKEY_MNT}:/root/.mujoco/mjkey.txt" \
   ${DOCKER_IMAGE} \
   /bin/bash -c "${CMD} && exec bash"

--- a/runners/launch_docker-dev.sh
+++ b/runners/launch_docker-dev.sh
@@ -9,7 +9,7 @@ Usage: launch_docker-dev.sh [options]
 options:
   -p, --pull                pull the image to DockerHub
 
-Note: You can specify LOCAL_MNT and MJKEY_MNT environment variables to mount
+Note: You can specify IMIT_LOCAL_MNT and IMIT_MJKEY_MNT environment variables to mount
   local repository and MuJoCo license key respectively.
 "
 
@@ -33,18 +33,18 @@ while test $# -gt 0; do
 done
 
 DOCKER_IMAGE="humancompatibleai/imitation:python-req"
-# Specify LOCAL_MNT if you want to mount a local directory to the docker container
-if [[ ${LOCAL_MNT} == "" ]]; then
-  LOCAL_MNT="${HOME}"
+# Specify IMIT_LOCAL_MNT if you want to mount a local directory to the docker container
+if [[ ${IMIT_LOCAL_MNT} == "" ]]; then
+  IMIT_LOCAL_MNT="${HOME}/imitation"
 fi
 
 # Pass your own mjkey.txt
-if [[ ${MJKEY_MNT} == "" ]]; then
-  MJKEY_MNT="${HOME}/mnt/mjkey.txt"
+if [[ ${IMIT_MJKEY_MNT} == "" ]]; then
+  IMIT_MJKEY_MNT="${HOME}/mnt/mjkey.txt"
 fi
 
 # install imitation in developer mode
-CMD="pip install -e .[docs,parallel,test] gym[mujoco]" # borrowed from ci/build_and_activate_venv.sh
+CMD="pip install -e .[docs,parallel,test] gym[mujoco]" # copied from ci/build_and_activate_venv.sh
 
 # Pull image from DockerHub if prompted
 if [[ $PULL == 1 ]]; then
@@ -53,7 +53,7 @@ if [[ $PULL == 1 ]]; then
 fi
 
 docker run -it --rm --init \
-  -v "${LOCAL_MNT}/imitation:/imitation" \
-  -v "${MJKEY_MNT}:/root/.mujoco/mjkey.txt" \
+  -v "${IMIT_LOCAL_MNT}:/imitation" \
+  -v "${IMIT_MJKEY_MNT}:/root/.mujoco/mjkey.txt" \
   ${DOCKER_IMAGE} \
   /bin/bash -c "${CMD} && exec bash"

--- a/runners/launch_docker-dev.sh
+++ b/runners/launch_docker-dev.sh
@@ -35,7 +35,7 @@ done
 DOCKER_IMAGE="humancompatibleai/imitation:python-req"
 # Specify LOCAL_MNT if you want to mount a local directory to the docker container
 if [[ ${LOCAL_MNT} == "" ]]; then
-  LOCAL_MNT="${HOME}/imitation"
+  LOCAL_MNT="${HOME}"
 fi
 
 # Pass your own mjkey.txt
@@ -53,7 +53,7 @@ if [[ $PULL == 1 ]]; then
 fi
 
 docker run -it --rm --init \
-  -v "${LOCAL_MNT}:/imitation" \
+  -v "${LOCAL_MNT}/imitation:/imitation" \
   -v "${MJKEY_MNT}:/root/.mujoco/mjkey.txt" \
   ${DOCKER_IMAGE} \
   /bin/bash -c "${CMD} && exec bash"

--- a/src/imitation/algorithms/adversarial/airl.py
+++ b/src/imitation/algorithms/adversarial/airl.py
@@ -1,7 +1,8 @@
 """Adversarial Inverse Reinforcement Learning (AIRL)."""
 
 import torch as th
-from stable_baselines3.common import base_class, vec_env
+from stable_baselines3.common import base_class, policies, vec_env
+from stable_baselines3.sac import policies as sac_policies
 
 from imitation.algorithms import base
 from imitation.algorithms.adversarial import common
@@ -54,7 +55,13 @@ class AIRL(common.AdversarialTrainer):
             reward_net=reward_net,
             **kwargs,
         )
-        if not hasattr(self.gen_algo.policy, "evaluate_actions"):
+        # AIRL needs a stochastic policy to compute the discriminator output.
+        # sac_policies.SACPolicy and policies.ActorCriticPolicy both have an actor
+        # to generate stochastic actions.
+        if not isinstance(
+            self.gen_algo.policy,
+            (sac_policies.SACPolicy, policies.ActorCriticPolicy),
+        ):
             raise TypeError(
                 "AIRL needs a stochastic policy to compute the discriminator output.",
             )

--- a/src/imitation/algorithms/adversarial/airl.py
+++ b/src/imitation/algorithms/adversarial/airl.py
@@ -8,6 +8,8 @@ from imitation.algorithms import base
 from imitation.algorithms.adversarial import common
 from imitation.rewards import reward_nets
 
+STOCHASTIC_POLICIES = (sac_policies.SACPolicy, policies.ActorCriticPolicy)
+
 
 class AIRL(common.AdversarialTrainer):
     """Adversarial Inverse Reinforcement Learning (`AIRL`_).
@@ -55,13 +57,8 @@ class AIRL(common.AdversarialTrainer):
             reward_net=reward_net,
             **kwargs,
         )
-        # AIRL needs a stochastic policy to compute the discriminator output.
-        # sac_policies.SACPolicy and policies.ActorCriticPolicy both have an actor
-        # to generate stochastic actions.
-        if not isinstance(
-            self.gen_algo.policy,
-            (sac_policies.SACPolicy, policies.ActorCriticPolicy),
-        ):
+        # AIRL needs a policy from STOCHASTIC_POLICIES to compute discriminator output.
+        if not isinstance(self.gen_algo.policy, STOCHASTIC_POLICIES):
             raise TypeError(
                 "AIRL needs a stochastic policy to compute the discriminator output.",
             )

--- a/src/imitation/algorithms/adversarial/common.py
+++ b/src/imitation/algorithms/adversarial/common.py
@@ -438,13 +438,13 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
         """Evaluates the given actions on the given observations.
 
         Args:
-            obs: A batch of observations.
-            actions: A batch of actions.
+            obs_th: A batch of observations.
+            acts_th: A batch of actions.
 
         Returns:
             A batch of log policy action probabilities.
         """
-        log_policy_act_prob = None
+        log_policy_act_prob, log_policy_act_prob_th = None, None
         if isinstance(self.gen_algo.policy, policies.ActorCriticPolicy):
             # policies.ActorCriticPolicy has a concrete implementation of
             # evaluate_actions to generate log_policy_act_prob given obs and actions.
@@ -547,8 +547,9 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
             obs_th = th.as_tensor(obs, device=self.gen_algo.device)
             acts_th = th.as_tensor(acts, device=self.gen_algo.device)
             log_policy_act_prob = self._get_log_policy_act_prob(obs_th, acts_th)
-            assert len(log_policy_act_prob) == n_samples
-            log_policy_act_prob = log_policy_act_prob.reshape((n_samples,))
+            if log_policy_act_prob is not None:
+                assert len(log_policy_act_prob) == n_samples
+                log_policy_act_prob = log_policy_act_prob.reshape((n_samples,))
             del obs_th, acts_th  # unneeded
 
         obs_th, acts_th, next_obs_th, dones_th = self.reward_train.preprocess(

--- a/src/imitation/algorithms/adversarial/common.py
+++ b/src/imitation/algorithms/adversarial/common.py
@@ -459,12 +459,13 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
             )
             # SAC applies a squashing function to bound the actions to a finite range
             # `acts_th` need to be scaled accordingly before computing log prob.
+            # Scale actions only if the policy squashes outputs.
+            assert self.policy.squash_output
             scaled_acts_th = self.policy.scale_action(acts_th)
             log_policy_act_prob_th = distribution.log_prob(scaled_acts_th)
         else:
             return None
-        log_policy_act_prob = log_policy_act_prob_th.detach().cpu().numpy()
-        return log_policy_act_prob
+        return log_policy_act_prob_th.detach().cpu().numpy()
 
     def _make_disc_train_batch(
         self,

--- a/src/imitation/policies/base.py
+++ b/src/imitation/policies/base.py
@@ -64,7 +64,7 @@ class FeedForward32Policy(policies.ActorCriticPolicy):
 
     Note: This differs from stable_baselines3 ActorCriticPolicy in two ways: by
     having 32 rather than 64 units, and by having policy and value networks
-    share weights.
+    share weights except at the final layer, where there are different linear heads.
     """
 
     def __init__(self, *args, **kwargs):

--- a/src/imitation/policies/base.py
+++ b/src/imitation/policies/base.py
@@ -7,6 +7,7 @@ import gym
 import numpy as np
 import torch as th
 from stable_baselines3.common import policies, torch_layers
+from stable_baselines3.sac import policies as sac_policies
 from torch import nn
 
 from imitation.util import networks
@@ -63,12 +64,28 @@ class FeedForward32Policy(policies.ActorCriticPolicy):
 
     Note: This differs from stable_baselines3 ActorCriticPolicy in two ways: by
     having 32 rather than 64 units, and by having policy and value networks
-    share weights except at the final layer.
+    share weights.
     """
 
     def __init__(self, *args, **kwargs):
         """Builds FeedForward32Policy; arguments passed to `ActorCriticPolicy`."""
         super().__init__(*args, **kwargs, net_arch=[32, 32])
+
+
+class SAC1024Policy(sac_policies.SACPolicy):
+    """Actor and value networks with two hidden layers of 1024 units respectively.
+
+    This matches the implementation of SAC policies in the PEBBLE paper. See:
+    https://arxiv.org/pdf/2106.05091.pdf
+    https://github.com/denisyarats/pytorch_sac/blob/master/config/agent/sac.yaml
+
+    Note: This differs from stable_baselines3 SACPolicy by having 1024 hidden units
+    in each layer instead of the default value of 256.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Builds SAC1024Policy; arguments passed to `SACPolicy`."""
+        super().__init__(*args, **kwargs, net_arch=[1024, 1024])
 
 
 class NormalizeFeaturesExtractor(torch_layers.FlattenExtractor):

--- a/src/imitation/policies/serialize.py
+++ b/src/imitation/policies/serialize.py
@@ -99,6 +99,7 @@ def _add_stable_baselines_policies(classes):
 
 STABLE_BASELINES_CLASSES = {
     "ppo": "stable_baselines3:PPO",
+    "sac": "stable_baselines3:SAC",
 }
 _add_stable_baselines_policies(STABLE_BASELINES_CLASSES)
 

--- a/src/imitation/scripts/common/rl.py
+++ b/src/imitation/scripts/common/rl.py
@@ -68,7 +68,7 @@ def sac():
     rl_cls = stable_baselines3.SAC
     # Default HPs are as follows:
     batch_size = 256  # batch size for RL algorithm
-    rl_kwargs = dict(batch_size=None) # make sure to set batch size to None
+    rl_kwargs = dict(batch_size=None)  # make sure to set batch size to None
     locals()  # quieten flake8
 
 

--- a/src/imitation/scripts/common/rl.py
+++ b/src/imitation/scripts/common/rl.py
@@ -54,14 +54,6 @@ def fast():
 
 
 @rl_ingredient.named_config
-def ppo():
-    # For recommended PPO hyperparams in each environment, see:
-    # https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/ppo.yml
-    rl_cls = sb3.PPO
-    locals()  # quieten flake8
-
-
-@rl_ingredient.named_config
 def sac():
     # For recommended SAC hyperparams in each environment, see:
     # https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml

--- a/src/imitation/scripts/common/rl.py
+++ b/src/imitation/scripts/common/rl.py
@@ -61,8 +61,11 @@ def ppo():
     locals()  # quieten flake8
 
 
+# TODO(yawen): The current implementation of Soft Actor Critic in SB3 only supports
+# contionuous action spaces. Consider adding a discrete version as mentioned here:
+# https://github.com/DLR-RM/stable-baselines3/issues/505
 @rl_ingredient.named_config
-def sac():
+def sac():   
     # For recommended SAC hyperparams in each environment, see:
     # https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml
     rl_cls = stable_baselines3.SAC

--- a/src/imitation/scripts/common/rl.py
+++ b/src/imitation/scripts/common/rl.py
@@ -114,7 +114,8 @@ def make_rl_algo(
         ), "set 'n_steps' at top-level using 'batch_size'"
         rl_kwargs["n_steps"] = batch_size // venv.num_envs
     elif issubclass(rl_cls, off_policy_algorithm.OffPolicyAlgorithm):
-        assert "batch_size" not in rl_kwargs, "set 'batch_size' at top-level"
+        if "batch_size" not in rl_kwargs or rl_kwargs["batch_size"] is not None:
+            raise ValueError("set 'batch_size' at top-level")
         rl_kwargs["batch_size"] = batch_size
     else:
         raise TypeError(f"Unsupported RL algorithm '{rl_cls}'")

--- a/src/imitation/scripts/common/rl.py
+++ b/src/imitation/scripts/common/rl.py
@@ -42,6 +42,20 @@ def fast():
     locals()  # quieten flake8
 
 
+@rl_ingredient.named_config
+def sac():
+    rl_cls = stable_baselines3.SAC
+    # Default HPs are as follows:
+    batch_size = 256  # batch size for RL algorithm
+    rl_kwargs = dict(
+        learning_rate=3e-4,
+        learning_starts=100,
+        # For recommended SAC hyperparams in each environment, see:
+        # https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml
+        
+    )
+
+
 @rl_ingredient.capture
 def make_rl_algo(
     venv: vec_env.VecEnv,

--- a/src/imitation/scripts/common/rl.py
+++ b/src/imitation/scripts/common/rl.py
@@ -65,7 +65,7 @@ def ppo():
 # contionuous action spaces. Consider adding a discrete version as mentioned here:
 # https://github.com/DLR-RM/stable-baselines3/issues/505
 @rl_ingredient.named_config
-def sac():   
+def sac():
     # For recommended SAC hyperparams in each environment, see:
     # https://github.com/DLR-RM/rl-baselines3-zoo/blob/master/hyperparams/sac.yml
     rl_cls = stable_baselines3.SAC

--- a/src/imitation/scripts/common/rl.py
+++ b/src/imitation/scripts/common/rl.py
@@ -68,7 +68,7 @@ def sac():
     rl_cls = stable_baselines3.SAC
     # Default HPs are as follows:
     batch_size = 256  # batch size for RL algorithm
-    rl_kwargs = dict()
+    rl_kwargs = dict(batch_size=None) # make sure to set batch size to None
     locals()  # quieten flake8
 
 
@@ -124,7 +124,7 @@ def make_rl_algo(
         # for possible changing configs in a captured function. For off-policy
         # algorithms in SB3, policy_kwargs["use_sde"] could be changed in
         # rl_cls.__init__() for certain algorithms, such as Soft Actor Critic.
-        # https://github.com/DLR-RM/stable-baselines3/blob/master/stable_baselines3/common/off_policy_algorithm.py#L142
+        # https://github.com/DLR-RM/stable-baselines3/blob/30772aa9f53a4cf61571ee90046cdc454c1b11d7/stable_baselines3/common/off_policy_algorithm.py#L145
         policy_kwargs=dict(train["policy_kwargs"]),
         env=venv,
         seed=_seed,

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -29,15 +29,12 @@ def config():
 
 @train_ingredient.named_config
 def fast():
-    n_episodes_eval = 1
-    locals()  # quieten flake8
+    n_episodes_eval = 1  # noqa: F841
 
 
 @train_ingredient.named_config
 def sac():
-    policy_cls = SACPolicy
-
-    locals()  # quieten flake8
+    policy_cls = SACPolicy  # noqa: F841
 
 
 @train_ingredient.named_config

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -35,10 +35,8 @@ def fast():
 
 @train_ingredient.named_config
 def sac():
-    # Training
     policy_cls = SACPolicy
-    policy_kwargs = {}
-    
+
     locals()  # quieten flake8
 
 

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -5,7 +5,6 @@ from typing import Any, Mapping, Union
 
 import sacred
 from stable_baselines3.common import base_class, policies, torch_layers, vec_env
-from stable_baselines3.sac.policies import SACPolicy
 
 import imitation.util.networks
 from imitation.data import rollout
@@ -34,7 +33,7 @@ def fast():
 
 @train_ingredient.named_config
 def sac():
-    policy_cls = SACPolicy  # noqa: F841
+    policy_cls = base.SAC1024Policy  # noqa: F841
 
 
 @train_ingredient.named_config

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -5,6 +5,7 @@ from typing import Any, Mapping, Union
 
 import sacred
 from stable_baselines3.common import base_class, policies, torch_layers, vec_env
+from stable_baselines3.sac.policies import SACPolicy
 
 import imitation.util.networks
 from imitation.data import rollout
@@ -29,6 +30,15 @@ def config():
 @train_ingredient.named_config
 def fast():
     n_episodes_eval = 1
+    locals()  # quieten flake8
+
+
+@train_ingredient.named_config
+def sac():
+    # Training
+    policy_cls = SACPolicy
+    policy_kwargs = {}
+    
     locals()  # quieten flake8
 
 

--- a/src/imitation/scripts/config/train_rl.py
+++ b/src/imitation/scripts/config/train_rl.py
@@ -71,11 +71,6 @@ def half_cheetah():
 
 
 @train_rl_ex.named_config
-def seals_half_cheetah():
-    common = dict(env_name="seals/HalfCheetah-v0")
-
-
-@train_rl_ex.named_config
 def seals_hopper():
     common = dict(env_name="seals/Hopper-v0")
 

--- a/src/imitation/scripts/config/train_rl.py
+++ b/src/imitation/scripts/config/train_rl.py
@@ -135,6 +135,6 @@ def seals_walker():
 
 @train_rl_ex.named_config
 def fast():
-    """Intended for testing purposes: small # of updates, ends quickly."""
+    # Intended for testing purposes: small # of updates, ends quickly.
     total_timesteps = int(4)
     policy_save_interval = 2

--- a/src/imitation/scripts/config/train_rl.py
+++ b/src/imitation/scripts/config/train_rl.py
@@ -66,7 +66,7 @@ def seals_cartpole():
 
 @train_rl_ex.named_config
 def half_cheetah():
-    common = dict(env_name="HalfCheetah-v2")
+    common = dict(env_name="HalfCheetah-v3")
     total_timesteps = int(5e6)  # does OK after 1e6, but continues improving
 
 

--- a/src/imitation/scripts/config/train_rl.py
+++ b/src/imitation/scripts/config/train_rl.py
@@ -71,6 +71,11 @@ def half_cheetah():
 
 
 @train_rl_ex.named_config
+def seals_half_cheetah():
+    common = dict(env_name="seals/HalfCheetah-v0")
+
+
+@train_rl_ex.named_config
 def seals_hopper():
     common = dict(env_name="seals/Hopper-v0")
 

--- a/tests/policies/test_policies.py
+++ b/tests/policies/test_policies.py
@@ -35,17 +35,17 @@ def test_actions_valid(env_name, policy_type):
 
 
 @pytest.mark.parametrize(
-    "policy_env_pair",
+    "policy_env_name_pair",
     [
         ("ppo", SIMPLE_DISCRETE_ENV),
         ("sac", SIMPLE_CONTINUOUS_ENV),
     ],
 )
-def test_save_stable_model_errors_and_warnings(tmpdir, policy_env_pair):
+def test_save_stable_model_errors_and_warnings(tmpdir, policy_env_name_pair):
     """Check errors and warnings in `save_stable_model()`."""
-    policy, env = policy_env_pair
+    policy, env_name = policy_env_name_pair
     tmpdir = pathlib.Path(tmpdir)
-    venv = util.make_vec_env(env)
+    venv = util.make_vec_env(env_name)
 
     # Trigger FileNotFoundError for no model.{zip,pkl}
     dir_a = tmpdir / "a"

--- a/tests/policies/test_policies.py
+++ b/tests/policies/test_policies.py
@@ -14,12 +14,10 @@ from imitation.data import rollout
 from imitation.policies import base, serialize
 from imitation.util import registry, util
 
-SIMPLE_ENVS = [
-    "CartPole-v0",  # Discrete(2) action space
-    "MountainCarContinuous-v0",  # Box(1) action space
-]
+SIMPLE_DISCRETE_ENV = "CartPole-v0"  # Discrete(2) action space
+SIMPLE_CONTINUOUS_ENV = "MountainCarContinuous-v0"  # Box(1) action space
+SIMPLE_ENVS = [SIMPLE_DISCRETE_ENV, SIMPLE_CONTINUOUS_ENV]
 HARDCODED_TYPES = ["random", "zero"]
-
 
 assert_equal = functools.partial(th.testing.assert_close, rtol=0, atol=0)
 
@@ -36,31 +34,37 @@ def test_actions_valid(env_name, policy_type):
         assert venv.action_space.contains(a)
 
 
-def test_save_stable_model_errors_and_warnings(tmpdir):
+@pytest.mark.parametrize(
+    "policy_env_pair",
+    [
+        ("ppo", SIMPLE_DISCRETE_ENV),
+        ("sac", SIMPLE_CONTINUOUS_ENV),
+    ],
+)
+def test_save_stable_model_errors_and_warnings(tmpdir, policy_env_pair):
     """Check errors and warnings in `save_stable_model()`."""
+    policy, env = policy_env_pair
     tmpdir = pathlib.Path(tmpdir)
-    venv = util.make_vec_env("CartPole-v0")
+    venv = util.make_vec_env(env)
 
     # Trigger FileNotFoundError for no model.{zip,pkl}
     dir_a = tmpdir / "a"
     dir_a.mkdir()
     with pytest.raises(FileNotFoundError, match=".*No such file or.*model.zip.*"):
-        serialize.load_policy("ppo", str(dir_a), venv)
+        serialize.load_policy(policy, str(dir_a), venv)
 
     vec_normalize = dir_a / "vec_normalize.pkl"
     vec_normalize.touch()
     with pytest.raises(FileExistsError, match="Outdated policy format.*"):
-        serialize.load_policy("ppo", str(dir_a), venv)
+        serialize.load_policy(policy, str(dir_a), venv)
 
     # Trigger FileNotError for nonexistent directory
     dir_nonexistent = tmpdir / "i_dont_exist"
     with pytest.raises(FileNotFoundError, match=".*needs to be a directory.*"):
-        serialize.load_policy("ppo", str(dir_nonexistent), venv)
+        serialize.load_policy(policy, str(dir_nonexistent), venv)
 
 
-@pytest.mark.parametrize("env_name", SIMPLE_ENVS)
-@pytest.mark.parametrize("model_cfg", serialize.STABLE_BASELINES_CLASSES.items())
-def test_serialize_identity(env_name, model_cfg, tmpdir):
+def _test_serialize_identity(env_name, model_cfg, tmpdir):
     """Test output actions of deserialized policy are same as original."""
     venv = util.make_vec_env(env_name, n_envs=1, parallel=False)
 
@@ -93,6 +97,26 @@ def test_serialize_identity(env_name, model_cfg, tmpdir):
     )
 
     assert np.allclose(orig_rollout.acts, new_rollout.acts)
+
+
+SB_CONFIGS = serialize.STABLE_BASELINES_CLASSES.items()
+CONTINUOUS_ONLY = ["sac"]
+NORMAL_CONFIGS = [cfg for cfg in SB_CONFIGS if cfg[0] not in CONTINUOUS_ONLY]
+CONTINUOUS_ONLY_CONFIGS = [cfg for cfg in SB_CONFIGS if cfg[0] in CONTINUOUS_ONLY]
+
+
+@pytest.mark.parametrize("env_name", SIMPLE_ENVS)
+@pytest.mark.parametrize("model_cfg", NORMAL_CONFIGS)
+def test_serialize_identity(env_name, model_cfg, tmpdir):
+    """Test output actions of deserialized policy are same as original."""
+    _test_serialize_identity(env_name, model_cfg, tmpdir)
+
+
+@pytest.mark.parametrize("env_name", [SIMPLE_CONTINUOUS_ENV])
+@pytest.mark.parametrize("model_cfg", CONTINUOUS_ONLY_CONFIGS)
+def test_serialize_identity_continuous_only(env_name, model_cfg, tmpdir):
+    """Test serialize identity for continuous_only algorithms."""
+    _test_serialize_identity(env_name, model_cfg, tmpdir)
 
 
 class ZeroModule(nn.Module):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -222,7 +222,7 @@ def test_train_dagger_main(tmpdir):
 
 def test_train_dagger_error_and_exceptions(tmpdir):
     with pytest.raises(Exception, match=".*expert_policy_path cannot be None.*"):
-        run = train_imitation.train_imitation_ex.run(
+        train_imitation.train_imitation_ex.run(
             command_name="dagger",
             named_configs=["cartpole"] + ALGO_FAST_CONFIGS["imitation"],
             config_updates=dict(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -309,21 +309,18 @@ def _check_train_ex_result(result: dict):
         ["train.normalize_disable", "reward.normalize_input_disable"],
     ),
 )
-def test_train_adversarial(tmpdir, named_configs):
+@pytest.mark.parametrize("command", ("airl", "gail"))
+def test_train_adversarial(tmpdir, named_configs, command):
     """Smoke test for imitation.scripts.train_adversarial."""
     named_configs = named_configs + ["cartpole"] + ALGO_FAST_CONFIGS["adversarial"]
     config_updates = {
-        "common": {
-            "log_root": tmpdir,
-        },
-        "demonstrations": {
-            "rollout_path": CARTPOLE_TEST_ROLLOUT_PATH,
-        },
+        "common": dict(log_root=tmpdir),
+        "demonstrations": dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
         # TensorBoard logs to get extra coverage
-        "algorithm_kwargs": {"init_tensorboard": True},
+        "algorithm_kwargs": dict(init_tensorboard=True),
     }
     run = train_adversarial.train_adversarial_ex.run(
-        command_name="gail",
+        command_name=command,
         named_configs=named_configs,
         config_updates=config_updates,
     )
@@ -331,25 +328,20 @@ def test_train_adversarial(tmpdir, named_configs):
     _check_train_ex_result(run.result)
 
 
-def test_train_adversarial_sac(tmpdir):
+@pytest.mark.parametrize("command", ("airl", "gail"))
+def test_train_adversarial_sac(tmpdir, command):
     """Smoke test for imitation.scripts.train_adversarial."""
-    # make sure rl.sac named_config is called after rl.fast to overwrite
+    # Make sure rl.sac named_config is called after rl.fast to overwrite
     # rl_kwargs.batch_size to None
     named_configs = (
         ["pendulum"] + ALGO_FAST_CONFIGS["adversarial"] + RL_SAC_NAMED_CONFIGS
     )
     config_updates = {
-        "common": {
-            "log_root": tmpdir,
-        },
-        "demonstrations": {
-            "rollout_path": PENDULUM_TEST_ROLLOUT_PATH,
-        },
-        # TensorBoard logs to get extra coverage
-        "algorithm_kwargs": {"init_tensorboard": True},
+        "common": dict(log_root=tmpdir),
+        "demonstrations": dict(rollout_path=PENDULUM_TEST_ROLLOUT_PATH),
     }
     run = train_adversarial.train_adversarial_ex.run(
-        command_name="gail",
+        command_name=command,
         named_configs=named_configs,
         config_updates=config_updates,
     )
@@ -363,12 +355,8 @@ def test_train_adversarial_algorithm_value_error(tmpdir):
     base_named_configs = ["cartpole"] + ALGO_FAST_CONFIGS["adversarial"]
     base_config_updates = collections.ChainMap(
         {
-            "common": {
-                "log_root": tmpdir,
-            },
-            "demonstrations": {
-                "rollout_path": CARTPOLE_TEST_ROLLOUT_PATH,
-            },
+            "common": dict(log_root=tmpdir),
+            "demonstrations": dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
         },
     )
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -143,6 +143,16 @@ def test_train_preference_comparisons_sac(tmpdir):
     assert run.status == "COMPLETED"
     assert isinstance(run.result, dict)
 
+    with pytest.raises(Exception, match=".*set 'batch_size' at top-level.*"):
+        train_preference_comparisons.train_preference_comparisons_ex.run(
+            # make sure rl.sac named_config is called after rl.fast to overwrite
+            # rl_kwargs.batch_size to None
+            named_configs=["pendulum"]
+            + RL_SAC_NAMED_CONFIGS
+            + ALGO_FAST_CONFIGS["preference_comparison"],
+            config_updates=config_updates,
+        )
+
 
 @pytest.mark.parametrize(
     "named_configs",

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -220,6 +220,22 @@ def test_train_dagger_main(tmpdir):
     assert isinstance(run.result, dict)
 
 
+def test_train_dagger_error_and_exceptions(tmpdir):
+    with pytest.raises(Exception, match=".*expert_policy_path cannot be None.*"):
+        run = train_imitation.train_imitation_ex.run(
+            command_name="dagger",
+            named_configs=["cartpole"] + ALGO_FAST_CONFIGS["imitation"],
+            config_updates=dict(
+                common=dict(log_root=tmpdir),
+                demonstrations=dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+                dagger=dict(
+                    expert_policy_type="ppo",
+                    expert_policy_path=None,
+                ),
+            ),
+        )
+
+
 def test_train_bc_main(tmpdir):
     run = train_imitation.train_imitation_ex.run(
         command_name="bc",

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -17,12 +17,12 @@ from collections import Counter
 from typing import List, Optional
 from unittest import mock
 
-import stable_baselines3
 import pandas as pd
 import pytest
 import ray.tune as tune
 import sacred
 import sacred.utils
+import stable_baselines3
 
 from imitation.scripts import (
     analyze,
@@ -139,7 +139,7 @@ def test_train_preference_comparisons_sac(tmpdir):
         + RL_SAC_NAMED_CONFIGS,
         config_updates=config_updates,
     )
-    assert run.config["rl"]["rl_cls"] is stable_baselines3.sac.sac.SAC
+    assert run.config["rl"]["rl_cls"] is stable_baselines3.SAC
     assert run.status == "COMPLETED"
     assert isinstance(run.result, dict)
 
@@ -242,7 +242,7 @@ def test_train_rl_sac(tmpdir):
             common=dict(log_root=tmpdir),
         ),
     )
-    assert run.config["rl"]["rl_cls"] is stable_baselines3.sac.sac.SAC
+    assert run.config["rl"]["rl_cls"] is stable_baselines3.SAC
     assert run.status == "COMPLETED"
     assert isinstance(run.result, dict)
 
@@ -343,7 +343,7 @@ def test_train_adversarial_sac(tmpdir):
         named_configs=named_configs,
         config_updates=config_updates,
     )
-    assert run.config["rl"]["rl_cls"] is stable_baselines3.sac.sac.SAC
+    assert run.config["rl"]["rl_cls"] is stable_baselines3.SAC
     assert run.status == "COMPLETED"
     _check_train_ex_result(run.result)
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -337,6 +337,7 @@ def _check_train_ex_result(result: dict):
     "named_configs",
     (
         [],
+        ["train.normalize_running", "reward.normalize_input_running"],
         ["train.normalize_disable", "reward.normalize_input_disable"],
     ),
 )

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -129,6 +129,21 @@ def test_train_preference_comparisons_main(tmpdir, config):
     assert isinstance(run.result, dict)
 
 
+@pytest.mark.parametrize(
+    "env_name",
+    ["seals_cartpole", "mountain_car", "seals_mountain_car"],
+)
+def test_train_preference_comparisons_envs_no_crash(tmpdir, env_name):
+    """Test envs specified in imitation.scripts.config.train_preference_comparisons."""
+    config_updates = dict(common=dict(log_root=tmpdir))
+    run = train_preference_comparisons.train_preference_comparisons_ex.run(
+        named_configs=[env_name] + ALGO_FAST_CONFIGS["preference_comparison"],
+        config_updates=config_updates,
+    )
+    assert run.status == "COMPLETED"
+    assert isinstance(run.result, dict)
+
+
 def test_train_preference_comparisons_sac(tmpdir):
     config_updates = dict(common=dict(log_root=tmpdir))
     run = train_preference_comparisons.train_preference_comparisons_ex.run(


### PR DESCRIPTION
This PR aims to 
- Add the option of choosing SAC as RL algorithm in the `imitation.scripts.common.rl` and `imitation.scripts.common.train` ingredient.
- Construct test cases for SAC runs
- Some minor changes (e.g. comments instead of docstring in sacred configs; upgrade HalfCheetah-v2 to HalfCheetah-v3; modify paths in launch_docker-dev.sh)

Add SAC support for #447