### PR TITLE
Remove ntfy[slack] dependency from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,6 @@ setup(
         "dev": [
             "autopep8",
             "awscli",
-            "ntfy[slack]",
             "ipdb",
             "isort~=5.0",
             "codespell",


### PR DESCRIPTION
## Description

Solves #566 by removing the unused `ntfy[slack]` dependency in `dev` mode.

## Testing

Tests passing after removing dependency.
