### PR TITLE
Fix CI errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@3.2.3
   shellcheck: circleci/shellcheck@3.1.2
-  win: circleci/windows@5.0
+  win: circleci/windows@4.1
 
 defaults: &defaults
   docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v100-linux-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
+            - v6-linux-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
 
       - run:
           name: install dependencies
@@ -59,7 +59,7 @@ commands:
       - save_cache:
           paths:
             - /venv
-          key: v100-linux-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
+          key: v6-linux-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
 
       - run:
           name: install imitation
@@ -122,7 +122,7 @@ commands:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v6-win-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.ps1" }}
+            - v100-win-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.ps1" }}
 
       - run:
           name: install python and binary dependencies
@@ -151,7 +151,7 @@ commands:
       - save_cache:
           paths:
             - .\venv
-          key: v6-win-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.ps1" }}
+          key: v100-win-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.ps1" }}
 
       - run:
           name: install imitation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v6-linux-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
+            - v7linux-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
 
       - run:
           name: install dependencies
@@ -59,7 +59,7 @@ commands:
       - save_cache:
           paths:
             - /venv
-          key: v6-linux-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
+          key: v7linux-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
 
       - run:
           name: install imitation
@@ -80,7 +80,7 @@ commands:
 
       - restore_cache:
           keys:
-            - v6-macos-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
+            - v7macos-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
 
       - run:
           name: install dependencies
@@ -92,7 +92,7 @@ commands:
       - save_cache:
           paths:
             - ~/venv
-          key: v6-macos-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
+          key: v7macos-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
 
       - run:
           name: install imitation
@@ -122,7 +122,7 @@ commands:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v6-win-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.ps1" }}
+            - v7win-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.ps1" }}
 
       - run:
           name: install python and binary dependencies
@@ -152,7 +152,7 @@ commands:
       - save_cache:
           paths:
             - .\venv
-          key: v6-win-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.ps1" }}
+          key: v7win-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.ps1" }}
 
       - run:
           name: install imitation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@3.2.3
   shellcheck: circleci/shellcheck@3.1.2
-  win: circleci/windows@4.1
+  win: circleci/windows@5.0
 
 defaults: &defaults
   docker:
@@ -122,7 +122,7 @@ commands:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v100-win-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.ps1" }}
+            - v6-win-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.ps1" }}
 
       - run:
           name: install python and binary dependencies
@@ -151,7 +151,7 @@ commands:
       - save_cache:
           paths:
             - .\venv
-          key: v100-win-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.ps1" }}
+          key: v6-win-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.ps1" }}
 
       - run:
           name: install imitation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v6-linux-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
+            - v100-linux-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
 
       - run:
           name: install dependencies
@@ -59,7 +59,7 @@ commands:
       - save_cache:
           paths:
             - /venv
-          key: v6-linux-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
+          key: v100-linux-dependencies-{{ checksum "setup.py" }}-{{ checksum "ci/build_and_activate_venv.sh" }}
 
       - run:
           name: install imitation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ commands:
           command: |
             choco install --side-by-side -y python --version=3.8.10
             choco install -y ffmpeg
+            choco install -y openssl
           shell: powershell.exe
 
       - run:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ ATARI_REQUIRE = [
     "opencv-python",
     "ale-py==0.7.4",
     "pillow",
-    # "autorom[accept-rom-license]~=0.4.2",
+    "autorom[accept-rom-license]~=0.4.2",
 ]
 PYTYPE = ["pytype==2022.7.26"] if IS_NOT_WINDOWS else []
 STABLE_BASELINES3 = "stable-baselines3>=1.6.1"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ ATARI_REQUIRE = [
     "opencv-python",
     "ale-py==0.7.4",
     "pillow",
-    "autorom[accept-rom-license]~=0.4.2",
+    # "autorom[accept-rom-license]~=0.4.2",
 ]
 PYTYPE = ["pytype==2022.7.26"] if IS_NOT_WINDOWS else []
 STABLE_BASELINES3 = "stable-baselines3>=1.6.1"

--- a/tests/data/test_buffer.py
+++ b/tests/data/test_buffer.py
@@ -145,7 +145,7 @@ def test_replay_buffer(capacity, chunk_len, obs_shape, act_shape, dtype):
         assert sample.next_obs.dtype == dtype
         assert info_vals.dtype == dtype
         assert sample.dones.dtype == bool
-        assert sample.infos.dtype == np.object
+        assert sample.infos.dtype == object
 
         # Are samples in range?
         _check_bound(i + chunk_len, capacity, sample.obs)


### PR DESCRIPTION
## Description

Fixes the `np.object` error by replacing it with `object` and installs OpenSSL on Windows.

