### PR TITLE
Add more type hints to enable mypy for some files.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ executors:
           src/imitation/algorithms/preference_comparisons.py$
           | src/imitation/rewards/reward_nets.py$
           | src/imitation/algorithms/base.py$
-          | src/imitation/scripts/train_preference_comparisons.py$
           | src/imitation/rewards/serialize.py$
           | src/imitation/scripts/common/train.py$
           | src/imitation/algorithms/mce_irl.py$

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,12 +40,8 @@ executors:
       EXCLUDE_MYPY: | 
         (?x)(
           src/imitation/algorithms/preference_comparisons.py$
-          | src/imitation/rewards/reward_nets.py$
-          | src/imitation/algorithms/base.py$
           | src/imitation/rewards/serialize.py$
-          | src/imitation/scripts/common/train.py$
           | src/imitation/algorithms/mce_irl.py$
-          | src/imitation/algorithms/density.py$
           | tests/algorithms/test_bc.py$
         )
 

--- a/src/imitation/algorithms/base.py
+++ b/src/imitation/algorithms/base.py
@@ -273,7 +273,7 @@ def make_data_loader(
             **kwargs,
         )
     elif isinstance(transitions, Iterable):
-        # Safe to ignore this error since we've already coerced Iterable[Trajectory]
+        # Safe to ignore this error since we've already converted Iterable[Trajectory]
         # `transitions` into Iterable[TransitionMapping]
         return _WrappedDataLoader(transitions, batch_size)  # type: ignore[arg-type]
     else:

--- a/src/imitation/algorithms/base.py
+++ b/src/imitation/algorithms/base.py
@@ -192,7 +192,7 @@ class _WrappedDataLoader:
         self.expected_batch_size = expected_batch_size
 
     def __iter__(self):
-        """Iterator yielding data from `self.data_loader`, checking `self.expected_batch_size`.
+        """Yields data from `self.data_loader`, checking `self.expected_batch_size`.
 
         Yields:
             Identity -- yields same batches as from `self.data_loader`.
@@ -244,7 +244,10 @@ def make_data_loader(
 
     if isinstance(transitions, Iterable):
         # Inferring the correct type here is difficult with generics.
-        first_item, transitions = util.get_first_iter_element(  # type: ignore[assignment]
+        (
+            first_item,
+            transitions,
+        ) = util.get_first_iter_element(  # type: ignore[assignment]
             transitions
         )
         if isinstance(first_item, types.Trajectory):
@@ -270,8 +273,8 @@ def make_data_loader(
             **kwargs,
         )
     elif isinstance(transitions, Iterable):
-        # Safe to ignore this error since we've already coerced Iterable transitions into
-        # Iterable[TransitionMapping]
+        # Safe to ignore this error since we've already coerced Iterable[Trajectory]
+        # `transitions` into Iterable[TransitionMapping]
         return _WrappedDataLoader(transitions, batch_size)  # type: ignore[arg-type]
     else:
         raise TypeError(f"`demonstrations` unexpected type {type(transitions)}")

--- a/src/imitation/algorithms/base.py
+++ b/src/imitation/algorithms/base.py
@@ -244,9 +244,9 @@ def make_data_loader(
 
     if isinstance(transitions, Iterable):
         # Inferring the correct type here is difficult with generics.
-        first_item, transitions = util.get_first_iter_element(
+        first_item, transitions = util.get_first_iter_element(  # type: ignore[assignment]
             transitions
-        )  # type: ignore[assignment]
+        )
         if isinstance(first_item, types.Trajectory):
             transitions = cast(Iterable[types.Trajectory], transitions)
             transitions = rollout.flatten_trajectories(list(transitions))

--- a/src/imitation/algorithms/base.py
+++ b/src/imitation/algorithms/base.py
@@ -243,9 +243,10 @@ def make_data_loader(
         raise ValueError(f"batch_size={batch_size} must be positive.")
 
     if isinstance(transitions, Iterable):
-         # Inferring the correct type here is difficult with generics.
-        first_item, transitions = (
-           util.get_first_iter_element(transitions)) # type: ignore[assignment]
+        # Inferring the correct type here is difficult with generics.
+        first_item, transitions = util.get_first_iter_element(
+            transitions
+        )  # type: ignore[assignment]
         if isinstance(first_item, types.Trajectory):
             transitions = cast(Iterable[types.Trajectory], transitions)
             transitions = rollout.flatten_trajectories(list(transitions))
@@ -271,6 +272,6 @@ def make_data_loader(
     elif isinstance(transitions, Iterable):
         # Safe to ignore this error since we've already coerced Iterable transitions into
         # Iterable[TransitionMapping]
-        return _WrappedDataLoader(transitions, batch_size) # type: ignore[arg-type]
+        return _WrappedDataLoader(transitions, batch_size)  # type: ignore[arg-type]
     else:
         raise TypeError(f"`demonstrations` unexpected type {type(transitions)}")

--- a/src/imitation/algorithms/base.py
+++ b/src/imitation/algorithms/base.py
@@ -182,7 +182,7 @@ class _WrappedDataLoader:
         data_loader: Iterable[TransitionMapping],
         expected_batch_size: int,
     ):
-        """Builds _WrapedDataLoader.
+        """Builds _WrappedDataLoader.
 
         Args:
             data_loader: The data loader (batch iterable) to wrap.
@@ -243,7 +243,9 @@ def make_data_loader(
         raise ValueError(f"batch_size={batch_size} must be positive.")
 
     if isinstance(transitions, Iterable):
-        first_item, transitions = util.get_first_iter_element(transitions)
+         # Inferring the correct type here is difficult with generics.
+        first_item, transitions = (
+           util.get_first_iter_element(transitions)) # type: ignore[assignment]
         if isinstance(first_item, types.Trajectory):
             transitions = cast(Iterable[types.Trajectory], transitions)
             transitions = rollout.flatten_trajectories(list(transitions))
@@ -267,6 +269,8 @@ def make_data_loader(
             **kwargs,
         )
     elif isinstance(transitions, Iterable):
-        return _WrappedDataLoader(transitions, batch_size)
+        # Safe to ignore this error since we've already coerced Iterable transitions into
+        # Iterable[TransitionMapping]
+        return _WrappedDataLoader(transitions, batch_size) # type: ignore[arg-type]
     else:
         raise TypeError(f"`demonstrations` unexpected type {type(transitions)}")

--- a/src/imitation/algorithms/base.py
+++ b/src/imitation/algorithms/base.py
@@ -248,7 +248,7 @@ def make_data_loader(
             first_item,
             transitions,
         ) = util.get_first_iter_element(  # type: ignore[assignment]
-            transitions
+            transitions,
         )
         if isinstance(first_item, types.Trajectory):
             transitions = cast(Iterable[types.Trajectory], transitions)

--- a/src/imitation/algorithms/density.py
+++ b/src/imitation/algorithms/density.py
@@ -181,7 +181,7 @@ class DensityAlgorithm(base.DemonstrationAlgorithm):
                 first_item,
                 demonstrations,
             ) = util.get_first_iter_element(  # type: ignore[assignment]
-                demonstrations
+                demonstrations,
             )
             if isinstance(first_item, types.Trajectory):
                 # we assume that all elements are also types.Trajectory.

--- a/src/imitation/algorithms/density.py
+++ b/src/imitation/algorithms/density.py
@@ -177,9 +177,9 @@ class DensityAlgorithm(base.DemonstrationAlgorithm):
             )
         elif isinstance(demonstrations, Iterable):
             # Inferring the correct type here is difficult with generics.
-            first_item, demonstrations = util.get_first_iter_element(
+            first_item, demonstrations = util.get_first_iter_element(  # type: ignore[assignment]
                 demonstrations
-            )  # type: ignore[assignment]
+            )
             if isinstance(first_item, types.Trajectory):
                 # we assume that all elements are also types.Trajectory.
                 # (this means we have timestamp information)

--- a/src/imitation/algorithms/density.py
+++ b/src/imitation/algorithms/density.py
@@ -151,10 +151,12 @@ class DensityAlgorithm(base.DemonstrationAlgorithm):
             assert next_obs_b.shape[1:] == self.venv.observation_space.shape
             assert len(next_obs_b) == len(obs_b)
 
+        if next_obs_b is not None:
+            next_obs_b_iterator: Iterable = next_obs_b
+        else:
+            next_obs_b_iterator = itertools.repeat(None)
+
         transitions: Dict[Optional[int], List[np.ndarray]] = {}
-        next_obs_b_iterator = (
-            next_obs_b if next_obs_b is not None else itertools.repeat(None)
-        )
         for obs, act, next_obs in zip(obs_b, act_b, next_obs_b_iterator):
             flat_trans = self._preprocess_transition(obs, act, next_obs)
             transitions.setdefault(None, []).append(flat_trans)
@@ -174,7 +176,9 @@ class DensityAlgorithm(base.DemonstrationAlgorithm):
                 ),
             )
         elif isinstance(demonstrations, Iterable):
-            first_item, demonstrations = util.get_first_iter_element(demonstrations)
+            # Inferring the correct type here is difficult with generics.
+            first_item, demonstrations = (
+              util.get_first_iter_element(demonstrations)) # type: ignore[assignment]
             if isinstance(first_item, types.Trajectory):
                 # we assume that all elements are also types.Trajectory.
                 # (this means we have timestamp information)

--- a/src/imitation/algorithms/density.py
+++ b/src/imitation/algorithms/density.py
@@ -177,8 +177,9 @@ class DensityAlgorithm(base.DemonstrationAlgorithm):
             )
         elif isinstance(demonstrations, Iterable):
             # Inferring the correct type here is difficult with generics.
-            first_item, demonstrations = (
-              util.get_first_iter_element(demonstrations)) # type: ignore[assignment]
+            first_item, demonstrations = util.get_first_iter_element(
+                demonstrations
+            )  # type: ignore[assignment]
             if isinstance(first_item, types.Trajectory):
                 # we assume that all elements are also types.Trajectory.
                 # (this means we have timestamp information)

--- a/src/imitation/algorithms/density.py
+++ b/src/imitation/algorithms/density.py
@@ -177,7 +177,10 @@ class DensityAlgorithm(base.DemonstrationAlgorithm):
             )
         elif isinstance(demonstrations, Iterable):
             # Inferring the correct type here is difficult with generics.
-            first_item, demonstrations = util.get_first_iter_element(  # type: ignore[assignment]
+            (
+                first_item,
+                demonstrations,
+            ) = util.get_first_iter_element(  # type: ignore[assignment]
                 demonstrations
             )
             if isinstance(first_item, types.Trajectory):

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -884,6 +884,7 @@ class SyntheticGatherer(PreferenceGatherer):
         self.logger.record("entropy", entropy)
 
         if self.sample:
+            assert(self.rng is not None)
             return self.rng.binomial(n=1, p=model_probs).astype(np.float32)
         return model_probs
 

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -884,7 +884,7 @@ class SyntheticGatherer(PreferenceGatherer):
         self.logger.record("entropy", entropy)
 
         if self.sample:
-            assert(self.rng is not None)
+            assert self.rng is not None
             return self.rng.binomial(n=1, p=model_probs).astype(np.float32)
         return model_probs
 

--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -589,7 +589,7 @@ class CnnRewardNet(RewardNet):
             rewards = th.sum(outputs * full_acts, dim=1)
         elif not self.use_action and self.use_done:
             # here we turn done into a one-hot vector.
-            dones_binary = done.type(th.LongTensor)
+            dones_binary = done.long()
             dones_one_hot = nn.functional.one_hot(dones_binary, num_classes=2)
             rewards = th.sum(outputs * dones_one_hot, dim=1)
         else:

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -102,7 +102,9 @@ def eval_policy(
         # Generate trajectories with the RL algorithm's env - SB3 may apply wrappers
         # under the hood to get it to work with the RL algorithm (e.g. transposing
         # images so they can be fed into CNNs).
-        train_env = cast(vec_env.VecEnv, rl_algo.get_env())
+        maybe_train_env = rl_algo.get_env()
+        assert maybe_train_env is not None
+        train_env = maybe_train_env
     else:
         train_env = venv
     trajs = rollout.generate_trajectories(

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -1,7 +1,7 @@
 """Common configuration elements for training imitation algorithms."""
 
 import logging
-from typing import Any, Mapping, Union
+from typing import Any, Mapping, Union, cast
 
 import sacred
 from stable_baselines3.common import base_class, policies, torch_layers, vec_env
@@ -102,7 +102,7 @@ def eval_policy(
         # Generate trajectories with the RL algorithm's env - SB3 may apply wrappers
         # under the hood to get it to work with the RL algorithm (e.g. transposing
         # images so they can be fed into CNNs).
-        train_env = rl_algo.get_env()
+        train_env = cast(vec_env.VecEnv, rl_algo.get_env())
     else:
         train_env = venv
     trajs = rollout.generate_trajectories(

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -102,9 +102,8 @@ def eval_policy(
         # Generate trajectories with the RL algorithm's env - SB3 may apply wrappers
         # under the hood to get it to work with the RL algorithm (e.g. transposing
         # images so they can be fed into CNNs).
-        maybe_train_env = rl_algo.get_env()
-        assert maybe_train_env is not None
-        train_env = maybe_train_env
+        train_env = rl_algo.get_env()
+        assert train_env is not None
     else:
         train_env = venv
     trajs = rollout.generate_trajectories(

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -1,7 +1,7 @@
 """Common configuration elements for training imitation algorithms."""
 
 import logging
-from typing import Any, Mapping, Union, cast
+from typing import Any, Mapping, Union
 
 import sacred
 from stable_baselines3.common import base_class, policies, torch_layers, vec_env

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -47,7 +47,8 @@ def save_checkpoint(
         # contains one. Currently we are slightly over-conservative, by requiring
         # that an AgentTrainer be used if we're saving the policy.
         assert isinstance(
-            trainer.trajectory_generator, preference_comparisons.AgentTrainer
+            trainer.trajectory_generator,
+            preference_comparisons.AgentTrainer,
         )
         save_model(trainer.trajectory_generator, save_path)
     else:

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -46,7 +46,9 @@ def save_checkpoint(
         # Note: We should only save the model as model.pkl if `trajectory_generator`
         # contains one. Currently we are slightly over-conservative, by requiring
         # that an AgentTrainer be used if we're saving the policy.
-        assert isinstance(trainer.trajectory_generator, preference_comparisons.AgentTrainer)
+        assert isinstance(
+            trainer.trajectory_generator, preference_comparisons.AgentTrainer
+        )
         save_model(trainer.trajectory_generator, save_path)
     else:
         trainer.logger.warn(
@@ -178,7 +180,9 @@ def train_preference_comparisons(
             # Stable Baselines will automatically occupy GPU 0 if it is available.
             # Let's use the same device as the SB3 agent for the reward model.
             reward_net = reward_net.to(agent_trainer.algorithm.device)
-            trajectory_generator: preference_comparisons.TrajectoryGenerator = agent_trainer 
+            trajectory_generator: preference_comparisons.TrajectoryGenerator = (
+                agent_trainer
+            )
         else:
             if exploration_frac > 0:
                 raise ValueError(

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -44,9 +44,9 @@ def save_checkpoint(
     th.save(trainer.model, save_path / "reward_net.pt")
     if allow_save_policy:
         # Note: We should only save the model as model.pkl if `trajectory_generator`
-        # contains one. Specifically we check if the `trajectory_generator` contains an
-        # `algorithm` attribute.
-        assert hasattr(trainer.trajectory_generator, "algorithm")
+        # contains one. Currently we are slightly over-conservative, by requiring
+        # that an AgentTrainer be used if we're saving the policy.
+        assert isinstance(trainer.trajectory_generator, preference_comparisons.AgentTrainer)
         save_model(trainer.trajectory_generator, save_path)
     else:
         trainer.logger.warn(
@@ -166,7 +166,7 @@ def train_preference_comparisons(
         if trajectory_path is None:
             # Setting the logger here is not necessary (PreferenceComparisons takes care
             # of it automatically) but it avoids creating unnecessary loggers.
-            trajectory_generator = preference_comparisons.AgentTrainer(
+            agent_trainer = preference_comparisons.AgentTrainer(
                 algorithm=agent,
                 reward_fn=reward_net,
                 venv=venv,
@@ -177,7 +177,8 @@ def train_preference_comparisons(
             )
             # Stable Baselines will automatically occupy GPU 0 if it is available.
             # Let's use the same device as the SB3 agent for the reward model.
-            reward_net = reward_net.to(trajectory_generator.algorithm.device)
+            reward_net = reward_net.to(agent_trainer.algorithm.device)
+            trajectory_generator: preference_comparisons.TrajectoryGenerator = agent_trainer 
         else:
             if exploration_frac > 0:
                 raise ValueError(


### PR DESCRIPTION
## Description
Adding more type hints to enable some of the skipped files highlighted in:
https://github.com/HumanCompatibleAI/imitation/issues/573

## Testing

* Ran mypy over all the files I'm removing from the EXCLUDE_MYPY. Ex:
mypy reward_nets.py --follow-imports=silent --show-error-codes --ignore-missing-imports

* Ran the ci/code_checks.sh linter, fixing pre-existing errors when they showed up in edited files.

* Ran the test script