### PR TITLE
Convert RewardFn from Callable to abstract class (#427) (#471)

### DIFF
--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -25,8 +25,7 @@ from imitation.data.types import (
     Transitions,
 )
 from imitation.policies import exploration_wrapper
-from imitation.rewards import common as rewards_common
-from imitation.rewards import reward_nets, reward_wrapper
+from imitation.rewards import reward_function, reward_nets, reward_wrapper
 from imitation.util import logger as imit_logger
 from imitation.util import networks, util
 
@@ -112,7 +111,7 @@ class AgentTrainer(TrajectoryGenerator):
     def __init__(
         self,
         algorithm: base_class.BaseAlgorithm,
-        reward_fn: Union[rewards_common.RewardFn, reward_nets.RewardNet],
+        reward_fn: Union[reward_function.RewardFn, reward_nets.RewardNet],
         exploration_frac: float = 0.0,
         switch_prob: float = 0.5,
         random_prob: float = 0.5,

--- a/src/imitation/rewards/common.py
+++ b/src/imitation/rewards/common.py
@@ -1,7 +1,0 @@
-"""Type alias shared by reward-related code."""
-
-from typing import Callable
-
-import numpy as np
-
-RewardFn = Callable[[np.ndarray, np.ndarray, np.ndarray, np.ndarray], np.ndarray]

--- a/src/imitation/rewards/reward_function.py
+++ b/src/imitation/rewards/reward_function.py
@@ -1,0 +1,34 @@
+"""Type alias shared by reward-related code."""
+
+import abc
+from typing import Protocol
+
+import numpy as np
+
+
+class RewardFn(Protocol):
+    """Abstract class for reward function.
+
+    Requires implementation of __call__() to compute the reward given a batch of
+    states, actions, next states and dones.
+    """
+
+    @abc.abstractmethod
+    def __call__(
+        self,
+        state: np.ndarray,
+        action: np.ndarray,
+        next_state: np.ndarray,
+        done: np.ndarray,
+    ) -> np.ndarray:
+        """Compute rewards for a batch of transitions.
+
+        Args:
+            state: Current states of shape `(batch_size,) + state_shape`.
+            action: Actions of shape `(batch_size,) + action_shape`.
+            next_state: Successor states of shape `(batch_size,) + state_shape`.
+            done: End-of-episode (terminal state) indicator of shape `(batch_size,)`.
+
+        Returns:
+            Computed rewards of shape `(batch_size,`).
+        """  # noqa: DAR202

--- a/src/imitation/rewards/reward_wrapper.py
+++ b/src/imitation/rewards/reward_wrapper.py
@@ -6,7 +6,7 @@ from typing import Deque
 import numpy as np
 from stable_baselines3.common import callbacks, vec_env
 
-from imitation.rewards import common
+from imitation.rewards import reward_function
 
 
 class WrappedRewardCallback(callbacks.BaseCallback):
@@ -47,7 +47,7 @@ class RewardVecEnvWrapper(vec_env.VecEnvWrapper):
     def __init__(
         self,
         venv: vec_env.VecEnv,
-        reward_fn: common.RewardFn,
+        reward_fn: reward_function.RewardFn,
         ep_history: int = 100,
     ):
         """Builds RewardVecEnvWrapper.

--- a/src/imitation/rewards/serialize.py
+++ b/src/imitation/rewards/serialize.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch as th
 from stable_baselines3.common.vec_env import VecEnv
 
-from imitation.rewards import common
+from imitation.rewards import reward_function
 from imitation.rewards.reward_nets import (
     NormalizedRewardNet,
     RewardNet,
@@ -18,25 +18,39 @@ from imitation.util import registry, util
 # TODO(sam): I suspect this whole file can be replaced with th.load calls. Try
 # that refactoring once I have things running.
 
-RewardFnLoaderFn = Callable[[str, VecEnv], common.RewardFn]
+RewardFnLoaderFn = Callable[[str, VecEnv], reward_function.RewardFn]
 
 reward_registry: registry.Registry[RewardFnLoaderFn] = registry.Registry()
 
 
-def _validate_reward(reward: common.RewardFn) -> common.RewardFn:
-    """Add sanity check to the reward function for dealing with VecEnvs."""
+class ValidateRewardFn(reward_function.RewardFn):
+    """Wrap reward function to add sanity check.
 
-    def rew_fn(
-        obs: np.ndarray,
-        act: np.ndarray,
-        next_obs: np.ndarray,
-        dones: np.ndarray,
+    Checks that the length of the reward vector is equal to the batch size of the input.
+    """
+
+    def __init__(
+        self,
+        reward_fn: reward_function.RewardFn,
+    ):
+        """Builds the reward validator.
+
+        Args:
+            reward_fn: base reward function
+        """
+        super().__init__()
+        self.reward_fn = reward_fn
+
+    def __call__(
+        self,
+        state: np.ndarray,
+        action: np.ndarray,
+        next_state: np.ndarray,
+        done: np.ndarray,
     ) -> np.ndarray:
-        rew = reward(obs, act, next_obs, dones)
-        assert rew.shape == (len(obs),)
+        rew = self.reward_fn(state, action, next_state, done)
+        assert rew.shape == (len(state),)
         return rew
-
-    return rew_fn
 
 
 def _strip_wrappers(
@@ -74,7 +88,7 @@ def _make_functional(
     net: RewardNet,
     attr: str = "predict",
     kwargs=dict(),
-) -> common.RewardFn:
+) -> reward_function.RewardFn:
     return lambda *args: getattr(net, attr)(*args, **kwargs)
 
 
@@ -84,7 +98,7 @@ def _validate_type(net: RewardNet, type_: Type[RewardNet]):
     return net
 
 
-def load_zero(path: str, venv: VecEnv) -> common.RewardFn:
+def load_zero(path: str, venv: VecEnv) -> reward_function.RewardFn:
     del path, venv
 
     def f(
@@ -103,21 +117,21 @@ def load_zero(path: str, venv: VecEnv) -> common.RewardFn:
 
 reward_registry.register(
     key="RewardNet_shaped",
-    value=lambda path, _: _validate_reward(
+    value=lambda path, _: ValidateRewardFn(
         _make_functional(_validate_type(th.load(str(path)), ShapedRewardNet)),
     ),
 )
 
 reward_registry.register(
     key="RewardNet_unshaped",
-    value=lambda path, _: _validate_reward(
+    value=lambda path, _: ValidateRewardFn(
         _make_functional(_strip_wrappers(th.load(str(path)), (ShapedRewardNet,))),
     ),
 )
 
 reward_registry.register(
     key="RewardNet_normalized",
-    value=lambda path, _: _validate_reward(
+    value=lambda path, _: ValidateRewardFn(
         _make_functional(
             _validate_type(th.load(str(path)), NormalizedRewardNet),
             attr="predict_processed",
@@ -128,7 +142,7 @@ reward_registry.register(
 
 reward_registry.register(
     key="RewardNet_unnormalized",
-    value=lambda path, _: _validate_reward(
+    value=lambda path, _: ValidateRewardFn(
         _make_functional(_strip_wrappers(th.load(str(path)), (NormalizedRewardNet,))),
     ),
 )
@@ -137,7 +151,11 @@ reward_registry.register(key="zero", value=load_zero)
 
 
 @util.docstring_parameter(reward_types=", ".join(reward_registry.keys()))
-def load_reward(reward_type: str, reward_path: str, venv: VecEnv) -> common.RewardFn:
+def load_reward(
+    reward_type: str,
+    reward_path: str,
+    venv: VecEnv,
+) -> reward_function.RewardFn:
     """Load serialized reward.
 
     Args:

--- a/tests/rewards/test_reward_fn.py
+++ b/tests/rewards/test_reward_fn.py
@@ -1,0 +1,46 @@
+"""Tests `imitation.rewards.reward_function` and `imitation.rewards.serialize`."""
+
+import numpy as np
+import pytest
+
+from imitation.rewards import reward_function, serialize
+
+OBS = np.random.randint(0, 10, (64, 100))
+ACTS = NEXT_OBS = OBS
+DONES = np.zeros(64, dtype=np.bool)
+
+
+def _funky_reward_fn(obs, act, next_obs, done):
+    """Returns consecutive reward from 1 to batch size `len(obs)`."""
+    # give each environment number from 1 to num_envs
+    return (np.arange(len(obs))).astype("float32")
+
+
+def _invalid_reward_fn(obs, act, next_obs, done):
+    """Returns rewards for lesser number of observations."""
+    return (np.arange(len(obs) - 1)).astype("float32")
+
+
+def test_reward_fn_override():
+    # test inheriting class from RewardFn works
+    class InheritedFunkyReward(reward_function.RewardFn):
+        """A reward inherited from RewardFn."""
+
+        def __init__(self):
+            super().__init__()
+
+        def __call__(self, obs, act, next_obs, steps=None):
+            """Returns consecutive reward from 0 to batch size -1 (`len(obs)` - 1)."""
+            return (np.arange(len(obs))).astype("float32")
+
+    inherited_funky_reward_fn = InheritedFunkyReward()
+    inherited_funky_reward_fn(OBS, ACTS, NEXT_OBS)
+
+
+def test_validate_rewardfn_class():
+    validated_reward_fn = serialize.ValidateRewardFn(_funky_reward_fn)
+    validated_reward_fn(OBS, ACTS, NEXT_OBS, DONES)
+
+    with pytest.raises(AssertionError):
+        invalidated_reward_fn = serialize.ValidateRewardFn(_invalid_reward_fn)
+        invalidated_reward_fn(OBS, ACTS, NEXT_OBS, DONES)


### PR DESCRIPTION
* Convert RewardFn from Callable to abstract class (#427)

* Convert validate_reward_fn to ValidateRewardFn class

* RewardFn inherits from typing.Protocol for structural subtyping functions as RewardFn objects

* Incorporate reviewer's suggestions & fix lint errors

* Add test script for reward_function.py

* Fix pytype error

* Remove lines not getting covered by codecov

* Incorporate reviewer's suggestions for test_reward_function.py & serialize.py