### PR TITLE
Refactor circleci to reuse commands from precommit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ jobs:
             rm -rf shellcheck-stable
             chmod a+x /usr/local/bin/shellcheck
 
+      # TODO can this be combined?
       - shellcheck/check:
           dir: .
           # Orb invokes shellcheck once per file. shellcheck complains if file
@@ -231,7 +232,7 @@ jobs:
 
       - run:
           name: ipynb-check
-          command: ./ci/clean_notebooks.py --check ./docs/tutorials
+          command: pre-commit run --all check-notebooks
 
       - run:
           name: typeignore-check
@@ -244,11 +245,19 @@ jobs:
 
       - run:
           name: black
-          command: black --version && black --check --diff ${SRC_FILES}
+          # Unsure if removing the --diff arg is OK here
+          command: |
+            pre-commit run --all black
+            pre-commit run --all black-jupyter
+
+      - run:
+          name: isort 
+          command: pre-commit run --all isort
 
       - run:
           name: codespell
-          command: codespell -I .codespell.skip --skip='*.pyc,tests/testdata/*,*.ipynb,*.csv' ${SRC_FILES}
+          # How to pass SRC files?
+          command: pre-commit run --all codespell
 
   doctest:
     executor: static-analysis-medium
@@ -270,11 +279,11 @@ jobs:
 
       - run:
           name: pytype
-          command: pytype --version && pytype -j "${NUM_CPUS}" ${SRC_FILES[@]}
+          command: pytype --version && pre-commit run --all pytype
 
       - run:
           name: mypy
-          command: mypy --version && mypy ${SRC_FILES[@]} --follow-imports=silent --show-error-codes
+          command: mypy --version && pre-commit run --all mypy
 
   unit-test-linux:
     executor: unit-test-linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   codecov: codecov/codecov@3.2.3
+  shellcheck: circleci/shellcheck@3.1.2
   win: circleci/windows@4.1
 
 defaults: &defaults
@@ -212,9 +213,16 @@ jobs:
     steps:
       - dependencies-linux
 
-      - run:
-          name: shellcheck-check
-          command: pre-commit run --all shellcheck
+      # We use the shellcheck orb for this, not pre-commit, as the pre-commit
+      # hook for shellcheck needs Docker. Running Docker-in-Docker on CircleCI
+      # is technically possible (https://circleci.com/docs/building-docker-images/)
+      # but more complex than just using the orb.
+      - shellcheck/check:
+          dir: .
+          # Orb invokes shellcheck once per file. shellcheck complains if file
+          # includes another file not given on the command line. Ignore this,
+          # since they'll just get checked in a separate shellcheck invocation.
+          exclude: SC1091
 
       - run:
           name: ipynb-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,6 @@ jobs:
             rm -rf shellcheck-stable
             chmod a+x /usr/local/bin/shellcheck
 
-      # TODO can this be combined?
       - shellcheck/check:
           dir: .
           # Orb invokes shellcheck once per file. shellcheck complains if file
@@ -241,12 +240,14 @@ jobs:
       - run:
           name: flake8
           # How to pass num CPUs here?
-          command: pre-commit run --all flake8
+          command: |
+            flake8 --version
+            pre-commit run --all flake8
 
       - run:
           name: black
-          # Unsure if removing the --diff arg is OK here
           command: |
+            black --version
             pre-commit run --all black
             pre-commit run --all black-jupyter
 
@@ -256,7 +257,6 @@ jobs:
 
       - run:
           name: codespell
-          # How to pass SRC files?
           command: pre-commit run --all codespell
 
   doctest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,6 @@ jobs:
 
       - run:
           name: flake8
-          # How to pass num CPUs here?
           command: |
             flake8 --version
             pre-commit run --all flake8
@@ -258,6 +257,14 @@ jobs:
       - run:
           name: codespell
           command: pre-commit run --all codespell
+
+      - run:
+          name: lint-misc
+          command: |
+            pre-commit run --all check-ast
+            pre-commit run --all trailing-whitespace 
+            pre-commit run --all end-of-file-fixer 
+            pre-commit run --all check-toml 
 
   doctest:
     executor: static-analysis-medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   codecov: codecov/codecov@3.2.3
-  shellcheck: circleci/shellcheck@2.2.4
   win: circleci/windows@4.1
 
 defaults: &defaults
@@ -214,20 +213,8 @@ jobs:
       - dependencies-linux
 
       - run:
-          name: install shellcheck
-          command: |
-            curl -Lo /tmp/shellcheck.tar.xz https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz
-            tar -x shellcheck-stable/shellcheck -f /tmp/shellcheck.tar.xz
-            mv shellcheck-stable/shellcheck /usr/local/bin/shellcheck
-            rm -rf shellcheck-stable
-            chmod a+x /usr/local/bin/shellcheck
-
-      - shellcheck/check:
-          dir: .
-          # Orb invokes shellcheck once per file. shellcheck complains if file
-          # includes another file not given on the command line. Ignore this,
-          # since they'll just get checked in a separate shellcheck invocation.
-          exclude: SC1091
+          name: shellcheck-check
+          command: pre-commit run --all shellcheck
 
       - run:
           name: ipynb-check
@@ -265,6 +252,7 @@ jobs:
             pre-commit run --all trailing-whitespace
             pre-commit run --all end-of-file-fixer
             pre-commit run --all check-toml
+            pre-commit run --all check-added-large-files
 
   doctest:
     executor: static-analysis-medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,7 @@ jobs:
       # hook for shellcheck needs Docker. Running Docker-in-Docker on CircleCI
       # is technically possible (https://circleci.com/docs/building-docker-images/)
       # but more complex than just using the orb.
+      - shellcheck/install
       - shellcheck/check:
           dir: .
           # Orb invokes shellcheck once per file. shellcheck complains if file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,8 @@ jobs:
 
       - run:
           name: flake8
-          command: flake8 --version && flake8 -j "${NUM_CPUS}" ${SRC_FILES}
+          # How to pass num CPUs here?
+          command: pre-commit run --all flake8 -j "${NUM_CPUS}"
 
       - run:
           name: black

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
             pre-commit run --all black-jupyter
 
       - run:
-          name: isort 
+          name: isort
           command: pre-commit run --all isort
 
       - run:
@@ -262,9 +262,9 @@ jobs:
           name: lint-misc
           command: |
             pre-commit run --all check-ast
-            pre-commit run --all trailing-whitespace 
-            pre-commit run --all end-of-file-fixer 
-            pre-commit run --all check-toml 
+            pre-commit run --all trailing-whitespace
+            pre-commit run --all end-of-file-fixer
+            pre-commit run --all check-toml
 
   doctest:
     executor: static-analysis-medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
       - run:
           name: flake8
           # How to pass num CPUs here?
-          command: pre-commit run --all flake8 -j "${NUM_CPUS}"
+          command: pre-commit run --all flake8
 
       - run:
           name: black

--- a/.codespell.skip
+++ b/.codespell.skip
@@ -1,3 +1,0 @@
-ith
-reacher
-iff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,11 +37,10 @@ repos:
   rev: v0.8.0
   hooks:
   - id: shellcheck
-  # Orb invokes shellcheck once per file. shellcheck complains if file
-  # includes another file not given on the command line. Ignore this,
-  # since they'll just get checked in a separate shellcheck invocation.
-    exclude: SC1091
-    types: [bash]
+  # precommit invokes shellcheck once per file. shellcheck complains if file
+  # includes another file not given on the command line. Ignore this, since
+  # they'll just get checked in a separate shellcheck invocation.
+    args: ["-e", "SC1091"]
 # Misc
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   rev: v2.2.2
   hooks:
   - id: codespell
-    args: ["--skip=*.pyc,tests/testdata/*,*.ipynb,*.csvi --ignore-words-list=reacher"]
+    args: ["--skip=*.pyc,tests/testdata/*,*.ipynb,*.csvi","--ignore-words-list=reacher"]
 - repo: https://github.com/syntaqx/git-hooks
   rev: v0.0.17
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   rev: v2.2.2
   hooks:
   - id: codespell
-    args: ["--skip=*.pyc,tests/testdata/*,*.ipynb,*.csvi","--ignore-words-list=reacher"]
+    args: ["--skip=*.pyc,tests/testdata/*,*.ipynb,*.csv","--ignore-words-list=reacher"]
 - repo: https://github.com/syntaqx/git-hooks
   rev: v0.0.17
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
     name: pytype
     language: system
     types: [python]
-    entry: pytype -j auto
+    entry: "bash -c 'pytype -j ${NUM_CPUS:-auto}'"
     require_serial: true
     verbose: true
   - id: docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   rev: v2.2.2
   hooks:
   - id: codespell
-    args: ["--skip=*.pyc,tests/testdata/*,*.ipynb,*.csv"]
+    args: ["--skip=*.pyc,tests/testdata/*,*.ipynb,*.csvi --ignore-words-list=reacher"]
 - repo: https://github.com/syntaqx/git-hooks
   rev: v0.0.17
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,17 @@ repos:
   rev: v0.8.0
   hooks:
   - id: shellcheck
+  # Orb invokes shellcheck once per file. shellcheck complains if file
+  # includes another file not given on the command line. Ignore this,
+  # since they'll just get checked in a separate shellcheck invocation.
+    exclude: SC1091
+    types: [bash]
 # Misc
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.2
   hooks:
   - id: codespell
-    args: ["--skip=*.pyc,tests/testdata/*,*.ipynb,*.csv","--ignore-words-list=reacher"]
+    args: ["--skip=*.pyc,tests/testdata/*,*.ipynb,*.csv","--ignore-words-list=reacher,ith,iff"]
 - repo: https://github.com/syntaqx/git-hooks
   rev: v0.0.17
   hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -q \
     && apt-get install -y --no-install-recommends \
     build-essential \
+    curl \
     wget \
     ffmpeg \
     git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -q \
     && apt-get install -y --no-install-recommends \
     build-essential \
-    curl \
+    wget \
     ffmpeg \
     git \
     libgl1-mesa-dev \


### PR DESCRIPTION
## Description

Run various hooks in circleci via calling them through precommit. This should reduce the likelihood that there is a divergence between the two.
https://github.com/HumanCompatibleAI/imitation/issues/605

It's somewhat difficult to pass the arguments as we'd like to, due to:
https://github.com/pre-commit/pre-commit/issues/2083

To get around this, we directly rely on NUM_CPUS in the bash call to pytype. For flake8, we instead allow the existing flake8 parallelism to work w/o specifying --j.

## Testing

Confirmed that circleci continues to pass, and ran the hooks locally.
