### PR TITLE
Expose name_to_{value,count,excluded} maps in HierarchicalLogger

### DIFF
--- a/ci/build_and_activate_venv.sh
+++ b/ci/build_and_activate_venv.sh
@@ -8,7 +8,7 @@ if [[ ${venv} == "" ]]; then
 fi
 
 virtualenv -p python3.8 ${venv}
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source ${venv}/bin/activate
 python -m pip install --upgrade pip
 pip install ".[docs,parallel,test,mujoco]"

--- a/src/imitation/util/logger.py
+++ b/src/imitation/util/logger.py
@@ -66,6 +66,11 @@ class HierarchicalLogger(sb_logger.Logger):
         self.format_strs = format_strs
         super().__init__(folder=self.default_logger.dir, output_formats=[])
 
+    def _update_name_to_maps(self) -> None:
+        self.name_to_value = self._logger.name_to_value
+        self.name_to_count = self._logger.name_to_count
+        self.name_to_excluded = self._logger.name_to_excluded
+
     @contextlib.contextmanager
     def accumulate_means(self, subdir: types.AnyPath) -> Generator[None, None, None]:
         """Temporarily modifies this HierarchicalLogger to accumulate means values.
@@ -116,10 +121,12 @@ class HierarchicalLogger(sb_logger.Logger):
         try:
             self.current_logger = logger
             self._subdir = subdir
+            self._update_name_to_maps()
             yield
         finally:
             self.current_logger = None
             self._subdir = None
+            self._update_name_to_maps()
 
     def record(self, key, val, exclude=None):
         if self.current_logger is not None:  # In accumulate_means context.

--- a/tests/algorithms/test_preference_comparisons.py
+++ b/tests/algorithms/test_preference_comparisons.py
@@ -165,7 +165,11 @@ def test_trainer_no_crash(agent_trainer, reward_net, fragmenter, custom_logger):
         fragmenter=fragmenter,
         custom_logger=custom_logger,
     )
-    main_trainer.train(10, 3)
+    result = main_trainer.train(10, 3)
+    # We don't expect good performance after training for 10 (!) timesteps,
+    # but check stats are within the bounds they should lie in.
+    assert result["reward_loss"] > 0.0
+    assert 0.0 < result["reward_accuracy"] < 1.0
 
 
 def test_discount_rate_no_crash(agent_trainer, reward_net, fragmenter, custom_logger):

--- a/tests/util/test_logger.py
+++ b/tests/util/test_logger.py
@@ -97,6 +97,35 @@ def test_close(tmpdir):
         hier_logger.dump()
 
 
+def test_name_to_value(tmpdir):
+    hier_logger = logger.configure(tmpdir)
+
+    with hier_logger.accumulate_means("foo"):
+        hier_logger.record("A", 1)
+        assert hier_logger.name_to_value["raw/foo/A"] == 1
+        assert hier_logger.name_to_count["raw/foo/A"] == 0
+        assert hier_logger.name_to_excluded["raw/foo/A"] is None
+        hier_logger.record("B", 10)
+        assert hier_logger.name_to_value["raw/foo/B"] == 10
+        assert hier_logger.name_to_count["raw/foo/B"] == 0
+        assert hier_logger.name_to_excluded["raw/foo/B"] is None
+        hier_logger.dump()
+        hier_logger.record("B", 20)
+        assert hier_logger.name_to_value["raw/foo/B"] == 20
+        assert hier_logger.name_to_count["raw/foo/B"] == 0
+        assert hier_logger.name_to_excluded["raw/foo/B"] is None
+    assert hier_logger.name_to_value["mean/foo/A"] == 1
+    assert hier_logger.name_to_count["mean/foo/A"] == 1
+    assert hier_logger.name_to_excluded["mean/foo/A"] is None
+    assert hier_logger.name_to_value["mean/foo/B"] == 15
+    assert hier_logger.name_to_count["mean/foo/B"] == 2
+    assert hier_logger.name_to_excluded["mean/foo/B"] is None
+    hier_logger.dump()
+    assert len(hier_logger.name_to_value) == 0
+    assert len(hier_logger.name_to_count) == 0
+    assert len(hier_logger.name_to_excluded) == 0
+
+
 def test_hard(tmpdir):
     hier_logger = logger.configure(tmpdir)
 


### PR DESCRIPTION
SB3 Logger has several (publicly accessible) maps `name_to_value`, `name_to_count` and `name_to_excluded` that store intermediate values prior to being "dumped" (persisted to an output format). The `HierarchicalLogger` has these attributes (as it inherits from Logger), but is currently not updating them as all the work is happening in sub-loggers.

This PR exposes the `name_to_*` maps of the current logger. It does this in a kind of hacky way by rewriting the attributes to match those of the current logger. Unfortunately we can't use `@property` which would be a cleaner way to do this, as the `__init__` method tries to write to these. (We could have a `@property.setter` that is a no-op but I think this is even more hacky.)

This fixes a bug that `PreferenceComparisons.train` was always returning zero reward loss and accuracy; I've also added a regression test for that.