### PR TITLE
Copy doc string to suppress mypy type error.

### DIFF
--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -318,7 +318,7 @@ class PredictProcessedWrapper(RewardNetWrapper):
         next_state: th.Tensor,
         done: th.Tensor,
     ) -> th.Tensor:
-        __doc__ = super().forward.__doc__  # noqa: F841
+        __doc__ = super().forward.__doc__  # type: ignore[safe-super] # noqa: F841
         return self.base.forward(state, action, next_state, done)
 
     @abc.abstractmethod

--- a/src/imitation/rewards/reward_nets.py
+++ b/src/imitation/rewards/reward_nets.py
@@ -318,7 +318,7 @@ class PredictProcessedWrapper(RewardNetWrapper):
         next_state: th.Tensor,
         done: th.Tensor,
     ) -> th.Tensor:
-        __doc__ = super().forward.__doc__  # type: ignore[safe-super] # noqa: F841
+        """Compute rewards for a batch of transitions and keep gradients."""
         return self.base.forward(state, action, next_state, done)
 
     @abc.abstractmethod


### PR DESCRIPTION
## Description

mypy is a little overly worried about using abstract function calls, even to just grab the doc string. Copying the doc string makes this not a problem.

## Testing

Ran mypy on it, noticed that this was failing in circleci previously.