### PR TITLE
Fix variable-horizon link to docs

### DIFF
--- a/src/imitation/algorithms/base.py
+++ b/src/imitation/algorithms/base.py
@@ -102,7 +102,7 @@ class BaseImitationAlgorithm(abc.ABC):
                 f"Episodes of different length detected: {horizons}. "
                 "Variable horizon environments are discouraged -- "
                 "termination conditions leak information about reward. See "
-                "https://imitation.readthedocs.io/en/latest/guide/variable_horizon.html"
+                "https://imitation.readthedocs.io/en/latest/getting-started/variable-horizon.html"
                 " for more information. If you are SURE you want to run imitation on a "
                 "variable horizon task, then please pass in the flag: "
                 "`allow_variable_horizon=True`.",
@@ -154,7 +154,7 @@ class DemonstrationAlgorithm(BaseImitationAlgorithm, Generic[TransitionKind]):
                 training. If True, overrides this safety check. WARNING: variable
                 horizon episodes leak information about the reward via termination
                 condition, and can seriously confound evaluation. Read
-                https://imitation.readthedocs.io/en/latest/guide/variable_horizon.html
+                https://imitation.readthedocs.io/en/latest/getting-started/variable-horizon.html
                 before overriding this.
         """
         super().__init__(

--- a/src/imitation/algorithms/base.py
+++ b/src/imitation/algorithms/base.py
@@ -102,8 +102,9 @@ class BaseImitationAlgorithm(abc.ABC):
                 f"Episodes of different length detected: {horizons}. "
                 "Variable horizon environments are discouraged -- "
                 "termination conditions leak information about reward. See "
-                "https://imitation.readthedocs.io/en/latest/getting-started/variable-horizon.html"
-                " for more information. If you are SURE you want to run imitation on a "
+                "https://imitation.readthedocs.io/en/latest/getting-started/"
+                "variable-horizon.html for more information. "
+                "If you are SURE you want to run imitation on a "
                 "variable horizon task, then please pass in the flag: "
                 "`allow_variable_horizon=True`.",
             )


### PR DESCRIPTION
## Description

The link wasn't fixed for all instances in `base.py`.

## Testing
The link
[https://imitation.readthedocs.io/en/latest/guide/variable_horizon.html](https://imitation.readthedocs.io/en/latest/guide/variable_horizon.html)
404s