### PR TITLE
Fix missing version error in python-req Docker build stage (fixes #641)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,12 @@ COPY ./setup.py ./setup.py
 COPY ./README.md ./README.md
 COPY ./src/imitation/__init__.py ./src/imitation/__init__.py
 COPY ci/build_and_activate_venv.sh ./ci/build_and_activate_venv.sh
-RUN    ci/build_and_activate_venv.sh /venv \
+
+# Passing version as an ARG because .git is missing inside Docker container and
+# setuptools-scm cannot determine version automatically. Can be supplied at build time
+# with `--build-arg "IMITATION_VERSION=$(python setup.py --version)"`
+ARG IMITATION_VERSION=1
+RUN SETUPTOOLS_SCM_PRETEND_VERSION="$IMITATION_VERSION" ci/build_and_activate_venv.sh /venv \
     && rm -rf $HOME/.cache/pip
 
 # full stage contains everything.

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,11 +59,11 @@ COPY ./README.md ./README.md
 COPY ./src/imitation/__init__.py ./src/imitation/__init__.py
 COPY ci/build_and_activate_venv.sh ./ci/build_and_activate_venv.sh
 
-# Passing version as an ARG because .git is missing inside Docker container and
-# setuptools-scm cannot determine version automatically. Can be supplied at build time
-# with `--build-arg "IMITATION_VERSION=$(python setup.py --version)"`
-ARG IMITATION_VERSION=1
-RUN SETUPTOOLS_SCM_PRETEND_VERSION="$IMITATION_VERSION" ci/build_and_activate_venv.sh /venv \
+# Pass mock value for version because .git is not present in the Docker container
+# at this stage, so setuptools-scm cannot determine version automatically.
+# setuptools-scm will compute it correctly when it comes to building and installing
+# imitation, as .git will then be present.
+RUN SETUPTOOLS_SCM_PRETEND_VERSION="dummy" ci/build_and_activate_venv.sh /venv \
     && rm -rf $HOME/.cache/pip
 
 # full stage contains everything.

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ ENV LANG C.UTF-8
 # Set the PATH to the venv before we create the venv, so it's visible in base.
 # This is since we may create the venv outside of Docker, e.g. in CI
 # or by binding it in for local development.
+ENV VIRTUAL_ENV=/venv
 ENV PATH="/venv/bin:$PATH"
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
 

--- a/ci/build_and_activate_venv.sh
+++ b/ci/build_and_activate_venv.sh
@@ -20,5 +20,5 @@ fi
 virtualenv -p ${python_version} ${venv}
 # shellcheck disable=SC1090,SC1091
 source ${venv}/bin/activate
-python -m pip install --upgrade pip
+python -m pip install --upgrade pip setuptools>=45
 pip install ".[docs,parallel,test]"


### PR DESCRIPTION
## Description
Fix the problem described in #641:
* Enforce compatible setuptools version
* Provide version to setuptools-scm explicitly, because it cannot determine version on its own inside container where `.git/` is missing

Also added VIRTUAL_ENV to be fully compatible with the way virtualenv is [normally activated](https://stackoverflow.com/questions/48561981/activate-python-virtualenv-in-dockerfile).

## Testing
`docker build  --platform linux/amd64 -t imitation .` now succeeds and (at least some) tests can be executed inside a container from the produced image.
