### PR TITLE
Convert RewardFn from Callable to abstract class (#427)

### DIFF
--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -25,8 +25,7 @@ from imitation.data.types import (
     Transitions,
 )
 from imitation.policies import exploration_wrapper
-from imitation.rewards import reward_function
-from imitation.rewards import reward_nets, reward_wrapper
+from imitation.rewards import reward_function, reward_nets, reward_wrapper
 from imitation.util import logger as imit_logger
 from imitation.util import networks, util
 

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -25,7 +25,7 @@ from imitation.data.types import (
     Transitions,
 )
 from imitation.policies import exploration_wrapper
-from imitation.rewards import common as rewards_common
+from imitation.rewards import reward_function
 from imitation.rewards import reward_nets, reward_wrapper
 from imitation.util import logger as imit_logger
 from imitation.util import networks, util
@@ -112,7 +112,7 @@ class AgentTrainer(TrajectoryGenerator):
     def __init__(
         self,
         algorithm: base_class.BaseAlgorithm,
-        reward_fn: Union[rewards_common.RewardFn, reward_nets.RewardNet],
+        reward_fn: Union[reward_function.RewardFn, reward_nets.RewardNet],
         exploration_frac: float = 0.0,
         switch_prob: float = 0.5,
         random_prob: float = 0.5,

--- a/src/imitation/rewards/common.py
+++ b/src/imitation/rewards/common.py
@@ -1,7 +1,0 @@
-"""Type alias shared by reward-related code."""
-
-from typing import Callable
-
-import numpy as np
-
-RewardFn = Callable[[np.ndarray, np.ndarray, np.ndarray, np.ndarray], np.ndarray]

--- a/src/imitation/rewards/reward_function.py
+++ b/src/imitation/rewards/reward_function.py
@@ -1,0 +1,35 @@
+"""Type alias shared by reward-related code."""
+
+from typing import Protocol
+import abc
+import numpy as np
+
+class RewardFn(Protocol):
+    """Abstract class for reward function.
+
+    Requires implementation of __call__() to compute the reward given a batch of
+    states, actions, next states and dones.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    @abc.abstractmethod
+    def __call__(
+        self,
+        state: np.ndarray,
+        action: np.ndarray,
+        next_state: np.ndarray,
+        done: np.ndarray,
+    ) -> np.ndarray:
+        """Compute rewards for a batch of transitions.
+
+        Args:
+            state: Current states of shape `(batch_size,) + state_shape`.
+            action: Actions of shape `(batch_size,) + action_shape`.
+            next_state: Successor states of shape `(batch_size,) + state_shape`.
+            done: End-of-episode (terminal state) indicator of shape `(batch_size,)`.
+        Returns:
+            Computed np.ndarray rewards of shape `(batch_size,`).
+        """
+        ...

--- a/src/imitation/rewards/reward_function.py
+++ b/src/imitation/rewards/reward_function.py
@@ -13,10 +13,6 @@ class RewardFn(Protocol):
     states, actions, next states and dones.
     """
 
-    def __init__(self):
-        """Builds a RewardFn."""
-        super().__init__()
-
     @abc.abstractmethod
     def __call__(
         self,
@@ -36,4 +32,3 @@ class RewardFn(Protocol):
         Returns:
             Computed rewards of shape `(batch_size,`).
         """  # noqa: DAR202
-        ...

--- a/src/imitation/rewards/reward_function.py
+++ b/src/imitation/rewards/reward_function.py
@@ -1,8 +1,10 @@
 """Type alias shared by reward-related code."""
 
-from typing import Protocol
 import abc
+from typing import Protocol
+
 import numpy as np
+
 
 class RewardFn(Protocol):
     """Abstract class for reward function.
@@ -12,6 +14,7 @@ class RewardFn(Protocol):
     """
 
     def __init__(self):
+        """Builds a RewardFn."""
         super().__init__()
 
     @abc.abstractmethod
@@ -29,7 +32,8 @@ class RewardFn(Protocol):
             action: Actions of shape `(batch_size,) + action_shape`.
             next_state: Successor states of shape `(batch_size,) + state_shape`.
             done: End-of-episode (terminal state) indicator of shape `(batch_size,)`.
+
         Returns:
-            Computed np.ndarray rewards of shape `(batch_size,`).
-        """
+            Computed rewards of shape `(batch_size,`).
+        """  # noqa: DAR202
         ...

--- a/src/imitation/rewards/reward_wrapper.py
+++ b/src/imitation/rewards/reward_wrapper.py
@@ -6,7 +6,7 @@ from typing import Deque
 import numpy as np
 from stable_baselines3.common import callbacks, vec_env
 
-from imitation.rewards import common
+from imitation.rewards import reward_function
 
 
 class WrappedRewardCallback(callbacks.BaseCallback):
@@ -47,7 +47,7 @@ class RewardVecEnvWrapper(vec_env.VecEnvWrapper):
     def __init__(
         self,
         venv: vec_env.VecEnv,
-        reward_fn: common.RewardFn,
+        reward_fn: reward_function.RewardFn,
         ep_history: int = 100,
     ):
         """Builds RewardVecEnvWrapper.

--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -24,13 +24,16 @@ reward_registry: registry.Registry[RewardFnLoaderFn] = registry.Registry()
 
 
 class ValidateRewardFn(reward_function.RewardFn):
-    """Add sanity check to the reward function for dealing with VecEnvs."""
+    """Wrap reward function to add sanity check.
+
+    Checks that the reward vector is equal to the batch size of the input.
+    """
 
     def __init__(
         self,
         reward_fn: reward_function.RewardFn,
     ):
-        """Initialize the Validate Reward 
+        """Builds the reward validator.
 
         Args:
             reward_fn: base reward function
@@ -48,7 +51,8 @@ class ValidateRewardFn(reward_function.RewardFn):
         rew = self.reward_fn(state, action, next_state, done)
         assert rew.shape == (len(state),)
         return rew
-    
+
+
 def _strip_wrappers(
     reward_net: RewardNet,
     wrapper_types: Iterable[Type[RewardNetWrapper]],
@@ -147,7 +151,11 @@ reward_registry.register(key="zero", value=load_zero)
 
 
 @util.docstring_parameter(reward_types=", ".join(reward_registry.keys()))
-def load_reward(reward_type: str, reward_path: str, venv: VecEnv) -> reward_function.RewardFn:
+def load_reward(
+    reward_type: str,
+    reward_path: str,
+    venv: VecEnv,
+) -> reward_function.RewardFn:
     """Load serialized reward.
 
     Args:

--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -26,7 +26,7 @@ reward_registry: registry.Registry[RewardFnLoaderFn] = registry.Registry()
 class ValidateRewardFn(reward_function.RewardFn):
     """Wrap reward function to add sanity check.
 
-    Checks that the reward vector is equal to the batch size of the input.
+    Checks that the length of the reward vector is equal to the batch size of the input.
     """
 
     def __init__(

--- a/tests/rewards/test_reward_fn.py
+++ b/tests/rewards/test_reward_fn.py
@@ -1,0 +1,46 @@
+"""Tests `imitation.rewards.reward_function` and `imitation.rewards.serialize`."""
+
+import numpy as np
+import pytest
+
+from imitation.rewards import reward_function, serialize
+
+
+def _funky_reward_fn(obs, act, next_obs, done):
+    """Returns consecutive reward from 1 to batch size `len(obs)`."""
+    # give each environment number from 1 to num_envs
+    return (np.arange(len(obs))).astype("float32")
+
+
+obs = np.random.randint(0, 10, (64, 100))
+acts = next_obs = obs
+
+
+def test_reward_fn_override():
+    # test inheriting class from RewardFn works
+    class InheritedFunkyReward(reward_function.RewardFn):
+        """A reward inherited from RewardFn."""
+
+        def __init__(self):
+            super().__init__()
+
+        def __call__(self, obs, act, next_obs, steps=None):
+            """Returns consecutive reward from 0 to batch size -1 (`len(obs)` - 1)."""
+            return (np.arange(len(obs))).astype("float32")
+
+    _funky_reward_fn = InheritedFunkyReward()
+    _funky_reward_fn(obs, acts, next_obs)
+
+
+def test_validate_rewardfn_class():
+    validated_reward_fn = serialize.ValidateRewardFn(_funky_reward_fn)
+    validated_reward_fn(obs, acts, next_obs, None)
+
+    with pytest.raises(AssertionError):
+
+        def _invalid_reward_fn(obs, act, next_obs, done):
+            """Returns rewards for lesser number of observations."""
+            return (np.arange(len(obs) - 1)).astype("float32")
+
+        invalidated_reward_fn = serialize.ValidateRewardFn(_invalid_reward_fn)
+        invalidated_reward_fn(obs, acts, next_obs, None)

--- a/tests/rewards/test_reward_fn.py
+++ b/tests/rewards/test_reward_fn.py
@@ -13,7 +13,7 @@ def _funky_reward_fn(obs, act, next_obs, done):
 
 
 obs = np.random.randint(0, 10, (64, 100))
-acts = next_obs = obs
+acts = next_obs = done = obs
 
 
 def test_reward_fn_override():
@@ -34,7 +34,7 @@ def test_reward_fn_override():
 
 def test_validate_rewardfn_class():
     validated_reward_fn = serialize.ValidateRewardFn(_funky_reward_fn)
-    validated_reward_fn(obs, acts, next_obs, None)
+    validated_reward_fn(obs, acts, next_obs, done)
 
     with pytest.raises(AssertionError):
 
@@ -43,4 +43,4 @@ def test_validate_rewardfn_class():
             return (np.arange(len(obs) - 1)).astype("float32")
 
         invalidated_reward_fn = serialize.ValidateRewardFn(_invalid_reward_fn)
-        invalidated_reward_fn(obs, acts, next_obs, None)
+        invalidated_reward_fn(obs, acts, next_obs, done)


### PR DESCRIPTION
* Convert validate_reward_fn to ValidateRewardFn class

* RewardFn inherits from typing.Protocol for structural subtyping functions as RewardFn objects