### PR TITLE
Fix flakiness in test_trajectory_dataset_shuffle

### DIFF
--- a/tests/algorithms/test_preference_comparisons.py
+++ b/tests/algorithms/test_preference_comparisons.py
@@ -1,5 +1,6 @@
 """Tests for the preference comparisons reward learning implementation."""
 
+import math
 import re
 from typing import Sequence
 
@@ -171,10 +172,15 @@ def test_trajectory_dataset_shuffle(
         cartpole_expert_trajectories,
         rng,
     )
-    sample = dataset.sample(num_steps)
-    sample2 = dataset.sample(num_steps)
+    n_trajectories = len(cartpole_expert_trajectories)
+    flakiness_prob = 1 / n_trajectories
+    max_flakiness = 1e-6
+    # Choose num_samples s.t. flakiness_prob**num_samples <= max_flakiness
+    num_samples = math.ceil(math.log(max_flakiness) / math.log(flakiness_prob))
+    samples = [dataset.sample(num_steps) for _ in range(num_samples)]
     with pytest.raises(AssertionError):
-        _check_trajs_equal(sample, sample2)
+        for sample in samples[1:]:
+            _check_trajs_equal(samples[0], sample)
 
 
 def test_transitions_left_in_buffer(agent_trainer):


### PR DESCRIPTION
## Description

test_trajectory_dataset_shuffle samples twice from a `TrajectoryDataset` and checks they're not equal. There is a `1/number_of_trajectories` chance of sampling the same trajectory twice. In our case the number of trajectories is 60, and we run this test multiple times in different configs, so it was failing in around 10% of cases.

This PR instead samples repeatedly and checks if any of them are different, ensuring flakiness below a threshold.

Main issues I can see with this change: (a) it only really tests the sampling isn't deterministic; if it was very "sticky" the test would often pass because of the repeated sampling; (b) it feels perhaps a bit overengineered with the num_samples calculation, but anything else I felt might break if we change the number of expert trajectories later.

## Testing

I ran the test 1000x and confirmed it always passed so is no longer flaky.