### PR TITLE
Replace `OrderedDict` with `dict` where possible.

### DIFF
--- a/src/imitation/algorithms/adversarial/common.py
+++ b/src/imitation/algorithms/adversarial/common.py
@@ -1,19 +1,8 @@
 """Core code for adversarial imitation learning, shared between GAIL and AIRL."""
 import abc
-import collections
 import dataclasses
 import logging
-from typing import (
-    Callable,
-    Iterable,
-    Iterator,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    overload,
-)
+from typing import Callable, Iterable, Iterator, Mapping, Optional, Type, overload
 
 import numpy as np
 import torch as th
@@ -81,23 +70,20 @@ def compute_train_stats(
         label_dist = th.distributions.Bernoulli(logits=disc_logits_expert_is_high)
         entropy = th.mean(label_dist.entropy())
 
-    pairs = [
-        ("disc_loss", float(th.mean(disc_loss))),
-        # accuracy, as well as accuracy on *just* expert examples and *just*
-        # generated examples
-        ("disc_acc", float(acc)),
-        ("disc_acc_expert", float(expert_acc)),
-        ("disc_acc_gen", float(generated_acc)),
+    return {
+        "disc_loss": float(th.mean(disc_loss)),
+        "disc_acc": float(acc),
+        "disc_acc_expert": float(expert_acc),  # accuracy on just expert examples
+        "disc_acc_gen": float(generated_acc),  # accuracy on just generated examples
         # entropy of the predicted label distribution, averaged equally across
         # both classes (if this drops then disc is very good or has given up)
-        ("disc_entropy", float(entropy)),
+        "disc_entropy": float(entropy),
         # true number of expert demos and predicted number of expert demos
-        ("disc_proportion_expert_true", float(pct_expert)),
-        ("disc_proportion_expert_pred", float(pct_expert_pred)),
-        ("n_expert", float(n_expert)),
-        ("n_generated", float(n_generated)),
-    ]  # type: Sequence[Tuple[str, float]]
-    return collections.OrderedDict(pairs)
+        "disc_proportion_expert_true": float(pct_expert),
+        "disc_proportion_expert_pred": float(pct_expert_pred),
+        "n_expert": float(n_expert),
+        "n_generated": float(n_generated),
+    }
 
 
 class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):

--- a/src/imitation/util/networks.py
+++ b/src/imitation/util/networks.py
@@ -3,7 +3,7 @@ import abc
 import collections
 import contextlib
 import functools
-from typing import Iterable, Optional, OrderedDict, Type, Union
+from typing import Dict, Iterable, Optional, Type, Union
 
 import torch as th
 from torch import nn
@@ -234,7 +234,7 @@ def build_mlp(
     Raises:
         ValueError: if squeeze_output was supplied with out_size!=1.
     """
-    layers: OrderedDict[str, nn.Module] = collections.OrderedDict()
+    layers: Dict[str, nn.Module] = {}
 
     if name is None:
         prefix = ""
@@ -273,7 +273,7 @@ def build_mlp(
             raise ValueError("squeeze_output is only applicable when out_size=1")
         layers[f"{prefix}squeeze"] = SqueezeLayer()
 
-    model = nn.Sequential(layers)
+    model = nn.Sequential(collections.OrderedDict(layers))
 
     return model
 
@@ -316,7 +316,7 @@ def build_cnn(
     Raises:
         ValueError: if squeeze_output was supplied with out_size!=1.
     """
-    layers: OrderedDict[str, nn.Module] = collections.OrderedDict()
+    layers: Dict[str, nn.Module] = {}
 
     if name is None:
         prefix = ""
@@ -348,5 +348,5 @@ def build_cnn(
             raise ValueError("squeeze_output is only applicable when out_size=1")
         layers[f"{prefix}squeeze"] = SqueezeLayer()
 
-    model = nn.Sequential(layers)
+    model = nn.Sequential(collections.OrderedDict(layers))
     return model


### PR DESCRIPTION
## Description

Since Python 3.7, `dict` is guaranteed to preserve insertion order. This makes `OrderedDict` mostly redundant, except where:
- it is used as an argument to `torch.nn.Sequential` which only accepts `OrderedDict`
- equality in insertion order matters (`dict` compares equally if the items are the same, regardless of the order they are inserted)

## Testing

All tests still pass.
