### PR TITLE
Update benchmarking configs

### DIFF
--- a/benchmarking/example_airl_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_ant_best_hp_eval.json
@@ -6,9 +6,9 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "reward": {
     "add_std_alpha": null,
     "ensemble_size": null,
@@ -41,7 +41,7 @@
       "vf_coef": 0.4351450387648799
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -58,7 +58,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Ant-v0"
+  "environment": {
+    "gym_id": "seals/Ant-v0"
   }
 }

--- a/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
@@ -6,9 +6,9 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "reward": {
     "add_std_alpha": null,
     "ensemble_size": null,
@@ -41,7 +41,7 @@
       "vf_coef": 0.11483689492120866
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -58,7 +58,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/HalfCheetah-v0"
+  "environment": {
+    "gym_id": "seals/HalfCheetah-v0"
   }
 }

--- a/benchmarking/example_airl_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_hopper_best_hp_eval.json
@@ -6,9 +6,9 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "reward": {
     "add_std_alpha": null,
     "ensemble_size": null,
@@ -41,7 +41,7 @@
       "vf_coef": 0.20315938606555833
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
@@ -59,13 +59,19 @@
       },
       "net_arch": [
         {
-          "pi": [64, 64],
-          "vf": [64, 64]
+          "pi": [
+            64,
+            64
+          ],
+          "vf": [
+            64,
+            64
+          ]
         }
       ]
     }
   },
-  "common": {
-    "env_name": "seals/Hopper-v0"
+  "environment": {
+    "gym_id": "seals/Hopper-v0"
   }
 }

--- a/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
@@ -6,11 +6,12 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
   "expert": {
     "loader_kwargs": {
-      "env_name": "seals/Swimmer-v0",
+      "gym_id": "seals/Swimmer-v0",
       "organization": "HumanCompatibleAI"
     }
   },
@@ -46,7 +47,7 @@
       "vf_coef": 0.6162112311062333
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
@@ -64,13 +65,19 @@
       },
       "net_arch": [
         {
-          "pi": [64, 64],
-          "vf": [64, 64]
+          "pi": [
+            64,
+            64
+          ],
+          "vf": [
+            64,
+            64
+          ]
         }
       ]
     }
   },
-  "common": {
-    "env_name": "seals/Swimmer-v0"
+  "environment": {
+    "gym_id": "seals/Swimmer-v0"
   }
 }

--- a/benchmarking/example_airl_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_walker_best_hp_eval.json
@@ -6,11 +6,12 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
   "expert": {
     "loader_kwargs": {
-      "env_name": "seals/Walker2d-v0",
+      "gym_id": "seals/Walker2d-v0",
       "organization": "HumanCompatibleAI"
     }
   },
@@ -46,7 +47,7 @@
       "vf_coef": 0.6167177795726859
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
@@ -64,13 +65,19 @@
       },
       "net_arch": [
         {
-          "pi": [64, 64],
-          "vf": [64, 64]
+          "pi": [
+            64,
+            64
+          ],
+          "vf": [
+            64,
+            64
+          ]
         }
       ]
     }
   },
-  "common": {
-    "env_name": "seals/Walker2d-v0"
+  "environment": {
+    "gym_id": "seals/Walker2d-v0"
   }
 }

--- a/benchmarking/example_bc_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_ant_best_hp_eval.json
@@ -16,13 +16,13 @@
   },
   "dagger": {
     "rollout_round_min_episodes": null,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -39,7 +39,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Ant-v0"
+  "environment": {
+    "gym_id": "seals/Ant-v0"
   }
 }

--- a/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
@@ -20,9 +20,9 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -39,7 +39,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/HalfCheetah-v0"
+  "environment": {
+    "gym_id": "seals/HalfCheetah-v0"
   }
 }

--- a/benchmarking/example_bc_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_hopper_best_hp_eval.json
@@ -16,13 +16,13 @@
   },
   "dagger": {
     "rollout_round_min_episodes": null,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -39,7 +39,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Hopper-v0"
+  "environment": {
+    "gym_id": "seals/Hopper-v0"
   }
 }

--- a/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
@@ -16,13 +16,13 @@
   },
   "dagger": {
     "rollout_round_min_episodes": null,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -39,7 +39,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Swimmer-v0"
+  "environment": {
+    "gym_id": "seals/Swimmer-v0"
   }
 }

--- a/benchmarking/example_bc_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_walker_best_hp_eval.json
@@ -16,13 +16,13 @@
   },
   "dagger": {
     "rollout_round_min_episodes": null,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -39,7 +39,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Walker2d-v0"
+  "environment": {
+    "gym_id": "seals/Walker2d-v0"
   }
 }

--- a/benchmarking/example_dagger_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_ant_best_hp_eval.json
@@ -20,13 +20,13 @@
       "rampdown_rounds": 15
     },
     "rollout_round_min_episodes": 5,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -43,7 +43,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Ant-v0"
+  "environment": {
+    "gym_id": "seals/Ant-v0"
   }
 }

--- a/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
@@ -24,9 +24,9 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -43,7 +43,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/HalfCheetah-v0"
+  "environment": {
+    "gym_id": "seals/HalfCheetah-v0"
   }
 }

--- a/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
@@ -20,13 +20,13 @@
       "py/object": "imitation.algorithms.dagger.ExponentialBetaSchedule"
     },
     "rollout_round_min_episodes": 10,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -43,7 +43,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Hopper-v0"
+  "environment": {
+    "gym_id": "seals/Hopper-v0"
   }
 }

--- a/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
@@ -20,13 +20,13 @@
       "rampdown_rounds": 15
     },
     "rollout_round_min_episodes": 3,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -43,7 +43,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Swimmer-v0"
+  "environment": {
+    "gym_id": "seals/Swimmer-v0"
   }
 }

--- a/benchmarking/example_dagger_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_walker_best_hp_eval.json
@@ -20,13 +20,13 @@
       "py/object": "imitation.algorithms.dagger.ExponentialBetaSchedule"
     },
     "rollout_round_min_episodes": 5,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -43,7 +43,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Walker2d-v0"
+  "environment": {
+    "gym_id": "seals/Walker2d-v0"
   }
 }

--- a/benchmarking/example_gail_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_ant_best_hp_eval.json
@@ -6,9 +6,9 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "reward": {
     "add_std_alpha": null,
     "ensemble_size": null,
@@ -41,7 +41,7 @@
       "vf_coef": 0.4351450387648799
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -58,7 +58,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Ant-v0"
+  "environment": {
+    "gym_id": "seals/Ant-v0"
   }
 }

--- a/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
@@ -6,9 +6,9 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "reward": {
     "add_std_alpha": null,
     "ensemble_size": null,
@@ -41,7 +41,7 @@
       "vf_coef": 0.11483689492120866
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -58,7 +58,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/HalfCheetah-v0"
+  "environment": {
+    "gym_id": "seals/HalfCheetah-v0"
   }
 }

--- a/benchmarking/example_gail_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_hopper_best_hp_eval.json
@@ -6,9 +6,9 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "reward": {
     "add_std_alpha": null,
     "ensemble_size": null,
@@ -41,7 +41,7 @@
       "vf_coef": 0.20315938606555833
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
@@ -59,13 +59,19 @@
       },
       "net_arch": [
         {
-          "pi": [64, 64],
-          "vf": [64, 64]
+          "pi": [
+            64,
+            64
+          ],
+          "vf": [
+            64,
+            64
+          ]
         }
       ]
     }
   },
-  "common": {
-    "env_name": "seals/Hopper-v0"
+  "environment": {
+    "gym_id": "seals/Hopper-v0"
   }
 }

--- a/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
@@ -6,11 +6,12 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
   "expert": {
     "loader_kwargs": {
-      "env_name": "seals/Swimmer-v0",
+      "gym_id": "seals/Swimmer-v0",
       "organization": "HumanCompatibleAI"
     }
   },
@@ -46,7 +47,7 @@
       "vf_coef": 0.6162112311062333
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
@@ -64,13 +65,19 @@
       },
       "net_arch": [
         {
-          "pi": [64, 64],
-          "vf": [64, 64]
+          "pi": [
+            64,
+            64
+          ],
+          "vf": [
+            64,
+            64
+          ]
         }
       ]
     }
   },
-  "common": {
-    "env_name": "seals/Swimmer-v0"
+  "environment": {
+    "gym_id": "seals/Swimmer-v0"
   }
 }

--- a/benchmarking/example_gail_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_walker_best_hp_eval.json
@@ -6,11 +6,12 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
   "expert": {
     "loader_kwargs": {
-      "env_name": "seals/Walker2d-v0",
+      "gym_id": "seals/Walker2d-v0",
       "organization": "HumanCompatibleAI"
     }
   },
@@ -46,7 +47,7 @@
       "vf_coef": 0.6167177795726859
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
@@ -64,13 +65,19 @@
       },
       "net_arch": [
         {
-          "pi": [64, 64],
-          "vf": [64, 64]
+          "pi": [
+            64,
+            64
+          ],
+          "vf": [
+            64,
+            64
+          ]
         }
       ]
     }
   },
-  "common": {
-    "env_name": "seals/Walker2d-v0"
+  "environment": {
+    "gym_id": "seals/Walker2d-v0"
   }
 }

--- a/benchmarking/util.py
+++ b/benchmarking/util.py
@@ -73,8 +73,8 @@ def clean_config_file(file: pathlib.Path, write_path: pathlib.Path, /) -> None:
     config.pop("seed")
     config.get("demonstrations", {}).pop("rollout_path")
     config.get("expert", {}).get("loader_kwargs", {}).pop("path", None)
-    env_name = config.pop("common").pop("env_name")
-    config["common"] = {"env_name": env_name}
+    env_name = config.pop("environment").pop("gym_id")
+    config["environment"] = {"gym_id": env_name}
     config.pop("show_config", None)
 
     remove_empty_dicts(config)


### PR DESCRIPTION
## Description

Added `demonstrations.rollout_type` in all the configs to download rollouts from the huggingface hub. Also, updated config key names changed in #604.

## Testing

Tested the configs locally using: `python -m imitation.scripts.<train_script> <algo> with benchmarking/<config_name>.json
`
