### PR TITLE
Remove type: ignore in evaluate_policy calls 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ ATARI_REQUIRE = [
     "autorom[accept-rom-license]~=0.4.2",
 ]
 PYTYPE = ["pytype==2022.7.26"] if IS_NOT_WINDOWS else []
-STABLE_BASELINES3 = "stable-baselines3>=1.6.1"
+STABLE_BASELINES3 = "stable-baselines3>=1.7.0"
 # pinned to 0.21 until https://github.com/DLR-RM/stable-baselines3/pull/780 goes
 # upstream.
 GYM_VERSION_SPECIFIER = "==0.21.0"

--- a/tests/algorithms/test_bc.py
+++ b/tests/algorithms/test_bc.py
@@ -186,11 +186,8 @@ def test_that_bc_improves_rewards(
     cartpole_venv: vec_env.VecEnv,
 ):
     # GIVEN
-    # TODO(https://github.com/HumanCompatibleAI/imitation/issues/600): the upstream
-    # annotation for this function is overly-conservative but passing the policy at
-    # runtime works, the ignore can be removed once fixed upstream.
     novice_rewards, _ = evaluation.evaluate_policy(
-        cartpole_bc_trainer.policy,  # type: ignore[arg-type]
+        cartpole_bc_trainer.policy,
         cartpole_venv,
         15,
         return_episode_rewards=True,
@@ -200,7 +197,7 @@ def test_that_bc_improves_rewards(
     # WHEN
     cartpole_bc_trainer.train(n_epochs=1)
     rewards_after_training, _ = evaluation.evaluate_policy(
-        cartpole_bc_trainer.policy,  # type: ignore[arg-type]
+        cartpole_bc_trainer.policy,
         cartpole_venv,
         15,
         return_episode_rewards=True,


### PR DESCRIPTION
## Description

Remove type: ignore in evaluate_policy calls that are not needed since the issue is solved in stable-baselines3
Solves #600 

Note: I had to change the way entropy is handled when the policy reports no action entropy.
