### PR TITLE
docs: add Prerequisites section in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ You can find [the documentation here](https://imitation.readthedocs.io/en/latest
 ### Prerequisites
 
 - Python 3.8+
-- (Optional) OpenGL (to render gym environments)
+- (Optional) OpenGL (to render Gym environments)
+- (Optional) FFmpeg (to encode videos of renders)
 - (Optional) MuJoCo (follow instructions to install [mujoco_py v1.5 here](https://github.com/openai/mujoco-py/tree/498b451a03fb61e5bdfcb6956d8d7c881b1098b5#install-mujoco))
 
 ### Installing PyPI release

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ You can find [the documentation here](https://imitation.readthedocs.io/en/latest
 
 ## Installation
 
+### Prerequisites
+
+- Python 3.8+
+- (Optional) OpenGL (to render gym environments)
+- (Optional) MuJoCo (follow instructions to install [mujoco_py v1.5 here](https://github.com/openai/mujoco-py/tree/498b451a03fb61e5bdfcb6956d8d7c881b1098b5#install-mujoco))
+
 ### Installing PyPI release
 
 Installing the PyPI release is the standard way to use `imitation`, and the recommended way for most users.
@@ -55,10 +61,6 @@ For macOS users, some packages are required to run experiments (see `./experimen
 ```
 brew install coreutils gnu-getopt parallel
 ```
-
-### Optional Mujoco Dependency
-
-Follow instructions to install [mujoco_py v1.5 here](https://github.com/openai/mujoco-py/tree/498b451a03fb61e5bdfcb6956d8d7c881b1098b5#install-mujoco).
 
 ## CLI Quickstart
 

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -2,6 +2,21 @@
 Installation
 ============
 
+Prerequisites
+-------------
+
+- Python 3.8+
+
+- (Optional) OpenGL (to render gym environments)
+
+- (Optional) MuJoCo (follow instructions to install `mujoco\_py v1.5 here`_)
+
+.. _mujoco_py v1.5 here:
+    https://github.com/openai/mujoco-py/tree/498b451a03fb61e5bdfcb6956d8d7c881b1098b5#install-mujoco
+
+
+Installation from PyPI
+----------------------
 
 To install the latest PyPI release, simply run:
 
@@ -10,18 +25,13 @@ To install the latest PyPI release, simply run:
     pip install imitation
 
 
-Alternatively, you can install the latest version of ``imitation`` from source. This is useful if you wish to contribute to the development of ``imitation``, or if you need features that have not yet been made available in a stable release:
+Installation from source
+------------------------
+
+Installation from source is useful if you wish to contribute to the development of ``imitation``, or if you need features that have not yet been made available in a stable release:
 
 .. code-block:: bash
 
     git clone http://github.com/HumanCompatibleAI/imitation
     cd imitation
     pip install -e .
-
-
-**Optional Mujoco Dependency**
-
-Follow instructions to install `mujoco\_py v1.5 here`_.
-
-.. _mujoco_py v1.5 here:
-    https://github.com/openai/mujoco-py/tree/498b451a03fb61e5bdfcb6956d8d7c881b1098b5#install-mujoco

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -6,9 +6,8 @@ Prerequisites
 -------------
 
 - Python 3.8+
-
 - (Optional) OpenGL (to render gym environments)
-
+- (Optional) FFmpeg (to encode videos of renders)
 - (Optional) MuJoCo (follow instructions to install `mujoco\_py v1.5 here`_)
 
 .. _mujoco_py v1.5 here:


### PR DESCRIPTION
This is useful information, especially for developing, that is currently only visible in the setup file itself.

To do:
- [x] add the same information in the documentation
- [x] any other requirements that should be added? The only thing I had to check when I installed was OpenGL, but not sure whether that is essential, or just for visualisation.