### PR TITLE
Improved logging for preference comparison

### DIFF
--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -995,17 +995,13 @@ class EnsembleTrainer(BasicRewardTrainer):
         loss = losses.sum()
 
         self.logger.record("loss", loss.item())
-        self.logger.record("loss_std", loss.std().item())
-        # Note here we are returning all the losses not just the mean
-        # This will give us a histogram
-        self.logger.record("dist_loss", losses.detach().cpu().numpy())
+        self.logger.record("loss_std", losses.std().item())
 
         # Turn metrics from a list of dictionaries into a dictionary of
-        # tensors. Again this should give us a histogram in tensorboard.
+        # tensors.
         metrics = {k: th.stack([di[k] for di in metrics]) for k in metrics[0]}
         for name, value in metrics.items():
             self.logger.record(name, value.mean().item())
-            self.logger.record(f"dist_{name}", value.cpu().numpy())
 
         return loss
 

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -787,7 +787,7 @@ class CrossEntropyRewardLoss(RewardLoss):
                 gt_probs,
                 preferences_th,
             )
-
+        metrics = {key: value.detach().cpu() for key, value in metrics.items()}
         return LossAndMetrics(
             loss=th.nn.functional.binary_cross_entropy(probs, preferences_th),
             metrics=metrics,
@@ -930,7 +930,7 @@ class BasicRewardTrainer(RewardTrainer):
         loss = output.loss
         self.logger.record("loss", loss.item())
         for name, value in output.metrics.items():
-            self.logger.record(name, value)
+            self.logger.record(name, value.item())
         return loss
 
 

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -769,7 +769,9 @@ class CrossEntropyRewardLoss(RewardLoss):
             rews2 = _evaluate_reward_on_transitions(model, trans2)
             probs[i] = self._probability(rews1, rews2)
             if gt_reward_available:
-                gt_probs[i] = self._probability(frag1.rews, frag2.rews)
+                gt_rews_1 = th.from_numpy(frag1.rews)
+                gt_rews_2 = th.from_numpy(frag2.rews)
+                gt_probs[i] = self._probability(gt_rews_1, gt_rews_2)
         # TODO(ejnnr): Here and below, > 0.5 is problematic
         # because getting exactly 0.5 is actually somewhat
         # common in some environments (as long as sample=False or temperature=0).


### PR DESCRIPTION
This pull request fixes a bug in the logging code for the `EnsembleTrainer` #512. It adds logging of the loss of the ground truth reward on the training data when the ground truth reward is available. This should allow users to more easily check how well the reward model is fitting the training data.