### PR TITLE
[MCE IRL] Fix flaky test `test_mce_irl_reasonable_mdp`

### DIFF
--- a/tests/algorithms/test_mce_irl.py
+++ b/tests/algorithms/test_mce_irl.py
@@ -393,4 +393,5 @@ def test_mce_irl_reasonable_mdp(
         )
         stats = rollout.rollout_stats(trajs)
         if discount > 0.0:  # skip check when discount==0.0 (random policy)
-            assert stats["return_mean"] >= (mdp.horizon - 1) * 2 * 0.8
+            eps = 1e-6  # avoid test failing due to rounding error
+            assert stats["return_mean"] >= (mdp.horizon - 1) * 2 * 0.8 - eps


### PR DESCRIPTION
Fixes #463 

Add `eps=1e-6` margin of error to inequality that was failing sometimes due to floating point error.

Passes 1000/1000 times with:
```bash
pytest --flake-finder -vv -k test_mce_irl_reasonable_mdp --flake-runs=1000 -n 8 tests/algorithms/test_mce_irl.py
```