### PR TITLE
Small typing fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ TESTS_REQUIRE = (
         # TODO: upgrade jupyter-client once
         #  https://github.com/jupyter/jupyter_client/issues/637 is fixed
         "jupyter-client~=6.1.12",
-        "mypy==0.971",
+        "mypy~=0.981",
         "pandas~=1.4.3",
         "pytest~=7.1.2",
         "pytest-cov~=3.0.0",

--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -15,6 +15,7 @@ from typing import (
     List,
     Mapping,
     NamedTuple,
+    NoReturn,
     Optional,
     Sequence,
     Tuple,
@@ -707,7 +708,7 @@ class ActiveSelectionFragmenter(Fragmenter):
     def uncertainty_on(self) -> str:
         return self._uncertainty_on
 
-    def raise_uncertainty_on_not_supported(self):
+    def raise_uncertainty_on_not_supported(self) -> NoReturn:
         raise ValueError(
             f"""{self.uncertainty_on} not supported.
             `uncertainty_on` should be from `logit`, `probability`, or `label`""",


### PR DESCRIPTION
## Description

This fixes some typing issues that arose on a fresh install:

- pytype fails in `preference_comparison.py`: https://github.com/HumanCompatibleAI/imitation/blob/944edce059d2278324b105df6b453a1be039440d/src/imitation/algorithms/preference_comparisons.py#L773 since `var_estimate` is defined in the previous code branches, except one, which calls `raise_uncertainty_on_not_supported` which raises an error, and this requires an explicit type annotation to indicate that
- mypy should be updated to version 0.981 since we don't target Python 3.7 (ref https://github.com/python/mypy/pull/13500)

This is a very small PR, so I can add more typing fixes where I notice them to add some more substance, if desired.

## Testing

`ci/code_checks.sh`, which failed on a fresh install, now passes
