### PR TITLE
Fix n_rounds is not an integer error

### DIFF
--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -107,7 +107,7 @@ def train_adversarial(
         `rollout_stats()` on the expert demonstrations.
     """
     # This allows to specify total_timesteps and checkpoint_interval in scientific
-    # notation, which is interpreted as a float by sacred.
+    # notation, which is interpreted as a float by python.
     total_timesteps = int(total_timesteps)
     checkpoint_interval = int(checkpoint_interval)
 

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -106,6 +106,11 @@ def train_adversarial(
         "monitor_return" key). "expert_stats" gives the return value of
         `rollout_stats()` on the expert demonstrations.
     """
+    # This allows to specify total_timesteps and checkpoint_interval in scientific
+    # notation, which is interpreted as a float by sacred.
+    total_timesteps = int(total_timesteps)
+    checkpoint_interval = int(checkpoint_interval)
+
     if show_config:
         # Running `train_adversarial print_config` will show unmerged config.
         # So, support showing merged config from `train_adversarial {airl,gail}`.

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -153,6 +153,18 @@ def train_preference_comparisons(
     Raises:
         ValueError: Inconsistency between config and deserialized policy normalization.
     """
+    # This allows to specify total_timesteps, total_comparisons etc. in scientific
+    # notation, which is interpreted as a float by sacred.
+    total_timesteps = int(total_timesteps)
+    total_comparisons = int(total_comparisons)
+    num_iterations = int(num_iterations)
+    comparison_queue_size = (
+        int(comparison_queue_size) if comparison_queue_size is not None else None
+    )
+    fragment_length = int(fragment_length)
+    active_selection_oversampling = int(active_selection_oversampling)
+    checkpoint_interval = int(checkpoint_interval)
+
     custom_logger, log_dir = logging_ingredient.setup_logging()
 
     with environment.make_venv() as venv:

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -154,7 +154,7 @@ def train_preference_comparisons(
         ValueError: Inconsistency between config and deserialized policy normalization.
     """
     # This allows to specify total_timesteps, total_comparisons etc. in scientific
-    # notation, which is interpreted as a float by sacred.
+    # notation, which is interpreted as a float by python.
     total_timesteps = int(total_timesteps)
     total_comparisons = int(total_comparisons)
     num_iterations = int(num_iterations)


### PR DESCRIPTION
This fix explicitly converts `n_rounds` to `int` as it can be of `float` type if any of the operands are float. For example, when we set `total_timesteps = 1e5`. The float type gives an error on line 422 in `range` as it requires an integer.

Alternatively, we can also ensure that `total_timesteps` and `gen_train_timesteps` are integers by explicitly converting them if given in the scientific notation.