### PR TITLE
Change dependencies for Python 3.10 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ TESTS_REQUIRE = [
     "pytest-notebook",
     "pytest-xdist",
     "pytype",
-    "ray[debug,tune]~=0.8.5",
+    "ray[debug,tune]>=0.8.5",
     "scipy>=1.8.0",
     "wandb",
 ]
@@ -76,7 +76,8 @@ setup(
             "@gym_fixes#egg=stable-baselines3"
         ),
         "stable-baselines3>=1.4.0",
-        "sacred~=0.8.1",
+        # TODO(nora) switch back to PyPi once following makes it to release:
+        "sacred@git+https://github.com/IDSIA/sacred.git",
         "tensorboard>=1.14",
     ],
     tests_require=TESTS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import find_packages, setup
 
 import src.imitation  # pytype: disable=import-error
 
+PARALLEL_REQUIRE = ["ray[debug,tune]>=1.13.0"]
 TESTS_REQUIRE = [
     "seals",
     "black",
@@ -29,17 +30,15 @@ TESTS_REQUIRE = [
     "pytest-notebook",
     "pytest-xdist",
     "pytype",
-    "ray[debug,tune]>=1.13.0",
     "scipy>=1.8.0",
     "wandb",
-]
+] + PARALLEL_REQUIRE
 DOCS_REQUIRE = [
     "sphinx",
     "sphinx-autodoc-typehints",
     "sphinx-rtd-theme",
     "sphinxcontrib-napoleon",
 ]
-PARALLEL_REQUIRE = ["ray[debug,tune]>=1.13.0"]
 
 
 def get_readme() -> str:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ TESTS_REQUIRE = [
     "pytest-notebook",
     "pytest-xdist",
     "pytype",
-    "ray[debug,tune]>=0.8.5",
+    "ray[debug,tune]>=1.13.0",
     "scipy>=1.8.0",
     "wandb",
 ]
@@ -39,7 +39,7 @@ DOCS_REQUIRE = [
     "sphinx-rtd-theme",
     "sphinxcontrib-napoleon",
 ]
-PARALLEL_REQUIRE = ["ray[debug,tune]~=0.8.5"]
+PARALLEL_REQUIRE = ["ray[debug,tune]>=1.13.0"]
 
 
 def get_readme() -> str:
@@ -77,7 +77,7 @@ setup(
         ),
         "stable-baselines3>=1.4.0",
         # TODO(nora) switch back to PyPi once 0.8.3 makes it to release:
-        "sacred@git+https://github.com/IDSIA/sacred.git",
+        "sacred@git+https://github.com/IDSIA/sacred.git@0.8.3",
         "tensorboard>=1.14",
     ],
     tests_require=TESTS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
             "@gym_fixes#egg=stable-baselines3"
         ),
         "stable-baselines3>=1.4.0",
-        # TODO(nora) switch back to PyPi once following makes it to release:
+        # TODO(nora) switch back to PyPi once 0.8.3 makes it to release:
         "sacred@git+https://github.com/IDSIA/sacred.git",
         "tensorboard>=1.14",
     ],

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -115,7 +115,7 @@ def parallel(
     # dashboard.
     ray_loggers = ()
 
-    ray.init(**init_kwargs, local_mode=True)
+    ray.init(**init_kwargs)
     try:
         ray.tune.run(
             trainable,
@@ -124,7 +124,6 @@ def parallel(
             local_dir=local_dir,
             loggers=ray_loggers,
             resources_per_trial=resources_per_trial,
-            max_concurrent_trials=1,
             sync_config=ray.tune.syncer.SyncConfig(upload_dir=upload_dir),
         )
     finally:

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -122,9 +122,9 @@ def parallel(
             config=search_space,
             name=run_name,
             local_dir=local_dir,
-            upload_dir=upload_dir,
             loggers=ray_loggers,
             resources_per_trial=resources_per_trial,
+            sync_config=ray.tune.syncer.SyncConfig(upload_dir=upload_dir),
         )
     finally:
         ray.shutdown()

--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -2,7 +2,6 @@
 
 import collections.abc
 import copy
-from multiprocessing.sharedctypes import Value
 import os
 from typing import Any, Callable, Mapping, Optional, Sequence
 
@@ -217,7 +216,7 @@ def _ray_tune_sacred_wrapper(
         for k, v in run_kwargs.items():
             if k not in updated_run_kwargs:
                 updated_run_kwargs[k] = v
-        
+
         run = ex.run(**updated_run_kwargs, options={"--run": run_name})
 
         # Ray Tune has a string formatting error if raylet completes without


### PR DESCRIPTION
Currently, `imitation` does not work properly on Python 3.10 due to its reliance on the PyPI version of Sacred (0.8.2). In particular, if you try to run `python -m imitation.scripts.train_rl`, you'll get errors like this:
```
Exception originated from within Sacred.
Traceback (most recent calls):
  File "/opt/homebrew/Caskroom/miniforge/base/lib/python3.10/site-packages/sacred/utils.py", line 345, in recursive_update
    if isinstance(v, collections.Mapping):
AttributeError: module 'collections' has no attribute 'Mapping'
```
The `Mapping` type was removed from the `collections` library in Python 3.10. The GitHub version of Sacred was actually updated for Python 3.10 back in March (it's now on 0.8.3), but unfortunately the maintainer in charge of pushing new releases to PyPI seems to be MIA (see https://github.com/IDSIA/sacred/issues/857), so it's not clear when the PyPI package will be updated. This PR fixes the issue by simply changing the Sacred dependency in `setup.py` to the GitHub version.

I also noticed that the tests currently require an out-of-date version of Ray Tune (~=0.8.5), but Ray just added support for Python 3.10 in its most recent release a few days ago ([1.13.0](https://github.com/ray-project/ray/releases/tag/ray-1.13.0)). So I changed that dependency from `~=0.8.5` to `>=0.8.5` to allow for downloading the most recent version for testing.