### PR TITLE
Bugfix: upload new release to PyPI on version tag push

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - '**'
+    tags:
+      - 'v**'
     paths:
       - '**'
 


### PR DESCRIPTION
## Description

https://github.com/HumanCompatibleAI/imitation/actions/runs/3559530321/jobs/5978943100 did not publish PyPI package since there was no version tag at the point the PR was merged, and it does not rerun when tag is created after https://github.com/HumanCompatibleAI/imitation/pull/623

This PR changes the workflow to also run on tag creation as well as when files are changed.

## Testing

Pointed v0.3.2 tag to this PR to verify it was uploaded.