### PR TITLE
Remove type ignore for `forward()` override

### DIFF
--- a/src/imitation/algorithms/mce_irl.py
+++ b/src/imitation/algorithms/mce_irl.py
@@ -178,7 +178,7 @@ class TabularPolicy(policies.BasePolicy):
     def _predict(self, observation: th.Tensor, deterministic: bool = False):
         raise NotImplementedError("Should never be called as predict overridden.")
 
-    def forward(  # type: ignore[override]
+    def forward(
         self,
         observation: th.Tensor,
         deterministic: bool = False,

--- a/src/imitation/policies/base.py
+++ b/src/imitation/policies/base.py
@@ -40,7 +40,7 @@ class HardCodedPolicy(policies.BasePolicy, abc.ABC):
     def forward(self, *args):
         # technically BasePolicy is a Torch module, so this needs a forward()
         # method
-        raise NotImplementedError()  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
 
 class RandomPolicy(HardCodedPolicy):

--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -985,7 +985,7 @@ class RewardEnsemble(RewardNetWithVariance):
 
     def forward(self, *args) -> th.Tensor:
         """The forward method of the ensemble should in general not be used directly."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def predict_processed(
         self,


### PR DESCRIPTION
## Description

Closes #553. Also removes instantiation from `NotImplementedError` from some forward calls since no error message is passed.
