### PR TITLE
Fix bug in shaped reward networks

### DIFF
--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -542,51 +542,9 @@ class ShapedRewardNet(RewardNetWrapper):
         assert final_rew.shape == state.shape[:1]
         return final_rew
 
-    def predict_th(
-        self,
-        state: np.ndarray,
-        action: np.ndarray,
-        next_state: np.ndarray,
-        done: np.ndarray,
-    ) -> th.Tensor:
-        __doc__ = super().forward.__doc__  # noqa: F841
-        with networks.evaluating(self):
-            # switch to eval mode (affecting normalization, dropout, etc)
-
-            state_th, action_th, next_state_th, done_th = self.preprocess(
-                state,
-                action,
-                next_state,
-                done,
-            )
-            with th.no_grad():
-                rew_th = self(state_th, action_th, next_state_th, done_th)
-
-            assert rew_th.shape == state.shape[:1]
-            return rew_th
-
-    def predict(
-        self,
-        state: np.ndarray,
-        action: np.ndarray,
-        next_state: np.ndarray,
-        done: np.ndarray,
-    ) -> np.ndarray:
-        __doc__ = super().forward.__doc__  # noqa: F841
-        rew_th = self.predict_th(state, action, next_state, done)
-        return rew_th.detach().cpu().numpy().flatten()
-
-    def predict_processed(
-        self,
-        state: np.ndarray,
-        action: np.ndarray,
-        next_state: np.ndarray,
-        done: np.ndarray,
-        **kwargs,
-    ) -> np.ndarray:
-        __doc__ = super().forward.__doc__  # noqa: F841
-        del kwargs
-        return self.predict(state, action, next_state, done)
+    predict_th = RewardNet.predict_th
+    predict = RewardNet.predict
+    predict_processed = RewardNet.predict_processed
 
 
 class BasicShapedRewardNet(ShapedRewardNet):

--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -298,7 +298,7 @@ class PredictProcessedWrapper(RewardNetWrapper):
         done: np.ndarray,
         **kwargs,
     ) -> np.ndarray:
-        ...
+        """Predict processed must be overridden in subclasses."""
 
     def predict(
         self,

--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -215,7 +215,7 @@ class RewardNet(nn.Module, abc.ABC):
 class RewardNetWrapper(RewardNet):
     """Abstract class representing a wrapper that modifies a `RewardNet`'s functionality.
 
-    In general `RewardNetWrapper`s should either override `ForwardWrapper`
+    In general `RewardNetWrapper`s should either subclass `ForwardWrapper`
     or `PredictProcessedWrapper`.
     """
 

--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -239,6 +239,15 @@ class RewardNetWrapper(RewardNet):
     def base(self) -> RewardNet:
         return self._base
 
+    @property
+    def device(self) -> th.device:
+        __doc__ = super().device.__doc__  # noqa: F841
+        return self.base.device
+
+    @property
+    def dtype(self) -> th.dtype:
+        return self.base.dtype
+
 
 class ForwardWrapper(RewardNetWrapper):
     """An abstract RewardNetWrapper that changes the behavior of forward.
@@ -272,7 +281,7 @@ class PredictProcessedWrapper(RewardNetWrapper):
     """An abstract RewardNetWrapper that changes the behavior of predict_processed.
 
     Subclasses should override `predict_processed`. Implementations
-    should pass along `kwargs` to the `base` reward nets `predict_processed` method.
+    should pass along `kwargs` to the `base` reward net's `predict_processed` method.
 
     Note: The wrapper will default to forwarding calls to `device`, `forward`,
         `preprocess` and `predict` to the base reward net unless
@@ -329,15 +338,6 @@ class PredictProcessedWrapper(RewardNetWrapper):
     ) -> Tuple[th.Tensor, th.Tensor, th.Tensor, th.Tensor]:
         __doc__ = super().preprocess.__doc__  # noqa: F841
         return self.base.preprocess(state, action, next_state, done)
-
-    @property
-    def device(self) -> th.device:
-        __doc__ = super().device.__doc__  # noqa: F841
-        return self.base.device
-
-    @property
-    def dtype(self) -> th.dtype:
-        return self.base.dtype
 
 
 class RewardNetWithVariance(RewardNet):

--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -500,7 +500,7 @@ class ShapedRewardNet(RewardNetWrapper):
         self.potential = potential
         self.discount_factor = discount_factor
 
-        if not isinstance(base, RewardNetWrapper):
+        if isinstance(base, RewardNetWrapper):
             # Doing this could cause confusing errors like normalization
             # not being applied.
             raise ValueError("Shaping cannot be applied to wrapped reward nets.")

--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -542,6 +542,9 @@ class ShapedRewardNet(RewardNetWrapper):
         assert final_rew.shape == state.shape[:1]
         return final_rew
 
+    # Use concrete implementations from base class rather than our direct
+    # superclass as we do not want to forward predict to base class, but
+    # rather call forward here.
     predict_th = RewardNet.predict_th
     predict = RewardNet.predict
     predict_processed = RewardNet.predict_processed

--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -275,7 +275,7 @@ class PredictProcessedWrapper(RewardNetWrapper):
     should pass along `kwargs` to the `base` reward nets `predict_processed` method.
 
     Note: The wrapper will default to forwarding calls to `device`, `forward`,
-        `preproces` and `predict` to the base reward net unless
+        `preprocess` and `predict` to the base reward net unless
         explicitly overridden in a subclass.
     """
 

--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -542,9 +542,51 @@ class ShapedRewardNet(RewardNetWrapper):
         assert final_rew.shape == state.shape[:1]
         return final_rew
 
-    predict_th = RewardNet.predict_th
-    predict = RewardNet.predict
-    predict_processed = RewardNet.predict_processed
+    def predict_th(
+        self,
+        state: np.ndarray,
+        action: np.ndarray,
+        next_state: np.ndarray,
+        done: np.ndarray,
+    ) -> th.Tensor:
+        __doc__ = super().forward.__doc__  # noqa: F841
+        with networks.evaluating(self):
+            # switch to eval mode (affecting normalization, dropout, etc)
+
+            state_th, action_th, next_state_th, done_th = self.preprocess(
+                state,
+                action,
+                next_state,
+                done,
+            )
+            with th.no_grad():
+                rew_th = self(state_th, action_th, next_state_th, done_th)
+
+            assert rew_th.shape == state.shape[:1]
+            return rew_th
+
+    def predict(
+        self,
+        state: np.ndarray,
+        action: np.ndarray,
+        next_state: np.ndarray,
+        done: np.ndarray,
+    ) -> np.ndarray:
+        __doc__ = super().forward.__doc__  # noqa: F841
+        rew_th = self.predict_th(state, action, next_state, done)
+        return rew_th.detach().cpu().numpy().flatten()
+
+    def predict_processed(
+        self,
+        state: np.ndarray,
+        action: np.ndarray,
+        next_state: np.ndarray,
+        done: np.ndarray,
+        **kwargs,
+    ) -> np.ndarray:
+        __doc__ = super().forward.__doc__  # noqa: F841
+        del kwargs
+        return self.predict(state, action, next_state, done)
 
 
 class BasicShapedRewardNet(ShapedRewardNet):

--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -542,9 +542,6 @@ class ShapedRewardNet(RewardNetWrapper):
         assert final_rew.shape == state.shape[:1]
         return final_rew
 
-    # Use concrete implementations from base class rather than our direct
-    # superclass as we do not want to forward predict to base class, but
-    # rather call forward here.
     predict_th = RewardNet.predict_th
     predict = RewardNet.predict
     predict_processed = RewardNet.predict_processed

--- a/src/imitation/testing/reward_nets.py
+++ b/src/imitation/testing/reward_nets.py
@@ -1,6 +1,7 @@
 """Utility functions for testing reward nets."""
 
 import gym
+import torch as th
 
 from imitation.rewards import reward_nets
 
@@ -20,3 +21,38 @@ def make_ensemble(
             for _ in range(num_members)
         ],
     )
+
+
+class MockRewardNet(reward_nets.RewardNet):
+    """A mock reward net for testing."""
+
+    def __init__(
+        self,
+        observation_space: gym.Space,
+        action_space: gym.Space,
+        value: float = 0.0,
+    ):
+        """Create mock reward.
+
+        Args:
+            observation_space: observation space of the env
+            action_space: action space of the env
+            value: The reward to always return. Defaults to 0.0.
+        """
+        super().__init__(observation_space, action_space)
+        self.value = value
+
+    def forward(
+        self,
+        state: th.Tensor,
+        action: th.Tensor,
+        next_state: th.Tensor,
+        done: th.Tensor,
+    ) -> th.Tensor:
+        batch_size = state.shape[0]
+        return th.full(
+            (batch_size,),
+            fill_value=self.value,
+            dtype=th.float32,
+            device=state.device,
+        )

--- a/tests/rewards/test_reward_nets.py
+++ b/tests/rewards/test_reward_nets.py
@@ -528,6 +528,8 @@ def test_shaped_reward_net(
         return th.full((x.shape[0],), 10, device=x.device)
 
     shaped = reward_nets.ShapedRewardNet(zero_reward_net, potential, 0.9)
+    # We expect the shaped reward to be -1 since,
+    # r'(s,a,s') = r(s,a,s') + \gamma \theta(s') - \theta(s) = (0) + (0.9)(10) - 10 = -1
     shaped_rew = th.full((10,), -1, dtype=th.float32)
     forward_args = shaped.preprocess(*numpy_transitions)
     assert th.allclose(shaped(*forward_args), shaped_rew)

--- a/tests/rewards/test_reward_nets.py
+++ b/tests/rewards/test_reward_nets.py
@@ -4,7 +4,7 @@ import logging
 import numbers
 import os
 import tempfile
-from typing import Tuple
+from typing import Callable, Tuple
 from unittest import mock
 
 import gym
@@ -43,9 +43,17 @@ MAKE_REWARD_NET = [
     testing_reward_nets.make_ensemble,
 ]
 
-
-MAKE_SIMPLE_REWARD_NET_WRAPPERS = [
+MakeForwardWrapper = Callable[[reward_nets.RewardNet], reward_nets.ForwardWrapper]
+MAKE_PREDICT_PROCESSED_WRAPPERS = [
     lambda base: reward_nets.NormalizedRewardNet(base, networks.RunningNorm),
+]
+
+MakePredictProcessedWrapper = Callable[
+    [reward_nets.RewardNet],
+    reward_nets.PredictProcessedWrapper,
+]
+MAKE_FORWARD_WRAPPERS = [
+    lambda base: reward_nets.ShapedRewardNet(base, _potential, 0.99),
 ]
 
 REWARD_NET_KWARGS = [
@@ -162,34 +170,6 @@ def test_reward_valid(env_name, reward_type, tmpdir):
 
     assert pred_reward.shape == (TRAJECTORY_LEN,)
     assert isinstance(pred_reward[0], numbers.Number)
-
-
-def test_wrappers_default_to_passing_on_method_calls_to_base(
-    numpy_transitions: NumpyTransitions,
-    torch_transitions: TorchTransitions,
-):
-    base = mock.MagicMock()
-    wrapper = reward_nets.RewardNetWrapper(base)
-    # Check method calls
-    for attr, call_with, return_value in [
-        ("forward", torch_transitions, th.zeros(10)),
-        ("predict_th", numpy_transitions, np.zeros(10)),
-        ("predict", numpy_transitions, np.zeros(10)),
-        ("predict_processed", numpy_transitions, np.zeros(10)),
-        ("preprocess", numpy_transitions, torch_transitions),
-    ]:
-        setattr(base, attr, mock.MagicMock(return_value=return_value))
-        assert getattr(wrapper, attr)(*call_with) is return_value
-        getattr(base, attr).assert_called_once_with(*call_with)
-
-    # Check property lookups
-    return_value = th.device("cpu")
-    base.device = mock.PropertyMock(return_value=return_value)
-    assert wrapper.device is base.device
-
-    return_value = th.float32
-    base.dtype = mock.PropertyMock(return_value=return_value)
-    assert wrapper.dtype is base.dtype
 
 
 def test_strip_wrappers_basic():
@@ -468,6 +448,11 @@ def zero_reward_net(env_2d) -> MockRewardNet:
     return MockRewardNet(env_2d.observation_space, env_2d.action_space, value=0)
 
 
+@pytest.fixture(params=MAKE_PREDICT_PROCESSED_WRAPPERS)
+def predict_processed_wrapper(request, zero_reward_net):
+    return request.param(zero_reward_net)
+
+
 @pytest.fixture
 def two_ensemble(env_2d) -> reward_nets.RewardEnsemble:
     """A simple reward ensemble made up of two mock reward nets."""
@@ -551,27 +536,29 @@ def test_shaped_reward_net(
     assert np.allclose(shaped.predict_processed(*numpy_transitions), shaped_rew.numpy())
 
 
-@pytest.mark.parametrize("make_wrapper", MAKE_SIMPLE_REWARD_NET_WRAPPERS)
-def test_shaping_cannot_be_applied_to_wrapped_reward_network(
-    zero_reward_net: MockRewardNet,
-    make_wrapper: reward_nets.RewardNetWrapper,
+@pytest.mark.parametrize("make_forward_wrapper", MAKE_FORWARD_WRAPPERS)
+def test_forward_wrapper_cannot_be_applied_predict_processed_wrapper(
+    predict_processed_wrapper: reward_nets.PredictProcessedWrapper,
+    make_forward_wrapper: MakeForwardWrapper,
 ):
-    wrapped_net = make_wrapper(zero_reward_net)
     with pytest.raises(
         ValueError,
-        match=r"Shaping cannot be applied to wrapped reward nets.",
+        match=r"ForwardWrapper cannot be applied on top of PredictProcessedWrapper!",
     ):
-        reward_nets.ShapedRewardNet(wrapped_net, _potential, 0.99)
+        make_forward_wrapper(predict_processed_wrapper)
 
 
-@pytest.mark.parametrize("make_wrapper", MAKE_SIMPLE_REWARD_NET_WRAPPERS)
-def test_wrappers_pass_on_kwargs(
-    make_wrapper: reward_nets.RewardNetWrapper,
+@pytest.mark.parametrize(
+    "make_predict_processed_wrapper",
+    MAKE_PREDICT_PROCESSED_WRAPPERS,
+)
+def test_predict_processed_wrappers_pass_on_kwargs(
+    make_predict_processed_wrapper: MakePredictProcessedWrapper,
     zero_reward_net: MockRewardNet,
     numpy_transitions: NumpyTransitions,
 ):
     zero_reward_net.predict_processed = mock.Mock(return_value=np.zeros((10,)))
-    wrapped_reward_net = make_wrapper(
+    wrapped_reward_net = make_predict_processed_wrapper(
         zero_reward_net,
     )
     wrapped_reward_net.predict_processed(
@@ -582,6 +569,36 @@ def test_wrappers_pass_on_kwargs(
         *numpy_transitions,
         foobar=42,
     )
+
+
+def test_predict_processed_wrappers_to_pass_on_method_calls_to_base(
+    numpy_transitions: NumpyTransitions,
+    torch_transitions: TorchTransitions,
+    predict_processed_wrapper: reward_nets.PredictProcessedWrapper,
+):
+    base = mock.create_autospec(MockRewardNet)
+
+    base.device = th.device("cpu")
+
+    base.dtype = th.float32
+
+    predict_processed_wrapper._base = base
+    # Check method calls
+    for attr, call_with, return_value in [
+        ("forward", torch_transitions, th.zeros(10)),
+        ("predict_th", numpy_transitions, np.zeros(10)),
+        ("predict", numpy_transitions, np.zeros(10)),
+        ("predict_processed", numpy_transitions, np.zeros(10)),
+        ("preprocess", numpy_transitions, torch_transitions),
+    ]:
+        setattr(base, attr, mock.MagicMock(return_value=return_value))
+        getattr(predict_processed_wrapper, attr)(*call_with)
+        getattr(base, attr).assert_called_once_with(*call_with)
+
+    # Check property lookups
+    assert predict_processed_wrapper.device is base.device
+
+    assert predict_processed_wrapper.dtype is base.dtype
 
 
 def test_load_reward_passes_along_alpha_to_add_std_wrappers_predict_processed_method(

--- a/tests/rewards/test_reward_nets.py
+++ b/tests/rewards/test_reward_nets.py
@@ -44,8 +44,7 @@ MAKE_REWARD_NET = [
 ]
 
 
-MAKE_BASIC_REWARD_NET_WRAPPERS = [
-    lambda base: reward_nets.ShapedRewardNet(base, _potential, 0.99),
+MAKE_SIMPLE_REWARD_NET_WRAPPERS = [
     lambda base: reward_nets.NormalizedRewardNet(base, networks.RunningNorm),
 ]
 
@@ -531,7 +530,7 @@ def test_add_std_reward_wrapper(
     assert np.allclose(rewards, 1 - 0.5 * np.sqrt(8))
 
 
-@pytest.mark.parametrize("make_wrapper", MAKE_BASIC_REWARD_NET_WRAPPERS)
+@pytest.mark.parametrize("make_wrapper", MAKE_SIMPLE_REWARD_NET_WRAPPERS)
 def test_wrappers_pass_on_kwargs(
     make_wrapper: reward_nets.RewardNetWrapper,
     env_2d: Env2D,


### PR DESCRIPTION
## Description

Addresses #543 

## Testing
- [x] Add test for shaping actually being applied during predict and predict processed.
- [x] Add test for `ValueError` being raised when you try to shape a wrapped reward net.
