### PR TITLE
Add line about dev dependencies in getting-started/installation

### DIFF
--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -38,4 +38,5 @@ Installation from source is useful if you wish to contribute to the development 
 There are also a number of dependencies used for running tests and building the documentation, which can be installed with:
 
 .. code-block:: bash
+
     pip install -e ".[dev]"

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -34,3 +34,8 @@ Installation from source is useful if you wish to contribute to the development 
     git clone http://github.com/HumanCompatibleAI/imitation
     cd imitation
     pip install -e .
+
+There are also a number of dependencies used for running tests and building the documentation, which can be installed with:
+
+.. code-block:: bash
+    pip install -e ".[dev]"


### PR DESCRIPTION
## Description

Add a line explaining how to install the optional dependencies used for running tests and generating docs.

This is somewhat redundant with the README (which also mentions this). I didn't think to look in the README and had some issues when running the tests as a result, so maybe this'll help other folks in my boat

## Testing

Confirmed that this is roughly what I wanted by looking at the docs:
https://imitation--608.org.readthedocs.build/en/608/getting-started/installation.html
