### PR TITLE
docs: Sync release notes to documentation (fixes #488)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,8 @@
 # list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
+import os
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -48,7 +50,7 @@ extensions = [
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False
 autosummary_generate = True
-sphinx_github_changelog_token = "mock-token"  # TODO(tomtseng)
+sphinx_github_changelog_token = os.environ.get("GITHUB_TOKEN")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,8 +6,6 @@
 # list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
-import os
-
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -50,7 +48,6 @@ extensions = [
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False
 autosummary_generate = True
-sphinx_github_changelog_token = os.environ.get("GITHUB_TOKEN")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,11 +42,13 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
+    "sphinx_github_changelog",
 ]
 
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False
 autosummary_generate = True
+sphinx_github_changelog_token = "mock-token"  # TODO(tomtseng)
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/development/release-notes.rst
+++ b/docs/development/release-notes.rst
@@ -1,4 +1,7 @@
 Release Notes
 =============
 
-Please, read the `release history <https://github.com/HumanCompatibleAI/imitation/releases>`_ page on GitHub for the release notes of each version.
+.. changelog::
+    :changelog-url: https://imitation.readthedocs.io/en/latest/development/release-notes.html
+    :github: https://github.com/HumanCompatibleAI/imitation/releases
+    :pypi: https://pypi.org/project/imitation/

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ DOCS_REQUIRE = [
     "sphinxcontrib-napoleon",
     "furo",
     "sphinx-copybutton",
+    "sphinx-github-changelog",
 ]
 
 


### PR DESCRIPTION
This PR uses [sphinx-github-changelog](https://github.com/ewjoachim/sphinx-github-changelog) to sync release notes from GitHub releases to the documentation (fixes #488).