### PR TITLE
Fix benchmarking configs + Add a minimal test suite for those configs.

### DIFF
--- a/benchmarking/example_airl_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_ant_best_hp_eval.json
@@ -6,9 +6,9 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "reward": {
     "add_std_alpha": null,
     "ensemble_size": null,
@@ -41,7 +41,7 @@
       "vf_coef": 0.4351450387648799
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -58,7 +58,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Ant-v0"
+  "environment": {
+    "gym_id": "seals/Ant-v0"
   }
 }

--- a/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
@@ -6,9 +6,9 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "reward": {
     "add_std_alpha": null,
     "ensemble_size": null,
@@ -41,7 +41,7 @@
       "vf_coef": 0.11483689492120866
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -58,7 +58,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/HalfCheetah-v0"
+  "environment": {
+    "gym_id": "seals/HalfCheetah-v0"
   }
 }

--- a/benchmarking/example_airl_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_hopper_best_hp_eval.json
@@ -6,9 +6,9 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "reward": {
     "add_std_alpha": null,
     "ensemble_size": null,
@@ -41,7 +41,7 @@
       "vf_coef": 0.20315938606555833
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
@@ -59,13 +59,19 @@
       },
       "net_arch": [
         {
-          "pi": [64, 64],
-          "vf": [64, 64]
+          "pi": [
+            64,
+            64
+          ],
+          "vf": [
+            64,
+            64
+          ]
         }
       ]
     }
   },
-  "common": {
-    "env_name": "seals/Hopper-v0"
+  "environment": {
+    "gym_id": "seals/Hopper-v0"
   }
 }

--- a/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
@@ -6,11 +6,12 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
   "expert": {
     "loader_kwargs": {
-      "env_name": "seals/Swimmer-v0",
+      "gym_id": "seals/Swimmer-v0",
       "organization": "HumanCompatibleAI"
     }
   },
@@ -46,7 +47,7 @@
       "vf_coef": 0.6162112311062333
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
@@ -64,13 +65,19 @@
       },
       "net_arch": [
         {
-          "pi": [64, 64],
-          "vf": [64, 64]
+          "pi": [
+            64,
+            64
+          ],
+          "vf": [
+            64,
+            64
+          ]
         }
       ]
     }
   },
-  "common": {
-    "env_name": "seals/Swimmer-v0"
+  "environment": {
+    "gym_id": "seals/Swimmer-v0"
   }
 }

--- a/benchmarking/example_airl_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_walker_best_hp_eval.json
@@ -6,11 +6,12 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
   "expert": {
     "loader_kwargs": {
-      "env_name": "seals/Walker2d-v0",
+      "gym_id": "seals/Walker2d-v0",
       "organization": "HumanCompatibleAI"
     }
   },
@@ -46,7 +47,7 @@
       "vf_coef": 0.6167177795726859
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
@@ -64,13 +65,19 @@
       },
       "net_arch": [
         {
-          "pi": [64, 64],
-          "vf": [64, 64]
+          "pi": [
+            64,
+            64
+          ],
+          "vf": [
+            64,
+            64
+          ]
         }
       ]
     }
   },
-  "common": {
-    "env_name": "seals/Walker2d-v0"
+  "environment": {
+    "gym_id": "seals/Walker2d-v0"
   }
 }

--- a/benchmarking/example_bc_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_ant_best_hp_eval.json
@@ -16,13 +16,13 @@
   },
   "dagger": {
     "rollout_round_min_episodes": null,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -39,7 +39,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Ant-v0"
+  "environment": {
+    "gym_id": "seals/Ant-v0"
   }
 }

--- a/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
@@ -20,9 +20,9 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -39,7 +39,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/HalfCheetah-v0"
+  "environment": {
+    "gym_id": "seals/HalfCheetah-v0"
   }
 }

--- a/benchmarking/example_bc_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_hopper_best_hp_eval.json
@@ -16,13 +16,13 @@
   },
   "dagger": {
     "rollout_round_min_episodes": null,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -39,7 +39,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Hopper-v0"
+  "environment": {
+    "gym_id": "seals/Hopper-v0"
   }
 }

--- a/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
@@ -16,13 +16,13 @@
   },
   "dagger": {
     "rollout_round_min_episodes": null,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -39,7 +39,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Swimmer-v0"
+  "environment": {
+    "gym_id": "seals/Swimmer-v0"
   }
 }

--- a/benchmarking/example_bc_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_walker_best_hp_eval.json
@@ -16,13 +16,13 @@
   },
   "dagger": {
     "rollout_round_min_episodes": null,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -39,7 +39,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Walker2d-v0"
+  "environment": {
+    "gym_id": "seals/Walker2d-v0"
   }
 }

--- a/benchmarking/example_dagger_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_ant_best_hp_eval.json
@@ -16,17 +16,17 @@
   },
   "dagger": {
     "beta_schedule": {
-      "py/object": "imitation.algorithms.dagger.LinearBetaSchedule",
+      "py/type": "imitation.algorithms.dagger.LinearBetaSchedule",
       "rampdown_rounds": 15
     },
     "rollout_round_min_episodes": 5,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -43,7 +43,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Ant-v0"
+  "environment": {
+    "gym_id": "seals/Ant-v0"
   }
 }

--- a/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
@@ -17,16 +17,16 @@
   "dagger": {
     "beta_schedule": {
       "decay_probability": 0.7,
-      "py/object": "imitation.algorithms.dagger.ExponentialBetaSchedule"
+      "py/type": "imitation.algorithms.dagger.ExponentialBetaSchedule"
     },
     "rollout_round_min_episodes": 5,
     "total_timesteps": 60000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -43,7 +43,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/HalfCheetah-v0"
+  "environment": {
+    "gym_id": "seals/HalfCheetah-v0"
   }
 }

--- a/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
@@ -17,16 +17,16 @@
   "dagger": {
     "beta_schedule": {
       "decay_probability": 0.7,
-      "py/object": "imitation.algorithms.dagger.ExponentialBetaSchedule"
+      "py/type": "imitation.algorithms.dagger.ExponentialBetaSchedule"
     },
     "rollout_round_min_episodes": 10,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -43,7 +43,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Hopper-v0"
+  "environment": {
+    "gym_id": "seals/Hopper-v0"
   }
 }

--- a/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
@@ -16,17 +16,17 @@
   },
   "dagger": {
     "beta_schedule": {
-      "py/object": "imitation.algorithms.dagger.LinearBetaSchedule",
+      "py/type": "imitation.algorithms.dagger.LinearBetaSchedule",
       "rampdown_rounds": 15
     },
     "rollout_round_min_episodes": 3,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -43,7 +43,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Swimmer-v0"
+  "environment": {
+    "gym_id": "seals/Swimmer-v0"
   }
 }

--- a/benchmarking/example_dagger_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_walker_best_hp_eval.json
@@ -17,16 +17,16 @@
   "dagger": {
     "beta_schedule": {
       "decay_probability": 0.7,
-      "py/object": "imitation.algorithms.dagger.ExponentialBetaSchedule"
+      "py/type": "imitation.algorithms.dagger.ExponentialBetaSchedule"
     },
     "rollout_round_min_episodes": 5,
-    "total_timesteps": 100000.0,
+    "total_timesteps": 100000,
     "use_offline_rollouts": false
   },
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -43,7 +43,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Walker2d-v0"
+  "environment": {
+    "gym_id": "seals/Walker2d-v0"
   }
 }

--- a/benchmarking/example_gail_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_ant_best_hp_eval.json
@@ -6,9 +6,9 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "reward": {
     "add_std_alpha": null,
     "ensemble_size": null,
@@ -41,7 +41,7 @@
       "vf_coef": 0.4351450387648799
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -58,7 +58,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/Ant-v0"
+  "environment": {
+    "gym_id": "seals/Ant-v0"
   }
 }

--- a/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
@@ -6,9 +6,9 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "reward": {
     "add_std_alpha": null,
     "ensemble_size": null,
@@ -41,7 +41,7 @@
       "vf_coef": 0.11483689492120866
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": {
@@ -58,7 +58,7 @@
       }
     }
   },
-  "common": {
-    "env_name": "seals/HalfCheetah-v0"
+  "environment": {
+    "gym_id": "seals/HalfCheetah-v0"
   }
 }

--- a/benchmarking/example_gail_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_hopper_best_hp_eval.json
@@ -6,9 +6,9 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-
   "reward": {
     "add_std_alpha": null,
     "ensemble_size": null,
@@ -41,7 +41,7 @@
       "vf_coef": 0.20315938606555833
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
@@ -59,13 +59,19 @@
       },
       "net_arch": [
         {
-          "pi": [64, 64],
-          "vf": [64, 64]
+          "pi": [
+            64,
+            64
+          ],
+          "vf": [
+            64,
+            64
+          ]
         }
       ]
     }
   },
-  "common": {
-    "env_name": "seals/Hopper-v0"
+  "environment": {
+    "gym_id": "seals/Hopper-v0"
   }
 }

--- a/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
@@ -6,11 +6,12 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
   "expert": {
     "loader_kwargs": {
-      "env_name": "seals/Swimmer-v0",
+      "gym_id": "seals/Swimmer-v0",
       "organization": "HumanCompatibleAI"
     }
   },
@@ -46,7 +47,7 @@
       "vf_coef": 0.6162112311062333
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
@@ -64,13 +65,19 @@
       },
       "net_arch": [
         {
-          "pi": [64, 64],
-          "vf": [64, 64]
+          "pi": [
+            64,
+            64
+          ],
+          "vf": [
+            64,
+            64
+          ]
         }
       ]
     }
   },
-  "common": {
-    "env_name": "seals/Swimmer-v0"
+  "environment": {
+    "gym_id": "seals/Swimmer-v0"
   }
 }

--- a/benchmarking/example_gail_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_walker_best_hp_eval.json
@@ -6,11 +6,12 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
+    "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
   "expert": {
     "loader_kwargs": {
-      "env_name": "seals/Walker2d-v0",
+      "gym_id": "seals/Walker2d-v0",
       "organization": "HumanCompatibleAI"
     }
   },
@@ -46,7 +47,7 @@
       "vf_coef": 0.6167177795726859
     }
   },
-  "total_timesteps": 10000000.0,
+  "total_timesteps": 10000000,
   "train": {
     "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
@@ -64,13 +65,19 @@
       },
       "net_arch": [
         {
-          "pi": [64, 64],
-          "vf": [64, 64]
+          "pi": [
+            64,
+            64
+          ],
+          "vf": [
+            64,
+            64
+          ]
         }
       ]
     }
   },
-  "common": {
-    "env_name": "seals/Walker2d-v0"
+  "environment": {
+    "gym_id": "seals/Walker2d-v0"
   }
 }

--- a/benchmarking/util.py
+++ b/benchmarking/util.py
@@ -73,8 +73,8 @@ def clean_config_file(file: pathlib.Path, write_path: pathlib.Path, /) -> None:
     config.pop("seed")
     config.get("demonstrations", {}).pop("rollout_path")
     config.get("expert", {}).get("loader_kwargs", {}).pop("path", None)
-    env_name = config.pop("common").pop("env_name")
-    config["common"] = {"env_name": env_name}
+    env_name = config.pop("environment").pop("gym_id")
+    config["environment"] = {"gym_id": env_name}
     config.pop("show_config", None)
 
     remove_empty_dicts(config)

--- a/src/imitation/algorithms/dagger.py
+++ b/src/imitation/algorithms/dagger.py
@@ -10,6 +10,7 @@ import abc
 import logging
 import os
 import pathlib
+import uuid
 from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -21,7 +22,6 @@ from torch.utils import data as th_data
 from imitation.algorithms import base, bc
 from imitation.data import rollout, types
 from imitation.util import logger as imit_logger
-from imitation.util import util
 
 
 class BetaSchedule(abc.ABC):
@@ -99,15 +99,17 @@ def reconstruct_trainer(
 
 def _save_dagger_demo(
     trajectory: types.Trajectory,
+    trajectory_index: int,
     save_dir: types.AnyPath,
+    rng: np.random.Generator,
     prefix: str = "",
 ) -> None:
     save_dir = types.parse_path(save_dir)
     assert isinstance(trajectory, types.Trajectory)
     actual_prefix = f"{prefix}-" if prefix else ""
-    timestamp = util.make_unique_timestamp()
-    filename = f"{actual_prefix}dagger-demo-{timestamp}.npz"
-
+    randbits = int.from_bytes(rng.bytes(16), "big")
+    random_uuid = uuid.UUID(int=randbits, version=4).hex
+    filename = f"{actual_prefix}dagger-demo-{trajectory_index}-{random_uuid}.npz"
     npz_path = save_dir / filename
     types.save(npz_path, [trajectory])
     logging.info(f"Saved demo at '{npz_path}'")
@@ -246,8 +248,8 @@ class InteractiveTrajectoryCollector(vec_env.VecEnvWrapper):
             infos=infos,
             dones=dones,
         )
-        for traj in fresh_demos:
-            _save_dagger_demo(traj, self.save_dir)
+        for traj_index, traj in enumerate(fresh_demos):
+            _save_dagger_demo(traj, traj_index, self.save_dir, self.rng)
 
         return next_obs, rews, dones, infos
 
@@ -372,7 +374,14 @@ class DAggerTrainer(base.BaseImitationAlgorithm):
         return demo_transitions, num_demos_by_round
 
     def _get_demo_paths(self, round_dir: pathlib.Path) -> List[pathlib.Path]:
-        return [round_dir / p for p in os.listdir(round_dir) if p.endswith(".npz")]
+        # listdir returns filenames in an arbitrary order that depends on the
+        # file system implementation:
+        # https://stackoverflow.com/questions/31534583/is-os-listdir-deterministic
+        # To ensure the order is consistent across file systems,
+        # we sort by the filename.
+        return [
+            round_dir / p for p in sorted(os.listdir(round_dir)) if p.endswith(".npz")
+        ]
 
     def _demo_dir_path_for_round(self, round_num: Optional[int] = None) -> pathlib.Path:
         if round_num is None:
@@ -570,10 +579,12 @@ class SimpleDAggerTrainer(DAggerTrainer):
         if expert_trajs is not None:
             # Save each initial expert trajectory into the "round 0" demonstration
             # data directory.
-            for traj in expert_trajs:
+            for traj_index, traj in enumerate(expert_trajs):
                 _save_dagger_demo(
                     traj,
+                    traj_index,
                     self._demo_dir_path_for_round(),
+                    self.rng,
                     prefix="initial_data",
                 )
 

--- a/tests/test_benchmarking.py
+++ b/tests/test_benchmarking.py
@@ -1,0 +1,64 @@
+"""Tests for config files in benchmarking/ folder."""
+import pytest
+
+from imitation.data import types
+from imitation.scripts import train_adversarial, train_imitation
+
+ALGO_FAST_CONFIGS = {
+    "adversarial": [
+        "environment.fast",
+        "demonstrations.fast",
+        "rl.fast",
+        "train.fast",
+        "fast",
+    ],
+    "eval_policy": ["environment.fast", "fast"],
+    "imitation": ["environment.fast", "demonstrations.fast", "train.fast", "fast"],
+    "preference_comparison": ["environment.fast", "rl.fast", "train.fast", "fast"],
+    "rl": ["environment.fast", "rl.fast", "train.fast", "fast"],
+}
+
+BENCHMARKING_DIR = types.parse_path("benchmarking")
+
+if not BENCHMARKING_DIR.exists():  # pragma: no cover
+    raise RuntimeError(
+        "The benchmarking/ folder has not been found. Make sure you are "
+        "running tests relative to the base imitation project folder.",
+    )
+
+
+@pytest.mark.parametrize("command_name", ["bc", "dagger"])
+def test_benchmarking_imitation_config_runs(tmpdir, command_name):
+    config_file = "example_" + command_name + "_seals_half_cheetah_best_hp_eval.json"
+    config_path = BENCHMARKING_DIR / config_file
+    train_imitation.train_imitation_ex.add_named_config(
+        tmpdir.basename,
+        config_path.as_posix(),
+    )
+    run = train_imitation.train_imitation_ex.run(
+        command_name=command_name,
+        named_configs=[tmpdir.basename] + ALGO_FAST_CONFIGS["imitation"],
+        config_updates=dict(
+            bc_train_kwargs=dict(n_epochs=None),
+            logging=dict(log_root=tmpdir),
+        ),
+    )
+    assert run.status == "COMPLETED"
+
+
+@pytest.mark.parametrize("command_name", ["airl", "gail"])
+def test_benchmarking_adversarial_config_runs(tmpdir, command_name):
+    config_file = "example_" + command_name + "_seals_half_cheetah_best_hp_eval.json"
+    config_path = BENCHMARKING_DIR / config_file
+    train_adversarial.train_adversarial_ex.add_named_config(
+        tmpdir.basename,
+        config_path.as_posix(),
+    )
+    run = train_adversarial.train_adversarial_ex.run(
+        command_name=command_name,
+        named_configs=[tmpdir.basename] + ALGO_FAST_CONFIGS["adversarial"],
+        config_updates=dict(
+            logging=dict(log_root=tmpdir),
+        ),
+    )
+    assert run.status == "COMPLETED"


### PR DESCRIPTION
## Description

This PR patches in the changes from PR #650. It also fixes an error in the dagger configs by replacing "py/object" with "py/type". "py/object" failed the assert in sacred.config.utils.assert_is_valid_key.

## Testing

The PR adds a minimal test suite for the benchmarking configs. It makes progress on testing, but still does not test that all the benchmarking configs work. Running all the configs with the fast configs applied is too slow. Calling sacred's print_config command for all the configs is also too slow.
