### PR TITLE
[tests] Support loading cached npz files & remove pip workaround

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ commands:
 
       - run:
           name: install imitation
-          command: pip install .
+          command: pip install --upgrade --force-reinstall --no-deps .
 
       - run:
           name: print installed packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,10 +63,7 @@ commands:
 
       - run:
           name: install imitation
-          # Build a wheel then install to avoid copying whole directory (pip issue #2195)
-          command: |
-            python setup.py sdist bdist_wheel
-            pip install --upgrade --force-reinstall --no-deps dist/imitation-*.whl
+          command: pip install .
 
       - run:
           name: print installed packages
@@ -119,7 +116,6 @@ jobs:
       - run:
           name: pytype
           command: pytype --version && pytype -j "${NUM_CPUS}" ${SRC_FILES[@]}
-
 
   unit-test:
     executor: unit-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,11 +140,11 @@ jobs:
       # still better than nothing.
       - restore_cache:
           keys:
-            - v6-pytest-cache-{{ checksum "setup.py" }}
+            - v7-pytest-cache-{{ checksum "setup.py" }}
             # This prefix-matched key restores the most recent pytest cache with any
             # checksum. If that cached policy happens to be still loadable, we avoid
             # retraining. See https://circleci.com/docs/2.0/caching/#restoring-cache
-            - v6-pytest-cache-
+            - v7-pytest-cache-
           paths:
             - .pytest_cache
 
@@ -161,7 +161,7 @@ jobs:
       - codecov/upload
 
       - save_cache:
-          key: v6-pytest-cache-{{ checksum "setup.py" }}
+          key: v7-pytest-cache-{{ checksum "setup.py" }}
           paths:
             - .pytest_cache
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,8 +56,7 @@ def load_or_rollout_trajectories(
     os.makedirs(os.path.dirname(cache_path), exist_ok=True)
     with FileLock(cache_path + ".lock"):
         try:
-            with open(cache_path, "rb") as f:
-                return pickle.load(f)
+            return types.load_with_rewards(cache_path)
         except (OSError, pickle.PickleError):  # pragma: no cover
             warnings.warn(
                 "Recomputing expert trajectories due to the following error when "
@@ -135,7 +134,7 @@ def cartpole_expert_trajectories(
     pytestconfig,
 ) -> Sequence[TrajectoryWithRew]:
     rollouts_path = str(
-        pytestconfig.cache.makedir("experts") / CARTPOLE_ENV_NAME / "rollout.pkl",
+        pytestconfig.cache.makedir("experts") / CARTPOLE_ENV_NAME / "rollout.npz",
     )
     return load_or_rollout_trajectories(
         rollouts_path,
@@ -194,7 +193,7 @@ def pendulum_expert_trajectories(
     pytestconfig,
 ) -> Sequence[TrajectoryWithRew]:
     rollouts_path = str(
-        pytestconfig.cache.makedir("experts") / PENDULUM_ENV_NAME / "rollout.pkl",
+        pytestconfig.cache.makedir("experts") / PENDULUM_ENV_NAME / "rollout.npz",
     )
     return load_or_rollout_trajectories(
         rollouts_path,


### PR DESCRIPTION
Some minor improvements to tests & CI:
  - Change `tests/conftest.py` to use `types.load_with_rewards` rather than `pickle.load` directly which is breaking with new `npz` format. Also change filenames to default to `.npz`. This should stop CircleCI from taking 45m to complete as it had to regenerate the rollouts each time :)
  - Remove a lengthly workaround for `pip` being slow to install as  https://github.com/pypa/pip/issues/2195 was closed after 8 years :)