### PR TITLE
Remove references to DiscrimNet

### DIFF
--- a/src/imitation/algorithms/adversarial/common.py
+++ b/src/imitation/algorithms/adversarial/common.py
@@ -29,7 +29,7 @@ def compute_train_stats(
 
     Args:
         disc_logits_gen_is_high: discriminator logits produced by
-            `algorithms.adversarial.common.AdversarialTrainer.logits_gen_is_high`.
+            `AdversarialTrainer.logits_gen_is_high`.
         labels_gen_is_one: integer labels describing whether logit was for an
             expert (0) or generator (1) sample.
         disc_loss: final discriminator loss.

--- a/src/imitation/algorithms/adversarial/common.py
+++ b/src/imitation/algorithms/adversarial/common.py
@@ -29,7 +29,7 @@ def compute_train_stats(
 
     Args:
         disc_logits_gen_is_high: discriminator logits produced by
-            `DiscrimNet.logits_gen_is_high`.
+            `algorithms.adversarial.common.AdversarialTrainer.logits_gen_is_high`.
         labels_gen_is_one: integer labels describing whether logit was for an
             expert (0) or generator (1) sample.
         disc_loss: final discriminator loss.

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -76,7 +76,8 @@ def train_adversarial(
     """Train an adversarial-network-based imitation learning algorithm.
 
     Checkpoints:
-        - DiscrimNets are saved to `f"{log_dir}/checkpoints/{step}/discrim/"`,
+        - AdversarialTrainer train and test RewardNets are saved to 
+           `f"{log_dir}/checkpoints/{step}/reward_train.pt"` (and similarly for test)
             where step is either the training round or "final".
         - Generator policies are saved to `f"{log_dir}/checkpoints/{step}/gen_policy/"`.
 

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -76,7 +76,7 @@ def train_adversarial(
     """Train an adversarial-network-based imitation learning algorithm.
 
     Checkpoints:
-        - AdversarialTrainer train and test RewardNets are saved to 
+        - AdversarialTrainer train and test RewardNets are saved to
            `f"{log_dir}/checkpoints/{step}/reward_{train,test}.pt"`
             where step is either the training round or "final".
         - Generator policies are saved to `f"{log_dir}/checkpoints/{step}/gen_policy/"`.

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -77,7 +77,7 @@ def train_adversarial(
 
     Checkpoints:
         - AdversarialTrainer train and test RewardNets are saved to 
-           `f"{log_dir}/checkpoints/{step}/reward_train.pt"` (and similarly for test)
+           `f"{log_dir}/checkpoints/{step}/reward_{train,test}.pt"`
             where step is either the training round or "final".
         - Generator policies are saved to `f"{log_dir}/checkpoints/{step}/gen_policy/"`.
 


### PR DESCRIPTION
Fixes #468 - removes DiscrimNet from those few places in the docstrings where it was still referenced, and brings any other part of the docstring up to speed if required.