### PR TITLE
Actually check RuntimeWarning message

### DIFF
--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -711,7 +711,10 @@ def test_train_rl_double_normalization(tmpdir: str, rng):
     th.save(net, tmppath)
 
     log_dir_data = os.path.join(tmpdir, "train_rl")
-    with pytest.warns(RuntimeWarning) as record:
+    with pytest.warns(
+        RuntimeWarning,
+        match=r"Applying normalization to already normalized reward function.*",
+    ):
         train_rl.train_rl_ex.run(
             named_configs=["cartpole"] + ALGO_FAST_CONFIGS["rl"],
             config_updates=dict(
@@ -721,16 +724,6 @@ def test_train_rl_double_normalization(tmpdir: str, rng):
                 reward_path=tmppath,
             ),
         )
-
-    filtered_warnings = filter(
-        lambda warning: warning.message.args[  # type: ignore[union-attr, arg-type]
-            0
-        ].startswith(
-            "Applying normalization to already normalized reward function.",
-        ),
-        record,
-    )
-    assert len(list(filtered_warnings)) == 1
 
 
 def test_train_rl_cnn_policy(tmpdir: str, rng):

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -711,7 +711,7 @@ def test_train_rl_double_normalization(tmpdir: str, rng):
     th.save(net, tmppath)
 
     log_dir_data = os.path.join(tmpdir, "train_rl")
-    with pytest.warns(RuntimeWarning):
+    with pytest.warns(RuntimeWarning) as record:
         train_rl.train_rl_ex.run(
             named_configs=["cartpole"] + ALGO_FAST_CONFIGS["rl"],
             config_updates=dict(
@@ -721,6 +721,16 @@ def test_train_rl_double_normalization(tmpdir: str, rng):
                 reward_path=tmppath,
             ),
         )
+
+    filtered_warnings = filter(
+        lambda warning: warning.message.args[  # type: ignore[union-attr, arg-type]
+            0
+        ].startswith(
+            "Applying normalization to already normalized reward function.",
+        ),
+        record,
+    )
+    assert len(list(filtered_warnings)) == 1
 
 
 def test_train_rl_cnn_policy(tmpdir: str, rng):


### PR DESCRIPTION
## Description
Solves #614, adding a better check for the Runtime Warning in `test_scripts.py:test_train_rl_double_normalization`. 

## Testing
Tested locally.
