### PR TITLE
Improve Windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,9 +89,10 @@ commands:
             - v6-win-dependencies-{{ checksum "setup.py" }}
 
       - run:
-          name: install python
+          name: install python and binary dependencies
           command: |
             choco install --side-by-side -y python --version 3.8
+            choco install -y ffmpeg
           shell: powershell.exe
 
       - run:
@@ -264,7 +265,7 @@ jobs:
             .\venv\Scripts\activate
             pytest -n auto --cov=venv\Lib\site-packages\imitation `
             --cov=tests --junitxml=\tmp\test-reports\junit.xml -k 'not run_example_sh_scripts' `
-            -vv tests\ --ignore tests\test_experiments.py ` --ignore tests\test_scripts.py
+            -vv tests\ --ignore tests\test_experiments.py
             # manually checking (required for exes) and returning if pytest gives error code other than 0
             if ($LASTEXITCODE -ne 0) { throw "pytest failed" }
             mv .coverage .coverage.imitation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,8 +264,7 @@ jobs:
           command: |
             .\venv\Scripts\activate
             pytest -n auto --cov=venv\Lib\site-packages\imitation `
-            --cov=tests --junitxml=\tmp\test-reports\junit.xml -k 'not run_example_sh_scripts' `
-            -vv tests\ --ignore tests\test_experiments.py
+            --cov=tests --junitxml=\tmp\test-reports\junit.xml -vv tests\
             # manually checking (required for exes) and returning if pytest gives error code other than 0
             if ($LASTEXITCODE -ne 0) { throw "pytest failed" }
             mv .coverage .coverage.imitation

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         "torch>=1.4.0",
         "tqdm",
         "scikit-learn>=0.21.2",
-        "stable-baselines3>=1.5.0",
+        "stable-baselines3@git+https://github.com/DLR-RM/stable-baselines3.git@master",
         # TODO(adam) switch to upstream release if they make it
         #  See https://github.com/IDSIA/sacred/issues/879
         "chai-sacred>=0.8.3",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,15 @@ IS_NOT_WINDOWS = os.name != "nt"
 
 PARALLEL_REQUIRE = ["ray[debug,tune]>=1.13.0"]
 PYTYPE = ["pytype"] if IS_NOT_WINDOWS else []
+if IS_NOT_WINDOWS:
+    # TODO(adam): use this for Windows as well once PyPI is at >=1.6.1
+    STABLE_BASELINES3 = "stable-baselines3>=1.6.0"
+else:
+    STABLE_BASELINES3 = (
+        "stable-baselines3@git+"
+        "https://github.com/DLR-RM/stable-baselines3.git@master"
+    )
+
 TESTS_REQUIRE = (
     [
         "seals",
@@ -100,7 +109,7 @@ setup(
         "torch>=1.4.0",
         "tqdm",
         "scikit-learn>=0.21.2",
-        "stable-baselines3@git+https://github.com/DLR-RM/stable-baselines3.git@master",
+        STABLE_BASELINES3,
         # TODO(adam) switch to upstream release if they make it
         #  See https://github.com/IDSIA/sacred/issues/879
         "chai-sacred>=0.8.3",

--- a/src/imitation/util/logger.py
+++ b/src/imitation/util/logger.py
@@ -112,7 +112,7 @@ class HierarchicalLogger(sb_logger.Logger):
             logger = self._cached_loggers[subdir]
         else:
             subdir = types.path_to_str(subdir)
-            folder = "/".join([self.default_logger.dir, "raw", subdir])
+            folder = os.path.join(self.default_logger.dir, "raw", subdir)
             os.makedirs(folder, exist_ok=True)
             output_formats = _build_output_formats(folder, self.format_strs)
             logger = sb_logger.Logger(folder, list(output_formats))

--- a/tests/algorithms/test_preference_comparisons.py
+++ b/tests/algorithms/test_preference_comparisons.py
@@ -1,6 +1,5 @@
 """Tests for the preference comparisons reward learning implementation."""
 
-import os
 import re
 from typing import Sequence
 
@@ -177,13 +176,11 @@ def test_trainer_no_crash(
         custom_logger=custom_logger,
         query_schedule=schedule,
     )
-    # TODO(GH494): remove this skip once SB3 fixed
-    if os.name != "nt":
-        result = main_trainer.train(100, 10)
-        # We don't expect good performance after training for 10 (!) timesteps,
-        # but check stats are within the bounds they should lie in.
-        assert result["reward_loss"] > 0.0
-        assert 0.0 < result["reward_accuracy"] <= 1.0
+    result = main_trainer.train(100, 10)
+    # We don't expect good performance after training for 10 (!) timesteps,
+    # but check stats are within the bounds they should lie in.
+    assert result["reward_loss"] > 0.0
+    assert 0.0 < result["reward_accuracy"] <= 1.0
 
 
 def test_discount_rate_no_crash(agent_trainer, reward_net, fragmenter, custom_logger):
@@ -203,9 +200,7 @@ def test_discount_rate_no_crash(agent_trainer, reward_net, fragmenter, custom_lo
         reward_trainer=reward_trainer,
         custom_logger=custom_logger,
     )
-    # TODO(GH494): remove this skip once SB3 fixed
-    if os.name != "nt":
-        main_trainer.train(100, 10)
+    main_trainer.train(100, 10)
 
 
 def test_synthetic_gatherer_deterministic(agent_trainer, fragmenter):
@@ -321,6 +316,4 @@ def test_exploration_no_crash(agent, reward_net, fragmenter, custom_logger):
         fragmenter=fragmenter,
         custom_logger=custom_logger,
     )
-    # TODO(GH494): remove this skip once SB3 fixed
-    if os.name != "nt":
-        main_trainer.train(100, 10)
+    main_trainer.train(100, 10)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -63,7 +63,7 @@ def test_run_example_py_scripts(py_path):
 @pytest.mark.parametrize("sh_path", SH_PATHS)
 def test_run_example_sh_scripts(sh_path):
     """Smoke test ensuring that shell example scripts run without error."""
-    if os.name == "nt":
+    if os.name == "nt":  # pragma: no cover
         pytest.skip("bash shell scripts not ported to Windows.")
     for _ in range(2):  # Repeat because historically these have failed on second run.
         exit_code = subprocess.call(["env", "bash", "-e", sh_path])

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,6 @@
 """Tests examples/*: quickstart code and Jupyter notebook."""
 
+import os
 import pathlib
 import subprocess
 import sys
@@ -62,6 +63,8 @@ def test_run_example_py_scripts(py_path):
 @pytest.mark.parametrize("sh_path", SH_PATHS)
 def test_run_example_sh_scripts(sh_path):
     """Smoke test ensuring that shell example scripts run without error."""
+    if os.name == "nt":
+        pytest.skip("bash shell scripts not ported to Windows.")
     for _ in range(2):  # Repeat because historically these have failed on second run.
         exit_code = subprocess.call(["env", "bash", "-e", sh_path])
         assert exit_code == 0

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -35,6 +35,8 @@ HAS_FULL_ROLLOUTS = _test_path.exists()
 )
 def test_experiments_fast(script_name: str):
     """Quickly check that experiments run successfully on fast mode."""
+    if os.name == "nt":
+        pytest.skip("bash shell scripts not ported to Windows.")
     env = None
     if script_name in USES_FULL_ROLLOUTS:
         if not HAS_FULL_ROLLOUTS:

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -37,6 +37,7 @@ def test_experiments_fast(script_name: str):
     """Quickly check that experiments run successfully on fast mode."""
     if os.name == "nt":
         pytest.skip("bash shell scripts not ported to Windows.")
+
     env = None
     if script_name in USES_FULL_ROLLOUTS:
         if not HAS_FULL_ROLLOUTS:

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -35,7 +35,7 @@ HAS_FULL_ROLLOUTS = _test_path.exists()
 )
 def test_experiments_fast(script_name: str):
     """Quickly check that experiments run successfully on fast mode."""
-    if os.name == "nt":
+    if os.name == "nt":  # pragma: no cover
         pytest.skip("bash shell scripts not ported to Windows.")
 
     env = None

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -763,6 +763,9 @@ def test_analyze_imitation(tmpdir: str, run_names: List[str], run_sacred_fn):
 
 
 def test_analyze_gather_tb(tmpdir: str):
+    if os.name == "nt":
+        pytest.skip("gather_tb uses symlinks: not supported by Windows")
+
     config_updates = dict(local_dir=tmpdir, run_name="test")
     config_updates.update(PARALLEL_CONFIG_LOW_RESOURCE)
     parallel_run = parallel.parallel_ex.run(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -763,7 +763,7 @@ def test_analyze_imitation(tmpdir: str, run_names: List[str], run_sacred_fn):
 
 
 def test_analyze_gather_tb(tmpdir: str):
-    if os.name == "nt":
+    if os.name == "nt":  # pragma: no cover
         pytest.skip("gather_tb uses symlinks: not supported by Windows")
 
     config_updates = dict(local_dir=tmpdir, run_name="test")


### PR DESCRIPTION
Unignore `tests/test_scripts.py` and install `ffmpeg` so the tests pass.

Where skips still are required (bash shell scripts that haven't been ported to Windows), skip in the test rather than in `.circleci/config.yml`. This has the benefit of: (a) documenting where tests do/don't work in the tests (easier to discover, and will be retained even if tests renamed); (b) skipping expected-to-fail tests on local test runs, not just CI builds.

I was running into the SB3 bug fixed in https://github.com/DLR-RM/stable-baselines3/pull/979 with `test_scripts.py` so I've swapped our SB3 version to `master` on Windows. This feels like the least-evil solution. Flipping it everywhere would break our PyPI automation. We can remove this hack as soon as the next SB3 release is out.