### PR TITLE
Remove cause of possible flakiness of tests when executing train_rl in parallel

### DIFF
--- a/src/imitation/scripts/parallel.py
+++ b/src/imitation/scripts/parallel.py
@@ -176,7 +176,6 @@ def _ray_tune_sacred_wrapper(
             "train_adversarial": train_adversarial_ex,
         }
         ex = experiments[sacred_ex_name]
-        ex.observers = [FileStorageObserver("sacred")]
 
         # Apply base configs to get modified `named_configs` and `config_updates`.
         named_configs = base_named_configs + run_kwargs["named_configs"]
@@ -190,7 +189,10 @@ def _ray_tune_sacred_wrapper(
             if k not in updated_run_kwargs:
                 updated_run_kwargs[k] = v
 
-        run = ex.run(**updated_run_kwargs, options={"--run": run_name})
+        run = ex.run(
+            **updated_run_kwargs,
+            options={"--run": run_name, "--file_storage": "sacred"},
+        )
 
         # Ray Tune has a string formatting error if raylet completes without
         # any calls to `reporter`.


### PR DESCRIPTION
## Description

Remove modification to experiment adding observer for running experiments in parallel, reducing flakiness of tests ran in parallel. Related to #551 

## Testing

Tested locally

@AdamGleave I wasn't able to reliably repro this issue but I figured it made sense to make the modification we discussed earlier anyway. I think it's maybe reasonable to hold off on merging this until we have more solid evidence that there's an issue, here, though it does seem like the previous code could have led to issues.
