### PR TITLE
Uniformize logits sign convention for adversarial algorithms

### DIFF
--- a/ci/code_checks.sh
+++ b/ci/code_checks.sh
@@ -41,3 +41,10 @@ if [ "${skipexpensive:-}" != "true" ]; then
     flake8 "${file_array[@]}"
   fi
 fi
+
+set +x
+
+echo
+echo
+printf "\e[1;32mCode checks completed. No errors found\e[0m"
+echo

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,4 +62,4 @@ inputs =
 	tests/
 	experiments/
 	setup.py
-python_version = 3.8
+python_version >= 3.8

--- a/src/imitation/algorithms/adversarial/airl.py
+++ b/src/imitation/algorithms/adversarial/airl.py
@@ -71,25 +71,38 @@ class AIRL(common.AdversarialTrainer):
         done: th.Tensor,
         log_policy_act_prob: th.Tensor,
     ) -> th.Tensor:
-        """
-        Compute the discriminator's logits for each state-action sample.
+        r"""Compute the discriminator's logits for each state-action sample.
 
         In Fu's AIRL paper (https://arxiv.org/pdf/1710.11248.pdf), the
-        discriminator output was given as 
+        discriminator output was given as
         $$
-        D_{\theta}(s,a) = 
+        D_{\theta}(s,a) =
         \frac{ \exp{r_{\theta}(s,a)} } { \exp{r_{\theta}(s,a)} + \pi(a|s) }
         $$
-        with a high value corresponding to expert and a low value corresponding to generator.
+        with a high value corresponding to the expert and a low value corresponding to
+        the generator.
 
-        In other words, the discriminator output is the probability that the action is taken 
-        by the expert rather than the generator.
+        In other words, the discriminator output is the probability that the action is
+        taken by the expert rather than the generator.
 
         The logit of the above is given as
         $$
         \operatorname{logit}(D_{\theta}(s,a)) = r_{\theta}(s,a) - \log{ \pi(a|s) }
         $$
-        which is what is returned by this function.        
+        which is what is returned by this function.
+
+        Args:
+            state: ?
+            action: ?
+            next_state: ?
+            done: ?
+            log_policy_act_prob: ?
+
+        Returns:
+            The logits of the discriminator for each state-action sample.
+
+        Raises:
+            TypeError: If `log_policy_act_prob` is not a tensor.
         """
         if log_policy_act_prob is None:
             raise TypeError(

--- a/src/imitation/algorithms/adversarial/airl.py
+++ b/src/imitation/algorithms/adversarial/airl.py
@@ -63,7 +63,7 @@ class AIRL(common.AdversarialTrainer):
                 "AIRL needs a stochastic policy to compute the discriminator output.",
             )
 
-    def logits_gen_is_high(
+    def logits_expert_is_high(
         self,
         state: th.Tensor,
         action: th.Tensor,
@@ -71,24 +71,32 @@ class AIRL(common.AdversarialTrainer):
         done: th.Tensor,
         log_policy_act_prob: th.Tensor,
     ) -> th.Tensor:
-        """Compute the discriminator's logits for each state-action sample."""
+        """
+        Compute the discriminator's logits for each state-action sample.
+
+        In Fu's AIRL paper (https://arxiv.org/pdf/1710.11248.pdf), the
+        discriminator output was given as 
+        $$
+        D_{\theta}(s,a) = 
+        \frac{ \exp{r_{\theta}(s,a)} } { \exp{r_{\theta}(s,a)} + \pi(a|s) }
+        $$
+        with a high value corresponding to expert and a low value corresponding to generator.
+
+        In other words, the discriminator output is the probability that the action is taken 
+        by the expert rather than the generator.
+
+        The logit of the above is given as
+        $$
+        \operatorname{logit}(D_{\theta}(s,a)) = r_{\theta}(s,a) - \log{ \pi(a|s) }
+        $$
+        which is what is returned by this function.        
+        """
         if log_policy_act_prob is None:
             raise TypeError(
                 "Non-None `log_policy_act_prob` is required for this method.",
             )
         reward_output_train = self._reward_net(state, action, next_state, done)
-        # In Fu's AIRL paper (https://arxiv.org/pdf/1710.11248.pdf), the
-        # discriminator output was given as exp(r_theta(s,a)) /
-        # (exp(r_theta(s,a)) + log pi(a|s)), with a high value corresponding to
-        # expert and a low value corresponding to generator (the opposite of
-        # our convention).
-        #
-        # Observe that sigmoid(log pi(a|s) - r(s,a)) = exp(log pi(a|s) -
-        # r(s,a)) / (1 + exp(log pi(a|s) - r(s,a))). If we multiply through by
-        # exp(r(s,a)), we get pi(a|s) / (pi(a|s) + exp(r(s,a))). This is the
-        # original AIRL discriminator expression with reversed logits to match
-        # our convention of low = expert and high = generator (like GAIL).
-        return log_policy_act_prob - reward_output_train
+        return reward_output_train - log_policy_act_prob
 
     @property
     def reward_train(self) -> reward_nets.RewardNet:

--- a/src/imitation/algorithms/adversarial/airl.py
+++ b/src/imitation/algorithms/adversarial/airl.py
@@ -92,11 +92,13 @@ class AIRL(common.AdversarialTrainer):
         which is what is returned by this function.
 
         Args:
-            state: ?
-            action: ?
-            next_state: ?
-            done: ?
-            log_policy_act_prob: ?
+            state: The state of the environment at the time of the action.
+            action: The action taken by the expert or generator.
+            next_state: The state of the environment after the action.
+            done: whether a `terminal state` (as defined under the MDP of the task) has 
+                been reached.
+            log_policy_act_prob: The log probability of the action taken by the 
+                generator.
 
         Returns:
             The logits of the discriminator for each state-action sample.

--- a/src/imitation/algorithms/adversarial/airl.py
+++ b/src/imitation/algorithms/adversarial/airl.py
@@ -95,9 +95,9 @@ class AIRL(common.AdversarialTrainer):
             state: The state of the environment at the time of the action.
             action: The action taken by the expert or generator.
             next_state: The state of the environment after the action.
-            done: whether a `terminal state` (as defined under the MDP of the task) has 
+            done: whether a `terminal state` (as defined under the MDP of the task) has
                 been reached.
-            log_policy_act_prob: The log probability of the action taken by the 
+            log_policy_act_prob: The log probability of the action taken by the
                 generator.
 
         Returns:

--- a/src/imitation/algorithms/adversarial/common.py
+++ b/src/imitation/algorithms/adversarial/common.py
@@ -28,8 +28,8 @@ def compute_train_stats(
     """Train statistics for GAIL/AIRL discriminator.
 
     Args:
-        disc_logits_gen_is_high: discriminator logits produced by
-            `AdversarialTrainer.logits_gen_is_high`.
+        disc_logits_expert_is_high: discriminator logits produced by
+            `AdversarialTrainer.logits_expert_is_high`.
         labels_gen_is_one: integer labels describing whether logit was for an
             expert (0) or generator (1) sample.
         disc_loss: final discriminator loss.

--- a/src/imitation/algorithms/adversarial/common.py
+++ b/src/imitation/algorithms/adversarial/common.py
@@ -21,30 +21,32 @@ from imitation.util import logger, networks, util
 
 
 def compute_train_stats(
-    disc_logits_gen_is_high: th.Tensor,
-    labels_gen_is_one: th.Tensor,
+    disc_logits_expert_is_high: th.Tensor,
+    labels_expert_is_one: th.Tensor,
     disc_loss: th.Tensor,
 ) -> Mapping[str, float]:
     """Train statistics for GAIL/AIRL discriminator.
 
     Args:
-        disc_logits_gen_is_high: discriminator logits produced by
-            `DiscrimNet.logits_gen_is_high`.
-        labels_gen_is_one: integer labels describing whether logit was for an
-            expert (0) or generator (1) sample.
+        disc_logits_expert_is_high: discriminator logits produced by
+            `DiscrimNet.logits_expert_is_high`.
+        labels_expert_is_one: integer labels describing whether logit was for an
+            expert (1) or generator (0) sample.
         disc_loss: final discriminator loss.
 
     Returns:
         A mapping from statistic names to float values.
     """
     with th.no_grad():
-        bin_is_generated_pred = disc_logits_gen_is_high > 0
-        bin_is_generated_true = labels_gen_is_one > 0
+        # Logits of the discriminator output; >0 for expert samples, <0 for generator.
+        bin_is_generated_pred = disc_logits_expert_is_high < 0
+        # Binary label, so 1 is for expert, 0 is for generator.
+        bin_is_generated_true = labels_expert_is_one == 0
         bin_is_expert_true = th.logical_not(bin_is_generated_true)
         int_is_generated_pred = bin_is_generated_pred.long()
         int_is_generated_true = bin_is_generated_true.long()
         n_generated = float(th.sum(int_is_generated_true))
-        n_labels = float(len(labels_gen_is_one))
+        n_labels = float(len(labels_expert_is_one))
         n_expert = n_labels - n_generated
         pct_expert = n_expert / float(n_labels) if n_labels > 0 else float("NaN")
         n_expert_pred = int(n_labels - th.sum(int_is_generated_pred))
@@ -67,7 +69,7 @@ def compute_train_stats(
         _n_gen_or_1 = max(1, n_generated)
         generated_acc = _n_pred_gen / float(_n_gen_or_1)
 
-        label_dist = th.distributions.Bernoulli(logits=disc_logits_gen_is_high)
+        label_dist = th.distributions.Bernoulli(logits=disc_logits_expert_is_high)
         entropy = th.mean(label_dist.entropy())
 
     pairs = [
@@ -238,7 +240,7 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
         return self.gen_algo.policy
 
     @abc.abstractmethod
-    def logits_gen_is_high(
+    def logits_expert_is_high(
         self,
         state: th.Tensor,
         action: th.Tensor,
@@ -248,8 +250,8 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
     ) -> th.Tensor:
         """Compute the discriminator's logits for each state-action sample.
 
-        A high value corresponds to predicting generator, and a low value corresponds to
-        predicting expert.
+        A high value corresponds to predicting expert, and a low value corresponds to
+        predicting generator.
 
         Args:
             state: state at time t, of shape `(batch_size,) + state_shape`.
@@ -261,8 +263,8 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
                 `action` at time t.
 
         Returns:
-            Discriminator logits of shape `(batch_size,)`. A high output indicates a
-            generator-like transition.
+            Discriminator logits of shape `(batch_size,)`. A high output indicates an
+            expert-like transition.
         """  # noqa: DAR202
 
     @property
@@ -318,7 +320,7 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
                 gen_samples=gen_samples,
                 expert_samples=expert_samples,
             )
-            disc_logits = self.logits_gen_is_high(
+            disc_logits = self.logits_expert_is_high(
                 batch["state"],
                 batch["action"],
                 batch["next_state"],
@@ -327,7 +329,7 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
             )
             loss = F.binary_cross_entropy_with_logits(
                 disc_logits,
-                batch["labels_gen_is_one"].float(),
+                batch["labels_expert_is_one"].float(),
             )
 
             # do gradient step
@@ -340,7 +342,7 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
             with th.no_grad():
                 train_stats = compute_train_stats(
                     disc_logits,
-                    batch["labels_gen_is_one"],
+                    batch["labels_expert_is_one"],
                     loss,
                 )
             self.logger.record("global_step", self._global_step)
@@ -536,8 +538,10 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
         acts = np.concatenate([expert_samples["acts"], gen_samples["acts"]])
         next_obs = np.concatenate([expert_samples["next_obs"], gen_samples["next_obs"]])
         dones = np.concatenate([expert_samples["dones"], gen_samples["dones"]])
-        labels_gen_is_one = np.concatenate(
-            [np.zeros(n_expert, dtype=int), np.ones(n_gen, dtype=int)],
+        # notice that the labels use the convention that expert samples are
+        # labelled with 1 and generator samples with 0.
+        labels_expert_is_one = np.concatenate(
+            [np.ones(n_expert, dtype=int), np.zeros(n_gen, dtype=int)],
         )
 
         # Calculate generator-policy log probabilities.
@@ -561,7 +565,7 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
             "action": acts_th,
             "next_state": next_obs_th,
             "done": dones_th,
-            "labels_gen_is_one": self._torchify_array(labels_gen_is_one),
+            "labels_expert_is_one": self._torchify_array(labels_expert_is_one),
             "log_policy_act_prob": self._torchify_array(log_policy_act_prob),
         }
 

--- a/src/imitation/algorithms/adversarial/common.py
+++ b/src/imitation/algorithms/adversarial/common.py
@@ -30,7 +30,7 @@ def compute_train_stats(
     Args:
         disc_logits_expert_is_high: discriminator logits produced by
             `AdversarialTrainer.logits_expert_is_high`.
-        labels_gen_is_one: integer labels describing whether logit was for an
+        labels_expert_is_one: integer labels describing whether logit was for an
             expert (0) or generator (1) sample.
         disc_loss: final discriminator loss.
 

--- a/src/imitation/algorithms/adversarial/gail.py
+++ b/src/imitation/algorithms/adversarial/gail.py
@@ -142,6 +142,7 @@ class GAIL(common.AdversarialTrainer):
         log_policy_act_prob: Optional[th.Tensor] = None,
     ) -> th.Tensor:
         """Compute the discriminator's logits for each state-action sample.
+
         Args:
             state: The state of the environment at the time of the action.
             action: The action taken by the expert or generator.

--- a/src/imitation/algorithms/adversarial/gail.py
+++ b/src/imitation/algorithms/adversarial/gail.py
@@ -141,7 +141,19 @@ class GAIL(common.AdversarialTrainer):
         done: th.Tensor,
         log_policy_act_prob: Optional[th.Tensor] = None,
     ) -> th.Tensor:
-        """Compute the discriminator's logits for each state-action sample."""
+        """Compute the discriminator's logits for each state-action sample.
+        Args:
+            state: The state of the environment at the time of the action.
+            action: The action taken by the expert or generator.
+            next_state: The state of the environment after the action.
+            done: whether a `terminal state` (as defined under the MDP of the task) has
+                been reached.
+            log_policy_act_prob: The log probability of the action taken by the
+                generator.
+
+        Returns:
+            The logits of the discriminator for each state-action sample.
+        """
         del log_policy_act_prob
         logits = self._reward_net(state, action, next_state, done)
         assert logits.shape == state.shape[:1]

--- a/tests/algorithms/test_adversarial.py
+++ b/tests/algorithms/test_adversarial.py
@@ -271,11 +271,11 @@ def trainer_diverse_env(_algorithm_kwargs, _env_name, tmpdir, expert_transitions
 
 
 @pytest.mark.parametrize("n_timesteps", [2, 4, 10])
-def test_logits_gen_is_high_log_policy_act_prob(
+def test_logits_expert_is_high_log_policy_act_prob(
     trainer_diverse_env: common.AdversarialTrainer,
     n_timesteps: int,
 ):
-    """Smoke test calling `logits_gen_is_high` on `AdversarialTrainer`.
+    """Smoke test calling `logits_expert_is_high` on `AdversarialTrainer`.
 
     For AIRL, also checks that the function raises
     error on `log_policy_act_prob=None`.
@@ -306,7 +306,7 @@ def test_logits_gen_is_high_log_policy_act_prob(
             maybe_error_ctx = contextlib.nullcontext()
 
         with maybe_error_ctx:
-            trainer_diverse_env.logits_gen_is_high(
+            trainer_diverse_env.logits_expert_is_high(
                 obs,
                 acts,
                 next_obs,
@@ -317,11 +317,13 @@ def test_logits_gen_is_high_log_policy_act_prob(
 
 @pytest.mark.parametrize("n_samples", [0, 1, 10, 40])
 def test_compute_train_stats(n_samples):
-    disc_logits_gen_is_high = th.from_numpy(np.random.standard_normal([n_samples]) * 10)
+    disc_logits_expert_is_high = th.from_numpy(
+        np.random.standard_normal([n_samples]) * 10,
+    )
     labels_gen_is_one = th.from_numpy(np.random.randint(2, size=[n_samples]))
     disc_loss = th.tensor(np.random.random() * 10)
     stats = common.compute_train_stats(
-        disc_logits_gen_is_high,
+        disc_logits_expert_is_high,
         labels_gen_is_one,
         disc_loss,
     )

--- a/tests/algorithms/test_adversarial.py
+++ b/tests/algorithms/test_adversarial.py
@@ -320,11 +320,11 @@ def test_compute_train_stats(n_samples):
     disc_logits_expert_is_high = th.from_numpy(
         np.random.standard_normal([n_samples]) * 10,
     )
-    labels_gen_is_one = th.from_numpy(np.random.randint(2, size=[n_samples]))
+    labels_expert_is_one = th.from_numpy(np.random.randint(2, size=[n_samples]))
     disc_loss = th.tensor(np.random.random() * 10)
     stats = common.compute_train_stats(
         disc_logits_expert_is_high,
-        labels_gen_is_one,
+        labels_expert_is_one,
         disc_loss,
     )
     for k, v in stats.items():


### PR DESCRIPTION
Fixes #275. This PR uniformizes the convention of the logits outputted by reward nets in adversarial networks (e.g. GAIL and AIRL) as reported on #275 to mean that high logits correspond to the discriminator considering the trajectory to come from the expert, and conversely, low logits mean that the discriminator believes the trajectory comes from the generator. 

Since the monotonicity of the reward net output is reversed, the reward passed to the generator for policy training is also adequately updated for GAIL and AIRL.