### PR TITLE
Add default config for cnn policies

### DIFF
--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -41,8 +41,7 @@ def sac():
 def normalize_disable():
     policy_kwargs = {  # noqa: F841
         # FlattenExtractor is the default for SB3; but we specify it here
-        # explicitly as no entry will be set to normalization by default
-        # via the config hook.
+        # explicitly
         "features_extractor_class": torch_layers.FlattenExtractor,
     }
 

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -37,15 +37,6 @@ def sac():
     policy_cls = base.SAC1024Policy  # noqa: F841
 
 
-@train_ingredient.named_config
-def normalize_disable():
-    policy_kwargs = {  # noqa: F841
-        # FlattenExtractor is the default for SB3; but we specify it here
-        # explicitly
-        "features_extractor_class": torch_layers.FlattenExtractor,
-    }
-
-
 NORMALIZE_RUNNING_POLICY_KWARGS = {
     "features_extractor_class": base.NormalizeFeaturesExtractor,
     "features_extractor_kwargs": {

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Mapping, Union
 
 import sacred
-from stable_baselines3.common import base_class, policies, torch_layers, vec_env
+from stable_baselines3.common import base_class, policies, vec_env
 
 import imitation.util.networks
 from imitation.data import rollout

--- a/src/imitation/scripts/common/train.py
+++ b/src/imitation/scripts/common/train.py
@@ -60,13 +60,10 @@ def normalize_running():
     policy_kwargs = NORMALIZE_RUNNING_POLICY_KWARGS  # noqa: F841
 
 
-@train_ingredient.config_hook
-def config_hook(config, command_name, logger):
-    """Sets defaults equivalent to `normalize_running`."""
-    del command_name, logger
-    if "features_extractor_class" not in config["train"]["policy_kwargs"]:
-        return {"policy_kwargs": NORMALIZE_RUNNING_POLICY_KWARGS}
-    return {}
+# Default config for CNN Policies
+@train_ingredient.named_config
+def cnn_policy():
+    policy_cls = policies.ActorCriticCnnPolicy  # noqa: F841
 
 
 @train_ingredient.capture

--- a/src/imitation/scripts/config/train_rl.py
+++ b/src/imitation/scripts/config/train_rl.py
@@ -1,8 +1,6 @@
 """Configuration settings for train_rl, training a policy with RL."""
 
 import sacred
-from stable_baselines3.common.torch_layers import NatureCNN
-from stable_baselines3.ppo import CnnPolicy
 
 from imitation.scripts.common import common, rl, train
 
@@ -44,16 +42,6 @@ def default_end_cond(rollout_save_n_timesteps, rollout_save_n_episodes):
     # without getting an error that `rollout_save_n_timesteps is not None`.
     if rollout_save_n_timesteps is None and rollout_save_n_episodes is None:
         rollout_save_n_timesteps = 2000  # Min timesteps saved per file, optional.
-
-
-# Default config for CNN Policies
-@train_rl_ex.named_config
-def cnn_policy():
-    train = dict(
-        policy_cls=CnnPolicy,
-        policy_kwargs=dict(features_extractor_class=NatureCNN),
-    )
-    locals()  # make flake8 happy
 
 
 # Standard Gym env configs

--- a/src/imitation/scripts/config/train_rl.py
+++ b/src/imitation/scripts/config/train_rl.py
@@ -1,6 +1,8 @@
 """Configuration settings for train_rl, training a policy with RL."""
 
 import sacred
+from stable_baselines3.common.torch_layers import NatureCNN
+from stable_baselines3.ppo import CnnPolicy
 
 from imitation.scripts.common import common, rl, train
 
@@ -42,6 +44,16 @@ def default_end_cond(rollout_save_n_timesteps, rollout_save_n_episodes):
     # without getting an error that `rollout_save_n_timesteps is not None`.
     if rollout_save_n_timesteps is None and rollout_save_n_episodes is None:
         rollout_save_n_timesteps = 2000  # Min timesteps saved per file, optional.
+
+
+# Default config for CNN Policies
+@train_rl_ex.named_config
+def cnn_policy():
+    train = dict(
+        policy_cls=CnnPolicy,
+        policy_kwargs=dict(features_extractor_class=NatureCNN),
+    )
+    locals()  # make flake8 happy
 
 
 # Standard Gym env configs

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -487,7 +487,7 @@ def _check_train_ex_result(result: dict):
     (
         [],
         ["train.normalize_running", "reward.normalize_input_running"],
-        ["train.normalize_disable", "reward.normalize_input_disable"],
+        ["reward.normalize_input_disable"],
     ),
 )
 @pytest.mark.parametrize("command", ("airl", "gail"))

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -730,20 +730,20 @@ def test_train_rl_cnn_policy(tmpdir: str, rng):
         parallel=False,
         rng=rng,
     )
-    print(venv)
     net = reward_nets.CnnRewardNet(venv.observation_space, venv.action_space)
     tmppath = os.path.join(tmpdir, "reward.pt")
     th.save(net, tmppath)
 
     log_dir_data = os.path.join(tmpdir, "train_rl")
-    with pytest.warns(RuntimeWarning):
-        train_rl.train_rl_ex.run(
-            named_configs=["train.cnn_policy"] + ALGO_FAST_CONFIGS["rl"],
-            config_updates=dict(
-                common=dict(log_dir=log_dir_data, env_name="AsteroidsNoFrameskip-v4"),
-                reward_path=tmppath,
-            ),
-        )
+    run = train_rl.train_rl_ex.run(
+        named_configs=["train.cnn_policy"] + ALGO_FAST_CONFIGS["rl"],
+        config_updates=dict(
+            common=dict(log_dir=log_dir_data, env_name="AsteroidsNoFrameskip-v4"),
+            reward_path=tmppath,
+        ),
+    )
+    assert run.status == "COMPLETED"
+    assert isinstance(run.result, dict)
 
 
 PARALLEL_CONFIG_UPDATES = [

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -723,6 +723,29 @@ def test_train_rl_double_normalization(tmpdir: str, rng):
         )
 
 
+def test_train_rl_cnn_policy(tmpdir: str, rng):
+    venv = util.make_vec_env(
+        "AsteroidsNoFrameskip-v4",
+        n_envs=1,
+        parallel=False,
+        rng=rng,
+    )
+    print(venv)
+    net = reward_nets.CnnRewardNet(venv.observation_space, venv.action_space)
+    tmppath = os.path.join(tmpdir, "reward.pt")
+    th.save(net, tmppath)
+
+    log_dir_data = os.path.join(tmpdir, "train_rl")
+    with pytest.warns(RuntimeWarning):
+        train_rl.train_rl_ex.run(
+            named_configs=["train.cnn_policy"] + ALGO_FAST_CONFIGS["rl"],
+            config_updates=dict(
+                common=dict(log_dir=log_dir_data, env_name="AsteroidsNoFrameskip-v4"),
+                reward_path=tmppath,
+            ),
+        )
+
+
 PARALLEL_CONFIG_UPDATES = [
     dict(
         sacred_ex_name="train_rl",


### PR DESCRIPTION
## Description

Adds a default configuration option for CNN policies, addressing #549 

## Testing

Tested with following command: 
`python -m imitation.scripts.train_rl with common.env_name=AsteroidsNoFrameskip-v4 train.cnn_policy`
