### PR TITLE
Add test for reward trainers improving agent

### DIFF
--- a/tests/algorithms/test_preference_comparisons.py
+++ b/tests/algorithms/test_preference_comparisons.py
@@ -1094,7 +1094,7 @@ def test_that_trainer_improves_agent(
     )
 
     # Train for a while, expecting the agent to have improved.
-    main_trainer.train(100, 20)
+    main_trainer.train(1000, 20)
 
     trained_rewards, _ = evaluation.evaluate_policy(
         agent_trainer.algorithm.policy,


### PR DESCRIPTION
## Description

Adds a test that BasicRewardTrainer and EnsembleRewardTrainer improve the performance of an agent when train is called.

## Testing

Ran the test with --flakefinder to see how long this needs to train before we can confidently expect reward to have improved. Training for (500, 20) was still fairly flaky with 3/80 flakes, but at (1000, 20) I didn't get any flakes when run over 100 tests.
