### PR TITLE
CNN scripts

### DIFF
--- a/src/imitation/policies/base.py
+++ b/src/imitation/policies/base.py
@@ -88,6 +88,14 @@ class SAC1024Policy(sac_policies.SACPolicy):
         super().__init__(*args, **kwargs, net_arch=[1024, 1024])
 
 
+class CnnPolicy(policies.ActorCriticCnnPolicy):
+    """A CNN Actor-Critic policy."""
+
+    def __init__(self, *args, **kwargs):
+        """Builds CnnPolicy; arguments passed to `CnnActorCriticPolicy`."""
+        super().__init__(*args, **kwargs)
+
+
 class NormalizeFeaturesExtractor(torch_layers.FlattenExtractor):
     """Feature extractor that flattens then normalizes input."""
 

--- a/src/imitation/scripts/common/common.py
+++ b/src/imitation/scripts/common/common.py
@@ -3,9 +3,10 @@
 import contextlib
 import logging
 import os
-from typing import Any, Mapping, Sequence, Tuple, Union
+from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, Union
 
 import sacred
+from gym import Env
 from stable_baselines3.common import vec_env
 
 from imitation.scripts.common import wb
@@ -33,6 +34,7 @@ def config():
     num_vec = 8  # number of environments in VecEnv
     parallel = True  # Use SubprocVecEnv rather than DummyVecEnv
     max_episode_steps = None  # Set to positive int to limit episode horizons
+    post_wrappers = []  # Sequence of wrappers to apply to each env in the VecEnv
     env_make_kwargs = {}  # The kwargs passed to `spec.make`.
 
     locals()  # quieten flake8
@@ -136,6 +138,7 @@ def make_venv(
     parallel: bool,
     log_dir: str,
     max_episode_steps: int,
+    post_wrappers: Optional[Sequence[Callable[[Env, int], Env]]],
     env_make_kwargs: Mapping[str, Any],
     **kwargs,
 ) -> vec_env.VecEnv:
@@ -149,6 +152,8 @@ def make_venv(
         max_episode_steps: If not None, then a TimeLimit wrapper is applied to each
             environment to artificially limit the maximum number of timesteps in an
             episode.
+        post_wrappers: If specified, iteratively wraps each environment with each
+            of the wrappers specified in the sequence.
         log_dir: Logs episode return statistics to a subdirectory 'monitor`.
         env_make_kwargs: The kwargs passed to `spec.make` of a gym environment.
         kwargs: Passed through to `util.make_vec_env`.
@@ -163,8 +168,9 @@ def make_venv(
         num_vec,
         seed=_seed,
         parallel=parallel,
-        max_episode_steps=max_episode_steps,
         log_dir=log_dir,
+        max_episode_steps=max_episode_steps,
+        post_wrappers=post_wrappers,
         env_make_kwargs=env_make_kwargs,
         **kwargs,
     )

--- a/src/imitation/scripts/common/reward.py
+++ b/src/imitation/scripts/common/reward.py
@@ -61,6 +61,11 @@ def reward_ensemble():
     locals()
 
 
+@reward_ingredient.named_config
+def cnn_reward():
+    net_cls = reward_nets.CnnRewardNet  # noqa: F841
+
+
 @reward_ingredient.config_hook
 def config_hook(config, command_name, logger):
     """Sets default values for `net_cls` and `net_kwargs`."""
@@ -72,7 +77,10 @@ def config_hook(config, command_name, logger):
             default_net = reward_nets.BasicShapedRewardNet
         res["net_cls"] = default_net
 
-    if "normalize_input_layer" not in config["reward"]["net_kwargs"]:
+    if (
+        "normalize_input_layer" not in config["reward"]["net_kwargs"]
+        and config["reward"]["net_cls"] != reward_nets.CnnRewardNet
+    ):
         res["net_kwargs"] = {"normalize_input_layer": networks.RunningNorm}
 
     if "net_cls" in res and issubclass(res["net_cls"], reward_nets.RewardEnsemble):

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -37,6 +37,15 @@ def sac():
 
 
 @train_ingredient.named_config
+def cnn():
+    policy_cls = base.CnnPolicy  # noqa: F841
+    # If features_extractor_class is not set, it will be set to a
+    # NormalizeFeaturesExtractor by default via the config hook, which implements an MLP.
+    # Therefore, to actually get this to implement a CNN, we need to set it here.
+    policy_kwargs = {"features_extractor_class": torch_layers.NatureCNN}  # noqa: F841
+
+
+@train_ingredient.named_config
 def normalize_disable():
     policy_kwargs = {  # noqa: F841
         # FlattenExtractor is the default for SB3; but we specify it here

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -40,8 +40,8 @@ def sac():
 def cnn():
     policy_cls = base.CnnPolicy  # noqa: F841
     # If features_extractor_class is not set, it will be set to a
-    # NormalizeFeaturesExtractor by default via the config hook, which implements an MLP.
-    # Therefore, to actually get this to implement a CNN, we need to set it here.
+    # NormalizeFeaturesExtractor by default via the config hook, which implements an
+    # MLP. Therefore, to actually get this to implement a CNN, we need to set it here.
     policy_kwargs = {"features_extractor_class": torch_layers.NatureCNN}  # noqa: F841
 
 

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -119,7 +119,7 @@ def seals_mountain_car():
 
 
 @train_preference_comparisons_ex.named_config
-def asteroids_fast():
+def asteroids_short_episodes():
     common = dict(
         env_name="AsteroidsNoFrameskip-v4",
         post_wrappers=[

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -1,6 +1,9 @@
 """Configuration for imitation.scripts.train_preference_comparisons."""
 
 import sacred
+from gym.wrappers import TimeLimit
+from seals.util import AutoResetWrapper
+from stable_baselines3.common.atari_wrappers import AtariWrapper
 
 from imitation.algorithms import preference_comparisons
 from imitation.scripts.common import common, reward, rl, train
@@ -113,6 +116,30 @@ def mountain_car():
 @train_preference_comparisons_ex.named_config
 def seals_mountain_car():
     common = dict(env_name="seals/MountainCar-v0")
+
+
+@train_preference_comparisons_ex.named_config
+def asteroids_fast():
+    common = dict(
+        env_name="AsteroidsNoFrameskip-v4",
+        post_wrappers=[
+            lambda env, _: AutoResetWrapper(env),
+            lambda env, _: AtariWrapper(env, terminal_on_life_loss=False),
+            lambda env, _: TimeLimit(env, max_episode_steps=100),
+        ],
+    )
+
+
+@train_preference_comparisons_ex.named_config
+def asteroids():
+    common = dict(
+        env_name="AsteroidsNoFrameskip-v4",
+        post_wrappers=[
+            lambda env, _: AutoResetWrapper(env),
+            lambda env, _: AtariWrapper(env, terminal_on_life_loss=False),
+            lambda env, _: TimeLimit(env, max_episode_steps=100_000),
+        ],
+    )
 
 
 @train_preference_comparisons_ex.named_config

--- a/src/imitation/scripts/config/train_rl.py
+++ b/src/imitation/scripts/config/train_rl.py
@@ -64,6 +64,18 @@ def asteroids():
 
 
 @train_rl_ex.named_config
+def asteroids_short_episodes():
+    common = dict(
+        env_name="AsteroidsNoFrameskip-v4",
+        post_wrappers=[
+            lambda env, _: AutoResetWrapper(env),
+            lambda env, _: AtariWrapper(env, terminal_on_life_loss=False),
+            lambda env, _: TimeLimit(env, max_episode_steps=100),
+        ],
+    )
+
+
+@train_rl_ex.named_config
 def ant():
     common = dict(env_name="Ant-v2")
     rl = dict(batch_size=16384)

--- a/src/imitation/scripts/config/train_rl.py
+++ b/src/imitation/scripts/config/train_rl.py
@@ -1,6 +1,9 @@
 """Configuration settings for train_rl, training a policy with RL."""
 
 import sacred
+from gym.wrappers import TimeLimit
+from seals.util import AutoResetWrapper
+from stable_baselines3.common.atari_wrappers import AtariWrapper
 
 from imitation.scripts.common import common, rl, train
 
@@ -46,6 +49,18 @@ def default_end_cond(rollout_save_n_timesteps, rollout_save_n_episodes):
 @train_rl_ex.named_config
 def acrobot():
     common = dict(env_name="Acrobot-v1")
+
+
+@train_rl_ex.named_config
+def asteroids():
+    common = dict(
+        env_name="AsteroidsNoFrameskip-v4",
+        post_wrappers=[
+            lambda env, _: AutoResetWrapper(env),
+            lambda env, _: AtariWrapper(env, terminal_on_life_loss=False),
+            lambda env, _: TimeLimit(env, max_episode_steps=100_000),
+        ],
+    )
 
 
 @train_rl_ex.named_config

--- a/src/imitation/scripts/train_rl.py
+++ b/src/imitation/scripts/train_rl.py
@@ -97,7 +97,7 @@ def train_rl(
     os.makedirs(policy_dir, exist_ok=True)
 
     all_post_wrappers = common["post_wrappers"] + [
-        lambda env, idx: wrappers.RolloutInfoWrapper(env)
+        lambda env, idx: wrappers.RolloutInfoWrapper(env),
     ]
     with scripts_common.make_venv(post_wrappers=all_post_wrappers) as venv:
         callback_objs = []


### PR DESCRIPTION
## Description

Add config options to train CNNs on image environments. This also involves letting configs set environment wrappers, so that environments like Atari can be appropriately wrapped.

## Testing

Ran some scripts of interest locally, ran `pytest tests/scripts/test_scripts.py`.

## TODOs:

- Add nice configs for all algorithms, not just preference comparisons.
- Add tests for CNN+image environment scripts.
