### PR TITLE
Upgrade Python version in Windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,14 @@ commands:
       - run:
           name: install python and binary dependencies
           command: |
-            choco install --side-by-side -y python --version 3.8
+            choco install --side-by-side -y python --version=3.8.10
             choco install -y ffmpeg
+          shell: powershell.exe
+
+      - run:
+          name: upgrade pip
+          command: |
+              python -m pip install --upgrade pip
           shell: powershell.exe
 
       - run:


### PR DESCRIPTION
## Description

Windows is currently failing CI in some PRs (e.g. https://app.circleci.com/pipelines/github/HumanCompatibleAI/imitation/2721/workflows/015d1fb1-21f8-4245-aeae-85a8f0524c24/jobs/8509/steps, #537) due to a bug in an old version of CPython (https://github.com/python/cpython/issues/83396). This was fixed in https://github.com/python/cpython/pull/17827, but since chocolatey is installing python 3.8.0., this (and other CPython bugs) are still present.

This PR upgrades python on windows to the most recent version available on chocolatey (3.8.10). At the time of writing, the most recent python version is actually 3.8.14.
