### PR TITLE
Add minimal issue templates and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Bug description
+Description of what the bug is.
+
+## Steps to reproduce
+Code or a description of how to reproduce the bug.
+
+## Environment
+- Operating system and version:
+- Python version:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,3 +16,4 @@ Code or a description of how to reproduce the bug.
 ## Environment
 - Operating system and version:
 - Python version:
+- Output of `pip freeze --all`:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## Problem
+Description of what problem this feature request aims to solve.
+
+## Solution
+Description of proposed solution or change.
+
+## Possible alternative solutions
+Description of any alternative solutions or features you've considered.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Description
+
+Description of changes and what issue this PR is solving.
+
+## Testing
+
+Description of how you've tested your changes.


### PR DESCRIPTION
## Description

This PR adds some very simple GitHub issue templates and a PR template. New issues and PRs will have their body auto-filled by these templates.

closes #499 

## Screenshots

### New issue

![Screen Shot 2022-08-05 at 16 07 08](https://user-images.githubusercontent.com/7245938/183156990-bce652df-d87e-4a63-9e6c-7814f1721536.png)

![Screen Shot 2022-08-05 at 16 07 24](https://user-images.githubusercontent.com/7245938/183157040-3d01cdfa-a387-42f8-a86c-dac365969c91.png)

![Screen Shot 2022-08-05 at 16 07 38](https://user-images.githubusercontent.com/7245938/183157050-239f5d39-18cf-4b90-9d13-9c719225cdc4.png)

### New PR

![Screen Shot 2022-08-05 at 16 18 29](https://user-images.githubusercontent.com/7245938/183157062-59dc6ef6-8520-4d35-bfeb-1aa11da93366.png)