### PR TITLE
Require files to be changed before running publish to PyPi

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,7 +2,12 @@
 
 name: Publish imitation distributions 📦 to PyPI and TestPyPI
 
-on: push
+on:
+  push:
+    paths:
+      # This requires that 'some' file is changed, to avoid running
+      # on new branch creation.
+      - '**'
 
 jobs:
   build-n-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,10 +3,14 @@
 name: Publish imitation distributions 📦 to PyPI and TestPyPI
 
 on:
+  # This requires that some file is changed, to avoid running
+  # on new branch creation, when it would fail.
+  # Both 'branches' and 'paths' need to be specified here, per:
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
   push:
+    branches:
+      - '**'
     paths:
-      # This requires that 'some' file is changed, to avoid running
-      # on new branch creation.
       - '**'
 
 jobs:


### PR DESCRIPTION
## Description

When creating a new branch, this workflow runs but will fail. The leading theory is that this is caused by the branch having the same hash, due to no files being changed.

By only running this on pushes that actually change a file, this should skip the run on new branch creation.

## Testing

I created another branch on top of this one (dpandori_quiet_test), and I confirmed that there was no workflow running for it.

Then, to test that it still works when you actually made an edit, I made an arbitrary edit, pushed, and confirmed that the workflow ran.
