### PR TITLE
Fix non-determinism in DAgger (fixes #643)

### DIFF
--- a/src/imitation/algorithms/dagger.py
+++ b/src/imitation/algorithms/dagger.py
@@ -382,9 +382,8 @@ class DAggerTrainer(base.BaseImitationAlgorithm):
         # https://stackoverflow.com/questions/31534583/is-os-listdir-deterministic
         # To ensure the order is consistent across file systems,
         # we sort by the filename.
-        return [
-            round_dir / p for p in sorted(os.listdir(round_dir)) if p.endswith(".npz")
-        ]
+        filenames = sorted(os.listdir(round_dir))
+        return [round_dir / f for f in filenames if f.endswith(".npz")]
 
     def _demo_dir_path_for_round(self, round_num: Optional[int] = None) -> pathlib.Path:
         if round_num is None:

--- a/src/imitation/algorithms/dagger.py
+++ b/src/imitation/algorithms/dagger.py
@@ -111,6 +111,9 @@ def _save_dagger_demo(
     random_uuid = uuid.UUID(int=randbits, version=4).hex
     filename = f"{actual_prefix}dagger-demo-{trajectory_index}-{random_uuid}.npz"
     npz_path = save_dir / filename
+    assert (
+        not npz_path.exists()
+    ), "The following DAgger demonstration path already exists: {0}".format(npz_path)
     types.save(npz_path, [trajectory])
     logging.info(f"Saved demo at '{npz_path}'")
 

--- a/src/imitation/algorithms/dagger.py
+++ b/src/imitation/algorithms/dagger.py
@@ -10,6 +10,7 @@ import abc
 import logging
 import os
 import pathlib
+import uuid
 from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -21,7 +22,6 @@ from torch.utils import data as th_data
 from imitation.algorithms import base, bc
 from imitation.data import rollout, types
 from imitation.util import logger as imit_logger
-from imitation.util import util
 
 
 class BetaSchedule(abc.ABC):
@@ -99,15 +99,17 @@ def reconstruct_trainer(
 
 def _save_dagger_demo(
     trajectory: types.Trajectory,
+    trajectory_index: int,
     save_dir: types.AnyPath,
+    rng: np.random.Generator,
     prefix: str = "",
 ) -> None:
     save_dir = types.parse_path(save_dir)
     assert isinstance(trajectory, types.Trajectory)
     actual_prefix = f"{prefix}-" if prefix else ""
-    timestamp = util.make_unique_timestamp()
-    filename = f"{actual_prefix}dagger-demo-{timestamp}.npz"
-
+    randbits = int.from_bytes(rng.bytes(16), "big")
+    random_uuid = uuid.UUID(int=randbits, version=4).hex
+    filename = f"{actual_prefix}dagger-demo-{trajectory_index}-{random_uuid}.npz"
     npz_path = save_dir / filename
     types.save(npz_path, [trajectory])
     logging.info(f"Saved demo at '{npz_path}'")
@@ -246,8 +248,8 @@ class InteractiveTrajectoryCollector(vec_env.VecEnvWrapper):
             infos=infos,
             dones=dones,
         )
-        for traj in fresh_demos:
-            _save_dagger_demo(traj, self.save_dir)
+        for traj_index, traj in enumerate(fresh_demos):
+            _save_dagger_demo(traj, traj_index, self.save_dir, self.rng)
 
         return next_obs, rews, dones, infos
 
@@ -372,7 +374,14 @@ class DAggerTrainer(base.BaseImitationAlgorithm):
         return demo_transitions, num_demos_by_round
 
     def _get_demo_paths(self, round_dir: pathlib.Path) -> List[pathlib.Path]:
-        return [round_dir / p for p in os.listdir(round_dir) if p.endswith(".npz")]
+        # listdir returns filenames in an arbitrary order that depends on the
+        # file system implementation:
+        # https://stackoverflow.com/questions/31534583/is-os-listdir-deterministic
+        # To ensure the order is consistent across file systems,
+        # we sort by the filename.
+        return [
+            round_dir / p for p in sorted(os.listdir(round_dir)) if p.endswith(".npz")
+        ]
 
     def _demo_dir_path_for_round(self, round_num: Optional[int] = None) -> pathlib.Path:
         if round_num is None:
@@ -570,10 +579,12 @@ class SimpleDAggerTrainer(DAggerTrainer):
         if expert_trajs is not None:
             # Save each initial expert trajectory into the "round 0" demonstration
             # data directory.
-            for traj in expert_trajs:
+            for traj_index, traj in enumerate(expert_trajs):
                 _save_dagger_demo(
                     traj,
+                    traj_index,
                     self._demo_dir_path_for_round(),
+                    self.rng,
                     prefix="initial_data",
                 )
 

--- a/tests/algorithms/test_dagger.py
+++ b/tests/algorithms/test_dagger.py
@@ -419,9 +419,7 @@ def test_trainer_reproducible(
                 rng,
             )
 
-            # Train for 10 iterations. (6 or less causes test to fail on some configs.)
-            # see https://github.com/HumanCompatibleAI/imitation/issues/580 for details
-            for i in range(10):
+            for i in range(2):
                 collector = trainer.create_trajectory_collector()
                 obs = collector.reset()
                 dones = [False] * pendulum_venv.num_envs


### PR DESCRIPTION
## Description

The issue (#643) was that DAgger demonstrations were loaded from disk for training in a different order each run. This was because the filenames for the saved demonstrations changed each run and that changed the order in which os.listdir returned the filenames. The filenames changed each run, because they included a timestamp and the first 6 characters of a UUID generated without fixing a random seed.

This PR fixes the non-determinism by making the filenames the same each run as long as the same random seed is used. It does so by removing the timestamp from the filename and fixing the seed of the UUID. Because the timestamp is removed, the PR introduces a trajectory index in the filename, so that a user can tell the order in which trajectories were created. It also includes the entire UUID instead of just the first 6 characters. Finally, it sorts the filenames returned by os.listdir. listdir returns filenames in an arbitrary order that depends on the file system implementation (https://stackoverflow.com/questions/31534583/is-os-listdir-deterministic). We sort the filenames to ensure the order is consistent across file systems.

We discuss a few other design decisions below.

Why include a UUID in the filename at all? If we removed the UUID from the filename, then the DAgger trainers would not overwrite filenames, because they take care to write to a new directory each round of training. However, if the InteractiveTrajectoryCollector is used independently of those trainers, then it can end up overwriting filenames without the UUID.

Do we need to shuffle the filenames returned by os.listdir after sorting? We could, but the demonstrations loaded from the files are passed to a DataLoader, which shuffles them. That seems like the right place to handle the shuffling rather than making it the responsibility of the utility function that returns the filenames.

## Testing

This PR also adds unit tests for the reproducibility of the InteractiveTrajectoryCollector, DAggerTrainer, and the SimpleDAggerTrainer. In particular, each unit test consists of running a block of code twice with the same random seeds and checking that the code produces the same result each time.
