### PR TITLE
Fix flaky density baseline test on MacOS/Windows

### DIFF
--- a/tests/algorithms/test_density_baselines.py
+++ b/tests/algorithms/test_density_baselines.py
@@ -48,9 +48,8 @@ def test_density_reward(
     rng,
 ):
     # use only a subset of trajectories
-    expert_trajectories_all = pendulum_expert_trajectories
-    n_experts = len(expert_trajectories_all)
-    expert_trajectories_train = expert_trajectories_all[: n_experts // 2]
+    n_experts = len(pendulum_expert_trajectories)
+    expert_trajectories_train = pendulum_expert_trajectories[: n_experts // 2]
     reward_fn = DensityAlgorithm(
         demonstrations=expert_trajectories_train,
         density_type=density_type,
@@ -76,7 +75,7 @@ def test_density_reward(
         sample_until=sample_until,
         rng=rng,
     )
-    expert_trajectories_test = expert_trajectories_all[n_experts // 2 :]
+    expert_trajectories_test = pendulum_expert_trajectories[n_experts // 2 :]
     random_returns = score_trajectories(random_trajectories, reward_fn)
     expert_returns = score_trajectories(expert_trajectories_test, reward_fn)
     assert reward_improvement.is_significant_reward_improvement(

--- a/tests/algorithms/test_density_baselines.py
+++ b/tests/algorithms/test_density_baselines.py
@@ -69,7 +69,7 @@ def test_density_reward(
         pendulum_venv.observation_space,
         pendulum_venv.action_space,
     )
-    sample_until = rollout.make_min_episodes(15)
+    sample_until = rollout.make_min_episodes(20)
     random_trajectories = rollout.generate_trajectories(
         random_policy,
         pendulum_venv,

--- a/tests/algorithms/test_density_baselines.py
+++ b/tests/algorithms/test_density_baselines.py
@@ -48,7 +48,7 @@ def test_density_reward(
     rng,
 ):
     # use only a subset of trajectories
-    expert_trajectories_all = pendulum_expert_trajectories[:8]
+    expert_trajectories_all = pendulum_expert_trajectories
     n_experts = len(expert_trajectories_all)
     expert_trajectories_train = expert_trajectories_all[: n_experts // 2]
     reward_fn = DensityAlgorithm(
@@ -69,7 +69,7 @@ def test_density_reward(
         pendulum_venv.observation_space,
         pendulum_venv.action_space,
     )
-    sample_until = rollout.make_min_episodes(20)
+    sample_until = rollout.make_min_episodes(15)
     random_trajectories = rollout.generate_trajectories(
         random_policy,
         pendulum_venv,


### PR DESCRIPTION
## Description

Uses all expert trajectories (60) rather than just 8 for training. This avoids test failure on Mac/Windows which was previously happening e.g. https://app.circleci.com/pipelines/github/HumanCompatibleAI/imitation/3269/workflows/ae9d13dc-132b-4087-b2dd-959d2b2da5b3/jobs/11843

I think with small # of trajectories there's a high chance of false-negative on statistical significance if reward function learned happens to evaluate a single expert trajectory unfavorably. Using more expert trajectories makes reward function more stable by increasing train dataset size, and evaluation less noisy by increasing test dataset size.

The downside is it does make the test be less challenging: even very dumb algorithms can do well with a big enough dataset size. That said, I don't think we believe the density baseline is particularly sample efficient.

## Testing

Verified passes locally on Linux and on Mac/Windows on CI.

On my local machine it increases the test time from 52s to 58s for `test_density_baseline` which is a modest increase, but unlikely to affect overall CI suite very much.