### PR TITLE
Establish BC as an ingredient

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ From [examples/quickstart.sh:](examples/quickstart.sh)
 
 ```bash
 # Train PPO agent on pendulum and collect expert demonstrations. Tensorboard logs saved in quickstart/rl/
-python -m imitation.scripts.train_rl with pendulum environment.fast train.fast rl.fast fast logging.log_dir=quickstart/rl/
+python -m imitation.scripts.train_rl with pendulum environment.fast policy_evaluation.fast rl.fast fast logging.log_dir=quickstart/rl/
 
 # Train GAIL from demonstrations. Tensorboard logs saved in output/ (default log directory).
-python -m imitation.scripts.train_adversarial gail with pendulum environment.fast demonstrations.fast train.fast rl.fast fast demonstrations.rollout_path=quickstart/rl/rollouts/final.npz
+python -m imitation.scripts.train_adversarial gail with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.rollout_path=quickstart/rl/rollouts/final.npz
 
 # Train AIRL from demonstrations. Tensorboard logs saved in output/ (default log directory).
-python -m imitation.scripts.train_adversarial airl with pendulum environment.fast demonstrations.fast train.fast rl.fast fast demonstrations.rollout_path=quickstart/rl/rollouts/final.npz
+python -m imitation.scripts.train_adversarial airl with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.rollout_path=quickstart/rl/rollouts/final.npz
 ```
 
 Tips:

--- a/benchmarking/example_airl_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_ant_best_hp_eval.json
@@ -42,7 +42,7 @@
     }
   },
   "total_timesteps": 10000000,
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_airl_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_ant_best_hp_eval.json
@@ -43,7 +43,6 @@
   },
   "total_timesteps": 10000000,
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -57,6 +56,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Ant-v0"

--- a/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
@@ -42,7 +42,7 @@
     }
   },
   "total_timesteps": 10000000,
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
@@ -43,7 +43,6 @@
   },
   "total_timesteps": 10000000,
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -57,6 +56,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/HalfCheetah-v0"

--- a/benchmarking/example_airl_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_hopper_best_hp_eval.json
@@ -43,7 +43,6 @@
   },
   "total_timesteps": 10000000,
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
     "policy_kwargs": {
       "activation_fn": {
@@ -70,6 +69,9 @@
         }
       ]
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Hopper-v0"

--- a/benchmarking/example_airl_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_hopper_best_hp_eval.json
@@ -42,7 +42,7 @@
     }
   },
   "total_timesteps": 10000000,
-  "train": {
+  "policy": {
     "policy_cls": "MlpPolicy",
     "policy_kwargs": {
       "activation_fn": {

--- a/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
@@ -48,7 +48,7 @@
     }
   },
   "total_timesteps": 10000000,
-  "train": {
+  "policy": {
     "policy_cls": "MlpPolicy",
     "policy_kwargs": {
       "activation_fn": {

--- a/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
@@ -49,7 +49,6 @@
   },
   "total_timesteps": 10000000,
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
     "policy_kwargs": {
       "activation_fn": {
@@ -76,6 +75,9 @@
         }
       ]
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Swimmer-v0"

--- a/benchmarking/example_airl_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_walker_best_hp_eval.json
@@ -48,7 +48,7 @@
     }
   },
   "total_timesteps": 10000000,
-  "train": {
+  "policy": {
     "policy_cls": "MlpPolicy",
     "policy_kwargs": {
       "activation_fn": {

--- a/benchmarking/example_airl_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_walker_best_hp_eval.json
@@ -49,7 +49,6 @@
   },
   "total_timesteps": 10000000,
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
     "policy_kwargs": {
       "activation_fn": {
@@ -76,6 +75,9 @@
         }
       ]
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Walker2d-v0"

--- a/benchmarking/example_bc_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_ant_best_hp_eval.json
@@ -23,7 +23,7 @@
     "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_bc_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_ant_best_hp_eval.json
@@ -24,7 +24,6 @@
     "n_expert_demos": null
   },
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -38,6 +37,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Ant-v0"

--- a/benchmarking/example_bc_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_ant_best_hp_eval.json
@@ -1,5 +1,5 @@
 {
-  "bc_kwargs": {
+  "bc": {
     "batch_size": 16,
     "l2_weight": 2.350251568550711e-5,
     "optimizer_cls": {
@@ -7,12 +7,12 @@
     },
     "optimizer_kwargs": {
       "lr": 0.0017601048183920826
+    },
+    "train_kwargs": {
+      "log_interval": 500,
+      "n_batches": null,
+      "n_epochs": 5
     }
-  },
-  "bc_train_kwargs": {
-    "log_interval": 500,
-    "n_batches": null,
-    "n_epochs": 5
   },
   "dagger": {
     "rollout_round_min_episodes": null,

--- a/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
@@ -23,7 +23,7 @@
     "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
@@ -1,5 +1,5 @@
 {
-  "bc_kwargs": {
+  "bc": {
     "batch_size": 64,
     "l2_weight": 0.005728455628518169,
     "optimizer_cls": {
@@ -7,12 +7,12 @@
     },
     "optimizer_kwargs": {
       "lr": 0.008056922426724927
+    },
+    "train_kwargs": {
+      "log_interval": 500,
+      "n_batches": null,
+      "n_epochs": 20
     }
-  },
-  "bc_train_kwargs": {
-    "log_interval": 500,
-    "n_batches": null,
-    "n_epochs": 20
   },
   "dagger": {
     "rollout_round_min_episodes": null,

--- a/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
@@ -24,7 +24,6 @@
     "n_expert_demos": null
   },
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -38,6 +37,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/HalfCheetah-v0"

--- a/benchmarking/example_bc_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_hopper_best_hp_eval.json
@@ -23,7 +23,7 @@
     "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_bc_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_hopper_best_hp_eval.json
@@ -24,7 +24,6 @@
     "n_expert_demos": null
   },
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -38,6 +37,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Hopper-v0"

--- a/benchmarking/example_bc_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_hopper_best_hp_eval.json
@@ -1,5 +1,5 @@
 {
-  "bc_kwargs": {
+  "bc": {
     "batch_size": 64,
     "l2_weight": 1.3610189916104634e-6,
     "optimizer_cls": {
@@ -7,12 +7,12 @@
     },
     "optimizer_kwargs": {
       "lr": 0.0007172435323620212
-    }
-  },
-  "bc_train_kwargs": {
-    "log_interval": 500,
-    "n_batches": null,
-    "n_epochs": 20
+    },
+    "train_kwargs": {
+      "log_interval": 500,
+      "n_batches": null,
+      "n_epochs": 20
+   }
   },
   "dagger": {
     "rollout_round_min_episodes": null,

--- a/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
@@ -23,7 +23,7 @@
     "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
@@ -1,5 +1,5 @@
 {
-  "bc_kwargs": {
+  "bc": {
     "batch_size": 16,
     "l2_weight": 4.37857842825771e-5,
     "optimizer_cls": {
@@ -7,12 +7,12 @@
     },
     "optimizer_kwargs": {
       "lr": 0.0016370547173923296
+    },
+    "train_kwargs": {
+      "log_interval": 500,
+      "n_batches": null,
+      "n_epochs": 10
     }
-  },
-  "bc_train_kwargs": {
-    "log_interval": 500,
-    "n_batches": null,
-    "n_epochs": 10
   },
   "dagger": {
     "rollout_round_min_episodes": null,

--- a/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
@@ -24,7 +24,6 @@
     "n_expert_demos": null
   },
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -38,6 +37,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Swimmer-v0"

--- a/benchmarking/example_bc_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_walker_best_hp_eval.json
@@ -23,7 +23,7 @@
     "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_bc_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_walker_best_hp_eval.json
@@ -1,5 +1,5 @@
 {
-  "bc_kwargs": {
+  "bc": {
     "batch_size": 32,
     "l2_weight": 0.0014680228143404998,
     "optimizer_cls": {
@@ -7,12 +7,12 @@
     },
     "optimizer_kwargs": {
       "lr": 0.0003034620018780926
+    },
+    "train_kwargs": {
+      "log_interval": 500,
+      "n_batches": null,
+      "n_epochs": 20
     }
-  },
-  "bc_train_kwargs": {
-    "log_interval": 500,
-    "n_batches": null,
-    "n_epochs": 20
   },
   "dagger": {
     "rollout_round_min_episodes": null,

--- a/benchmarking/example_bc_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_walker_best_hp_eval.json
@@ -24,7 +24,6 @@
     "n_expert_demos": null
   },
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -38,6 +37,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Walker2d-v0"

--- a/benchmarking/example_dagger_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_ant_best_hp_eval.json
@@ -27,7 +27,7 @@
     "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_dagger_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_ant_best_hp_eval.json
@@ -28,7 +28,6 @@
     "n_expert_demos": null
   },
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -42,6 +41,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Ant-v0"

--- a/benchmarking/example_dagger_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_ant_best_hp_eval.json
@@ -1,5 +1,5 @@
 {
-  "bc_kwargs": {
+  "bc": {
     "batch_size": 16,
     "l2_weight": 0.0001,
     "optimizer_cls": {
@@ -7,12 +7,12 @@
     },
     "optimizer_kwargs": {
       "lr": 0.001
+    },
+    "train_kwargs": {
+      "log_interval": 500,
+      "n_batches": null,
+      "n_epochs": 10
     }
-  },
-  "bc_train_kwargs": {
-    "log_interval": 500,
-    "n_batches": null,
-    "n_epochs": 10
   },
   "dagger": {
     "beta_schedule": {

--- a/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
@@ -27,7 +27,7 @@
     "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
@@ -28,7 +28,6 @@
     "n_expert_demos": null
   },
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -42,6 +41,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/HalfCheetah-v0"

--- a/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
@@ -1,5 +1,5 @@
 {
-  "bc_kwargs": {
+  "bc": {
     "batch_size": 16,
     "l2_weight": 0.0001,
     "optimizer_cls": {
@@ -7,12 +7,12 @@
     },
     "optimizer_kwargs": {
       "lr": 0.001
+    },
+    "train_kwargs": {
+      "log_interval": 500,
+      "n_batches": null,
+      "n_epochs": 5
     }
-  },
-  "bc_train_kwargs": {
-    "log_interval": 500,
-    "n_batches": null,
-    "n_epochs": 5
   },
   "dagger": {
     "beta_schedule": {

--- a/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
@@ -1,5 +1,5 @@
 {
-  "bc_kwargs": {
+  "bc": {
     "batch_size": 16,
     "l2_weight": 0.0001,
     "optimizer_cls": {
@@ -7,12 +7,12 @@
     },
     "optimizer_kwargs": {
       "lr": 0.001
+    },
+    "train_kwargs": {
+      "log_interval": 500,
+      "n_batches": null,
+      "n_epochs": 1
     }
-  },
-  "bc_train_kwargs": {
-    "log_interval": 500,
-    "n_batches": null,
-    "n_epochs": 1
   },
   "dagger": {
     "beta_schedule": {

--- a/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
@@ -27,7 +27,7 @@
     "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
@@ -28,7 +28,6 @@
     "n_expert_demos": null
   },
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -42,6 +41,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Hopper-v0"

--- a/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
@@ -1,5 +1,5 @@
 {
-  "bc_kwargs": {
+  "bc": {
     "batch_size": 16,
     "l2_weight": 0.0001,
     "optimizer_cls": {
@@ -7,12 +7,12 @@
     },
     "optimizer_kwargs": {
       "lr": 0.001
+    },
+    "train_kwargs": {
+      "log_interval": 500,
+      "n_batches": null,
+      "n_epochs": 1
     }
-  },
-  "bc_train_kwargs": {
-    "log_interval": 500,
-    "n_batches": null,
-    "n_epochs": 1
   },
   "dagger": {
     "beta_schedule": {

--- a/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
@@ -28,7 +28,6 @@
     "n_expert_demos": null
   },
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -42,6 +41,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Swimmer-v0"

--- a/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
@@ -27,7 +27,7 @@
     "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_dagger_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_walker_best_hp_eval.json
@@ -27,7 +27,7 @@
     "rollout_type": "ppo-huggingface",
     "n_expert_demos": null
   },
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_dagger_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_walker_best_hp_eval.json
@@ -1,5 +1,5 @@
 {
-  "bc_kwargs": {
+  "bc": {
     "batch_size": 16,
     "l2_weight": 0.0001,
     "optimizer_cls": {
@@ -7,12 +7,12 @@
     },
     "optimizer_kwargs": {
       "lr": 0.001
+    },
+    "train_kwargs": {
+      "log_interval": 500,
+      "n_batches": null,
+      "n_epochs": 5
     }
-  },
-  "bc_train_kwargs": {
-    "log_interval": 500,
-    "n_batches": null,
-    "n_epochs": 5
   },
   "dagger": {
     "beta_schedule": {

--- a/benchmarking/example_dagger_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_walker_best_hp_eval.json
@@ -28,7 +28,6 @@
     "n_expert_demos": null
   },
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -42,6 +41,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Walker2d-v0"

--- a/benchmarking/example_gail_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_ant_best_hp_eval.json
@@ -42,7 +42,7 @@
     }
   },
   "total_timesteps": 10000000,
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_gail_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_ant_best_hp_eval.json
@@ -43,7 +43,6 @@
   },
   "total_timesteps": 10000000,
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -57,6 +56,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Ant-v0"

--- a/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
@@ -42,7 +42,7 @@
     }
   },
   "total_timesteps": 10000000,
-  "train": {
+  "policy": {
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },

--- a/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
@@ -43,7 +43,6 @@
   },
   "total_timesteps": 10000000,
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": {
       "py/type": "imitation.policies.base.FeedForward32Policy"
     },
@@ -57,6 +56,9 @@
         }
       }
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/HalfCheetah-v0"

--- a/benchmarking/example_gail_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_hopper_best_hp_eval.json
@@ -43,7 +43,6 @@
   },
   "total_timesteps": 10000000,
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
     "policy_kwargs": {
       "activation_fn": {
@@ -70,6 +69,9 @@
         }
       ]
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Hopper-v0"

--- a/benchmarking/example_gail_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_hopper_best_hp_eval.json
@@ -42,7 +42,7 @@
     }
   },
   "total_timesteps": 10000000,
-  "train": {
+  "policy": {
     "policy_cls": "MlpPolicy",
     "policy_kwargs": {
       "activation_fn": {

--- a/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
@@ -48,7 +48,7 @@
     }
   },
   "total_timesteps": 10000000,
-  "train": {
+  "policy": {
     "policy_cls": "MlpPolicy",
     "policy_kwargs": {
       "activation_fn": {

--- a/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
@@ -49,7 +49,6 @@
   },
   "total_timesteps": 10000000,
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
     "policy_kwargs": {
       "activation_fn": {
@@ -76,6 +75,9 @@
         }
       ]
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Swimmer-v0"

--- a/benchmarking/example_gail_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_walker_best_hp_eval.json
@@ -48,7 +48,7 @@
     }
   },
   "total_timesteps": 10000000,
-  "train": {
+  "policy": {
     "policy_cls": "MlpPolicy",
     "policy_kwargs": {
       "activation_fn": {

--- a/benchmarking/example_gail_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_walker_best_hp_eval.json
@@ -49,7 +49,6 @@
   },
   "total_timesteps": 10000000,
   "train": {
-    "n_episodes_eval": 50,
     "policy_cls": "MlpPolicy",
     "policy_kwargs": {
       "activation_fn": {
@@ -76,6 +75,9 @@
         }
       ]
     }
+  },
+  "policy_evaluation": {
+    "n_episodes_eval": 50
   },
   "environment": {
     "gym_id": "seals/Walker2d-v0"

--- a/benchmarking/fast_dagger_seals_cartpole.json
+++ b/benchmarking/fast_dagger_seals_cartpole.json
@@ -2,7 +2,7 @@
     "bc_train_kwargs": {"n_batches": 50},
     "dagger": {"total_timesteps": 50},
     "demonstrations": {"n_expert_demos": 10},
-    "train": {"n_episodes_eval": 1},
+    "policy_evaluation": {"n_episodes_eval": 50},
     "environment": {
         "gym_id": "seals/CartPole-v0",
         "num_vec": 2,

--- a/benchmarking/fast_dagger_seals_cartpole.json
+++ b/benchmarking/fast_dagger_seals_cartpole.json
@@ -1,5 +1,5 @@
 {
-    "bc_train_kwargs": {"n_batches": 50},
+    "bc": {"train_kwargs": {"n_batches": 50}},
     "dagger": {"total_timesteps": 50},
     "demonstrations": {"n_expert_demos": 10},
     "policy_evaluation": {"n_episodes_eval": 50},

--- a/docs/development/developer.rst
+++ b/docs/development/developer.rst
@@ -118,7 +118,7 @@ available in ``scripts/``. You can take a look at the following doc links to und
     imitation.scripts.ingredients.expert
     imitation.scripts.ingredients.reward
     imitation.scripts.ingredients.rl
-    imitation.scripts.ingredients.train
+    imitation.scripts.ingredients.policy
     imitation.scripts.ingredients.wb
 
 - `Configurations <https://sacred.readthedocs.io/en/stable/configuration.html>`_: Explains how to use configurations to parametrize runs. The configurations for different algorithms are defined in their file in ``scripts/``. Some of the commonly used configs and ingredients used across algorithms are defined in ``scripts/ingredients/``.

--- a/examples/quickstart.sh
+++ b/examples/quickstart.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 # Train PPO agent on pendulum and collect expert demonstrations. Tensorboard logs saved in quickstart/rl/
-python -m imitation.scripts.train_rl with pendulum environment.fast train.fast rl.fast fast logging.log_dir=quickstart/rl/
+python -m imitation.scripts.train_rl with pendulum environment.fast policy_evaluation.fast rl.fast fast logging.log_dir=quickstart/rl/
 
 # Train GAIL from demonstrations. Tensorboard logs saved in output/ (default log directory).
-python -m imitation.scripts.train_adversarial gail with pendulum environment.fast demonstrations.fast train.fast rl.fast fast demonstrations.rollout_path=quickstart/rl/rollouts/final.npz
+python -m imitation.scripts.train_adversarial gail with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.rollout_path=quickstart/rl/rollouts/final.npz
 
 # Train AIRL from demonstrations. Tensorboard logs saved in output/ (default log directory).
-python -m imitation.scripts.train_adversarial airl with pendulum environment.fast demonstrations.fast train.fast rl.fast fast demonstrations.rollout_path=quickstart/rl/rollouts/final.npz
+python -m imitation.scripts.train_adversarial airl with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.rollout_path=quickstart/rl/rollouts/final.npz

--- a/experiments/bc_benchmark.sh
+++ b/experiments/bc_benchmark.sh
@@ -27,7 +27,7 @@ while true; do
     -f | --fast)
       # Fast mode (debug)
       SEEDS=(0)
-      extra_configs=("${extra_configs[@]}" environment.fast demonstrations.fast train.fast fast)
+      extra_configs=("${extra_configs[@]}" environment.fast demonstrations.fast policy_evaluation.fast fast)
       shift
       ;;
     --paper)  # Table benchmark settings

--- a/experiments/dagger_benchmark.sh
+++ b/experiments/dagger_benchmark.sh
@@ -20,7 +20,7 @@ while true; do
     # Fast mode (debug)
     -f | --fast)
       SEEDS=(0)
-      extra_configs=("${extra_configs[@]}" environment.fast demonstrations.fast train.fast fast)
+      extra_configs=("${extra_configs[@]}" environment.fast demonstrations.fast policy_evaluation.fast fast)
       shift
       ;;
     --paper)  # Table benchmark settings

--- a/experiments/imit_benchmark.sh
+++ b/experiments/imit_benchmark.sh
@@ -29,7 +29,7 @@ while true; do
     -f | --fast)
       CONFIG_CSV="tests/testdata/imit_benchmark_config.csv"
       SEEDS=(0)
-      extra_configs=("${extra_configs[@]}" environment.fast demonstrations.fast rl.fast train.fast fast)
+      extra_configs=("${extra_configs[@]}" environment.fast demonstrations.fast rl.fast policy_evaluation.fast fast)
       shift
       ;;
     -w | --wandb)

--- a/experiments/transfer_learn_benchmark.sh
+++ b/experiments/transfer_learn_benchmark.sh
@@ -29,7 +29,7 @@ while true; do
       REWARD_MODELS_DIR="tests/testdata/reward_models"
       NEED_TEST_FILES="true"
       SEEDS=(0)
-      extra_configs=("${extra_configs[@]}" environment.fast rl.fast train.fast fast)
+      extra_configs=("${extra_configs[@]}" environment.fast rl.fast policy_evaluation.fast fast)
       shift
       ;;
     -w | --wandb)

--- a/src/imitation/scripts/config/parallel.py
+++ b/src/imitation/scripts/config/parallel.py
@@ -73,7 +73,7 @@ def generate_test_data():
     base_named_configs = [
         "cartpole",
         "environment.fast",
-        "train.fast",
+        "policy_evaluation.fast",
         "rl.fast",
         "fast",
     ]

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -5,7 +5,7 @@ import sacred
 from imitation.rewards import reward_nets
 from imitation.scripts.ingredients import demonstrations, environment, expert
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients import policy_evaluation, reward, rl, train
+from imitation.scripts.ingredients import policy_evaluation, reward, rl
 
 train_adversarial_ex = sacred.Experiment(
     "train_adversarial",
@@ -14,7 +14,6 @@ train_adversarial_ex = sacred.Experiment(
         demonstrations.demonstrations_ingredient,
         reward.reward_ingredient,
         rl.rl_ingredient,
-        train.train_ingredient,
         expert.expert_ingredient,
         environment.environment_ingredient,
         policy_evaluation.policy_evaluation_ingredient,

--- a/src/imitation/scripts/config/train_adversarial.py
+++ b/src/imitation/scripts/config/train_adversarial.py
@@ -5,7 +5,7 @@ import sacred
 from imitation.rewards import reward_nets
 from imitation.scripts.ingredients import demonstrations, environment, expert
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients import reward, rl, train
+from imitation.scripts.ingredients import policy_evaluation, reward, rl, train
 
 train_adversarial_ex = sacred.Experiment(
     "train_adversarial",
@@ -17,6 +17,7 @@ train_adversarial_ex = sacred.Experiment(
         train.train_ingredient,
         expert.expert_ingredient,
         environment.environment_ingredient,
+        policy_evaluation.policy_evaluation_ingredient,
     ],
 )
 

--- a/src/imitation/scripts/config/train_imitation.py
+++ b/src/imitation/scripts/config/train_imitation.py
@@ -40,7 +40,7 @@ def config():
         use_offline_rollouts=False,  # warm-start policy with BC from offline demos
         total_timesteps=1e5,
     )
-    agent_path = None  # Path to load agent from, optional.
+    agent_path = None  # Path to serialized policy. If None, a new policy is created.
 
 
 @train_imitation_ex.named_config

--- a/src/imitation/scripts/config/train_imitation.py
+++ b/src/imitation/scripts/config/train_imitation.py
@@ -1,8 +1,8 @@
 """Configuration settings for train_dagger, training DAgger from synthetic demos."""
 
 import sacred
-import torch as th
 
+from imitation.scripts.ingredients import bc
 from imitation.scripts.ingredients import demonstrations as demos_common
 from imitation.scripts.ingredients import environment, expert
 from imitation.scripts.ingredients import logging as logging_ingredient
@@ -17,43 +17,30 @@ train_imitation_ex = sacred.Experiment(
         expert.expert_ingredient,
         environment.environment_ingredient,
         policy_evaluation.policy_evaluation_ingredient,
+        bc.bc_ingredient,
     ],
 )
 
 
 @train_imitation_ex.config
 def config():
-    bc_kwargs = dict(
-        batch_size=32,
-        l2_weight=3e-5,  # L2 regularization weight
-        optimizer_cls=th.optim.Adam,
-        optimizer_kwargs=dict(
-            lr=4e-4,
-        ),
-    )
-    bc_train_kwargs = dict(
-        n_epochs=None,  # Number of BC epochs per DAgger training round
-        n_batches=None,  # Number of BC batches per DAgger training round
-        log_interval=500,  # Number of updates between Tensorboard/stdout logs
-    )
     dagger = dict(
         use_offline_rollouts=False,  # warm-start policy with BC from offline demos
         total_timesteps=1e5,
     )
-    agent_path = None  # Path to serialized policy. If None, a new policy is created.
 
 
 @train_imitation_ex.named_config
 def mountain_car():
     environment = dict(gym_id="MountainCar-v0")
-    bc_kwargs = dict(l2_weight=0.0)
+    bc = dict(l2_weight=0.0)
     dagger = dict(total_timesteps=20000)
 
 
 @train_imitation_ex.named_config
 def seals_mountain_car():
     environment = dict(gym_id="seals/MountainCar-v0")
-    bc_kwargs = dict(l2_weight=0.0)
+    bc = dict(l2_weight=0.0)
     dagger = dict(total_timesteps=20000)
 
 
@@ -87,14 +74,14 @@ def seals_ant():
 @train_imitation_ex.named_config
 def half_cheetah():
     environment = dict(gym_id="HalfCheetah-v2")
-    bc_kwargs = dict(l2_weight=0.0)
+    bc = dict(l2_weight=0.0)
     dagger = dict(total_timesteps=60000)
 
 
 @train_imitation_ex.named_config
 def seals_half_cheetah():
     environment = dict(gym_id="seals/HalfCheetah-v0")
-    bc_kwargs = dict(l2_weight=0.0)
+    bc = dict(l2_weight=0.0)
     dagger = dict(total_timesteps=60000)
 
 
@@ -111,4 +98,4 @@ def seals_humanoid():
 @train_imitation_ex.named_config
 def fast():
     dagger = dict(total_timesteps=50)
-    bc_train_kwargs = dict(n_batches=50)
+    bc = dict(train_kwargs=dict(n_batches=50))

--- a/src/imitation/scripts/config/train_imitation.py
+++ b/src/imitation/scripts/config/train_imitation.py
@@ -6,14 +6,14 @@ import torch as th
 from imitation.scripts.ingredients import demonstrations as demos_common
 from imitation.scripts.ingredients import environment, expert
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients import policy_evaluation, train
+from imitation.scripts.ingredients import policy, policy_evaluation
 
 train_imitation_ex = sacred.Experiment(
     "train_imitation",
     ingredients=[
         logging_ingredient.logging_ingredient,
         demos_common.demonstrations_ingredient,
-        train.train_ingredient,
+        policy.policy_ingredient,
         expert.expert_ingredient,
         environment.environment_ingredient,
         policy_evaluation.policy_evaluation_ingredient,

--- a/src/imitation/scripts/config/train_imitation.py
+++ b/src/imitation/scripts/config/train_imitation.py
@@ -6,7 +6,7 @@ import torch as th
 from imitation.scripts.ingredients import demonstrations as demos_common
 from imitation.scripts.ingredients import environment, expert
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients import train
+from imitation.scripts.ingredients import policy_evaluation, train
 
 train_imitation_ex = sacred.Experiment(
     "train_imitation",
@@ -16,6 +16,7 @@ train_imitation_ex = sacred.Experiment(
         train.train_ingredient,
         expert.expert_ingredient,
         environment.environment_ingredient,
+        policy_evaluation.policy_evaluation_ingredient,
     ],
 )
 

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -5,7 +5,7 @@ import sacred
 from imitation.algorithms import preference_comparisons
 from imitation.scripts.ingredients import environment
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients import reward, rl, train
+from imitation.scripts.ingredients import policy_evaluation, reward, rl, train
 
 train_preference_comparisons_ex = sacred.Experiment(
     "train_preference_comparisons",
@@ -15,6 +15,7 @@ train_preference_comparisons_ex = sacred.Experiment(
         reward.reward_ingredient,
         rl.rl_ingredient,
         train.train_ingredient,
+        policy_evaluation.policy_evaluation_ingredient,
     ],
 )
 

--- a/src/imitation/scripts/config/train_preference_comparisons.py
+++ b/src/imitation/scripts/config/train_preference_comparisons.py
@@ -5,7 +5,7 @@ import sacred
 from imitation.algorithms import preference_comparisons
 from imitation.scripts.ingredients import environment
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients import policy_evaluation, reward, rl, train
+from imitation.scripts.ingredients import policy_evaluation, reward, rl
 
 train_preference_comparisons_ex = sacred.Experiment(
     "train_preference_comparisons",
@@ -14,7 +14,6 @@ train_preference_comparisons_ex = sacred.Experiment(
         environment.environment_ingredient,
         reward.reward_ingredient,
         rl.rl_ingredient,
-        train.train_ingredient,
         policy_evaluation.policy_evaluation_ingredient,
     ],
 )

--- a/src/imitation/scripts/config/train_rl.py
+++ b/src/imitation/scripts/config/train_rl.py
@@ -4,14 +4,13 @@ import sacred
 
 from imitation.scripts.ingredients import environment
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients import policy_evaluation, rl, train
+from imitation.scripts.ingredients import policy_evaluation, rl
 
 train_rl_ex = sacred.Experiment(
     "train_rl",
     ingredients=[
         logging_ingredient.logging_ingredient,
         environment.environment_ingredient,
-        train.train_ingredient,
         rl.rl_ingredient,
         policy_evaluation.policy_evaluation_ingredient,
     ],

--- a/src/imitation/scripts/config/train_rl.py
+++ b/src/imitation/scripts/config/train_rl.py
@@ -4,7 +4,7 @@ import sacred
 
 from imitation.scripts.ingredients import environment
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients import rl, train
+from imitation.scripts.ingredients import policy_evaluation, rl, train
 
 train_rl_ex = sacred.Experiment(
     "train_rl",
@@ -13,6 +13,7 @@ train_rl_ex = sacred.Experiment(
         environment.environment_ingredient,
         train.train_ingredient,
         rl.rl_ingredient,
+        policy_evaluation.policy_evaluation_ingredient,
     ],
 )
 

--- a/src/imitation/scripts/ingredients/bc.py
+++ b/src/imitation/scripts/ingredients/bc.py
@@ -1,0 +1,80 @@
+"""Ingredients for training a BC policy."""
+import warnings
+from typing import Optional, Sequence
+
+import sacred
+import torch as th
+from stable_baselines3.common import vec_env
+
+from imitation.algorithms import bc
+from imitation.data import types
+from imitation.scripts.ingredients import policy
+
+bc_ingredient = sacred.Ingredient("bc", ingredients=[policy.policy_ingredient])
+
+
+@bc_ingredient.config
+def config():
+    batch_size = 32
+    l2_weight = 3e-5  # L2 regularization weight
+    optimizer_cls = th.optim.Adam
+    optimizer_kwargs = dict(
+        lr=4e-4,
+    )
+    train_kwargs = dict(
+        n_epochs=None,  # Number of BC epochs per DAgger training round
+        n_batches=None,  # Number of BC batches per DAgger training round
+        log_interval=500,  # Number of updates between Tensorboard/stdout logs
+    )
+    agent_path = None  # Path to serialized policy. If None, a new policy is created.
+
+    locals()  # quieten flake8 unused variable warning
+
+
+@bc_ingredient.capture
+def make_bc(
+    venv: vec_env.VecEnv,
+    expert_trajs: Sequence[types.Trajectory],
+    custom_logger,
+    batch_size: int,
+    l2_weight: float,
+    optimizer_cls,
+    optimizer_kwargs,
+    _rnd,
+) -> bc.BC:
+    return bc.BC(
+        observation_space=venv.observation_space,
+        action_space=venv.action_space,
+        policy=make_or_load_policy(venv),
+        demonstrations=expert_trajs,
+        custom_logger=custom_logger,
+        rng=_rnd,
+        batch_size=batch_size,
+        l2_weight=l2_weight,
+        optimizer_cls=optimizer_cls,
+        optimizer_kwargs=optimizer_kwargs,
+    )
+
+
+@bc_ingredient.capture
+def make_or_load_policy(venv: vec_env.VecEnv, agent_path: Optional[str]):
+    """Makes a policy or loads a policy from a path if provided.
+
+    Args:
+        venv: Vectorized environment we will be imitating demos from.
+        agent_path: Path to serialized policy. If provided, then load the
+            policy from this path. Otherwise, make a new policy.
+            Specify only if policy_cls and policy_kwargs are not specified.
+
+    Returns:
+        A Stable Baselines3 policy.
+    """
+    if agent_path is None:
+        policy.make_policy(venv)
+    else:
+        warnings.warn(
+            "When agent_path is specified, policy.policy_cls and policy.policy_kwargs "
+            "are ignored.",
+            RuntimeWarning,
+        )
+        return bc.reconstruct_policy(agent_path)

--- a/src/imitation/scripts/ingredients/policy.py
+++ b/src/imitation/scripts/ingredients/policy.py
@@ -1,4 +1,4 @@
-"""Ingrdient implementation for a SB3 policy."""
+"""Ingredient implementation for a SB3 policy."""
 
 import logging
 from typing import Any, Mapping, Type

--- a/src/imitation/scripts/ingredients/policy.py
+++ b/src/imitation/scripts/ingredients/policy.py
@@ -1,4 +1,4 @@
-"""Common configuration elements for training imitation algorithms."""
+"""Ingrdient implementation for a SB3 policy."""
 
 import logging
 from typing import Any, Mapping, Type

--- a/src/imitation/scripts/ingredients/policy.py
+++ b/src/imitation/scripts/ingredients/policy.py
@@ -10,14 +10,14 @@ import imitation.util.networks
 from imitation.policies import base
 from imitation.scripts.ingredients import logging as logging_ingredient
 
-train_ingredient = sacred.Ingredient(
-    "train",
+policy_ingredient = sacred.Ingredient(
+    "policy",
     ingredients=[logging_ingredient.logging_ingredient],
 )
 logger = logging.getLogger(__name__)
 
 
-@train_ingredient.config
+@policy_ingredient.config
 def config():
     # Training
     policy_cls = base.FeedForward32Policy
@@ -26,7 +26,7 @@ def config():
     locals()  # quieten flake8
 
 
-@train_ingredient.named_config
+@policy_ingredient.named_config
 def sac():
     policy_cls = base.SAC1024Policy  # noqa: F841
 
@@ -39,17 +39,17 @@ NORMALIZE_RUNNING_POLICY_KWARGS = {
 }
 
 
-@train_ingredient.named_config
+@policy_ingredient.named_config
 def normalize_running():
     policy_kwargs = NORMALIZE_RUNNING_POLICY_KWARGS  # noqa: F841
 
 
 # Default config for CNN Policies
-@train_ingredient.named_config
+@policy_ingredient.named_config
 def cnn_policy():
     policy_cls = policies.ActorCriticCnnPolicy  # noqa: F841
 
 
-@train_ingredient.capture
+@policy_ingredient.capture
 def suppress_sacred_error(policy_kwargs: Mapping[str, Any]):
     """No-op so Sacred recognizes `policy_kwargs` is used (in `rl` and elsewhere)."""

--- a/src/imitation/scripts/ingredients/policy_evaluation.py
+++ b/src/imitation/scripts/ingredients/policy_evaluation.py
@@ -1,0 +1,69 @@
+"""Sacred ingredient for evaluating a policy on a VecEnv."""
+
+from typing import Mapping, Union
+
+import numpy as np
+import sacred
+from stable_baselines3.common import base_class, policies, vec_env
+
+from imitation.data import rollout
+
+policy_evaluation_ingredient = sacred.Ingredient("policy_evaluation")
+
+
+@policy_evaluation_ingredient.config
+def config():
+    n_episodes_eval = 50  # Num of episodes for final mean ground truth return
+    locals()  # quieten flake8
+
+
+@policy_evaluation_ingredient.named_config
+def fast():
+    n_episodes_eval = 1  # noqa: F841
+
+
+@policy_evaluation_ingredient.capture
+def eval_policy(
+    rl_algo: Union[base_class.BaseAlgorithm, policies.BasePolicy],
+    venv: vec_env.VecEnv,
+    n_episodes_eval: int,
+    _rnd: np.random.Generator,
+) -> Mapping[str, float]:
+    """Evaluation of imitation learned policy.
+
+    Has the side effect of setting `rl_algo`'s environment to `venv`
+    if it is a `BaseAlgorithm`.
+
+    Args:
+        rl_algo: Algorithm to evaluate.
+        venv: Environment to evaluate on.
+        n_episodes_eval: The number of episodes to average over when calculating
+            the average episode reward of the imitation policy for return.
+        _rnd: Random number generator provided by Sacred.
+
+    Returns:
+        A dictionary with two keys. "imit_stats" gives the return value of
+        `rollout_stats()` on rollouts test-reward-wrapped environment, using the final
+        policy (remember that the ground-truth reward can be recovered from the
+        "monitor_return" key). "expert_stats" gives the return value of
+        `rollout_stats()` on the expert demonstrations loaded from `rollout_path`.
+    """
+    sample_until_eval = rollout.make_min_episodes(n_episodes_eval)
+    if isinstance(rl_algo, base_class.BaseAlgorithm):
+        # Set RL algorithm's env to venv, removing any cruft wrappers that the RL
+        # algorithm's environment may have accumulated.
+        rl_algo.set_env(venv)
+        # Generate trajectories with the RL algorithm's env - SB3 may apply wrappers
+        # under the hood to get it to work with the RL algorithm (e.g. transposing
+        # images, so they can be fed into CNNs).
+        train_env = rl_algo.get_env()
+        assert train_env is not None
+    else:
+        train_env = venv
+    trajs = rollout.generate_trajectories(
+        rl_algo,
+        train_env,
+        sample_until=sample_until_eval,
+        rng=_rnd,
+    )
+    return rollout.rollout_stats(trajs)

--- a/src/imitation/scripts/ingredients/rl.py
+++ b/src/imitation/scripts/ingredients/rl.py
@@ -18,11 +18,11 @@ from imitation.policies import serialize
 from imitation.policies.replay_buffer_wrapper import ReplayBufferRewardWrapper
 from imitation.rewards.reward_function import RewardFn
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients.train import train_ingredient
+from imitation.scripts.ingredients.policy import policy_ingredient
 
 rl_ingredient = sacred.Ingredient(
     "rl",
-    ingredients=[train_ingredient, logging_ingredient.logging_ingredient],
+    ingredients=[policy_ingredient, logging_ingredient.logging_ingredient],
 )
 logger = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ def make_rl_algo(
     rl_cls: Type[base_class.BaseAlgorithm],
     batch_size: int,
     rl_kwargs: Mapping[str, Any],
-    train: Mapping[str, Any],
+    policy: Mapping[str, Any],
     _seed: int,
     relabel_reward_fn: Optional[RewardFn] = None,
 ) -> base_class.BaseAlgorithm:
@@ -116,7 +116,7 @@ def make_rl_algo(
         rl_cls: Type of a Stable Baselines3 RL algorithm.
         batch_size: The batch size of the RL algorithm.
         rl_kwargs: Keyword arguments for RL algorithm constructor.
-        train: Configuration for the train ingredient. We need the
+        policy: Configuration for the policy ingredient. We need the
             policy_cls and policy_kwargs component.
         relabel_reward_fn: Reward function used for reward relabeling
             in replay or rollout buffers of RL algorithms.
@@ -155,12 +155,12 @@ def make_rl_algo(
     else:
         raise TypeError(f"Unsupported RL algorithm '{rl_cls}'")
     rl_algo = rl_cls(
-        policy=train["policy_cls"],
+        policy=policy["policy_cls"],
         # Note(yawen): Copy `policy_kwargs` as SB3 may mutate the config we pass.
         # In particular, policy_kwargs["use_sde"] may be changed in rl_cls.__init__()
         # for certain algorithms, such as Soft Actor Critic. See:
         # https://github.com/DLR-RM/stable-baselines3/blob/30772aa9f53a4cf61571ee90046cdc454c1b11d7/sb3/common/off_policy_algorithm.py#L145
-        policy_kwargs=dict(train["policy_kwargs"]),
+        policy_kwargs=dict(policy["policy_kwargs"]),
         env=venv,
         seed=_seed,
         **rl_kwargs,

--- a/src/imitation/scripts/ingredients/train.py
+++ b/src/imitation/scripts/ingredients/train.py
@@ -1,14 +1,12 @@
 """Common configuration elements for training imitation algorithms."""
 
 import logging
-from typing import Any, Mapping, Union
+from typing import Any, Mapping
 
-import numpy as np
 import sacred
-from stable_baselines3.common import base_class, policies, vec_env
+from stable_baselines3.common import policies
 
 import imitation.util.networks
-from imitation.data import rollout
 from imitation.policies import base
 from imitation.scripts.ingredients import logging as logging_ingredient
 
@@ -25,15 +23,7 @@ def config():
     policy_cls = base.FeedForward32Policy
     policy_kwargs = {}
 
-    # Evaluation
-    n_episodes_eval = 50  # Num of episodes for final mean ground truth return
-
     locals()  # quieten flake8
-
-
-@train_ingredient.named_config
-def fast():
-    n_episodes_eval = 1  # noqa: F841
 
 
 @train_ingredient.named_config
@@ -58,53 +48,6 @@ def normalize_running():
 @train_ingredient.named_config
 def cnn_policy():
     policy_cls = policies.ActorCriticCnnPolicy  # noqa: F841
-
-
-@train_ingredient.capture
-def eval_policy(
-    rl_algo: Union[base_class.BaseAlgorithm, policies.BasePolicy],
-    venv: vec_env.VecEnv,
-    n_episodes_eval: int,
-    _rnd: np.random.Generator,
-) -> Mapping[str, float]:
-    """Evaluation of imitation learned policy.
-
-    Has the side effect of setting `rl_algo`'s environment to `venv`
-    if it is a `BaseAlgorithm`.
-
-    Args:
-        rl_algo: Algorithm to evaluate.
-        venv: Environment to evaluate on.
-        n_episodes_eval: The number of episodes to average over when calculating
-            the average episode reward of the imitation policy for return.
-        _rnd: Random number generator provided by Sacred.
-
-    Returns:
-        A dictionary with two keys. "imit_stats" gives the return value of
-        `rollout_stats()` on rollouts test-reward-wrapped environment, using the final
-        policy (remember that the ground-truth reward can be recovered from the
-        "monitor_return" key). "expert_stats" gives the return value of
-        `rollout_stats()` on the expert demonstrations loaded from `rollout_path`.
-    """
-    sample_until_eval = rollout.make_min_episodes(n_episodes_eval)
-    if isinstance(rl_algo, base_class.BaseAlgorithm):
-        # Set RL algorithm's env to venv, removing any cruft wrappers that the RL
-        # algorithm's environment may have accumulated.
-        rl_algo.set_env(venv)
-        # Generate trajectories with the RL algorithm's env - SB3 may apply wrappers
-        # under the hood to get it to work with the RL algorithm (e.g. transposing
-        # images so they can be fed into CNNs).
-        train_env = rl_algo.get_env()
-        assert train_env is not None
-    else:
-        train_env = venv
-    trajs = rollout.generate_trajectories(
-        rl_algo,
-        train_env,
-        sample_until=sample_until_eval,
-        rng=_rnd,
-    )
-    return rollout.rollout_stats(trajs)
 
 
 @train_ingredient.capture

--- a/src/imitation/scripts/train_adversarial.py
+++ b/src/imitation/scripts/train_adversarial.py
@@ -17,7 +17,7 @@ from imitation.policies import serialize
 from imitation.scripts.config.train_adversarial import train_adversarial_ex
 from imitation.scripts.ingredients import demonstrations, environment
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients import reward, rl, train
+from imitation.scripts.ingredients import policy_evaluation, reward, rl
 
 logger = logging.getLogger("imitation.scripts.train_adversarial")
 
@@ -158,7 +158,7 @@ def train_adversarial(
                 save(trainer, log_dir / "checkpoints" / f"{round_num:05d}")
 
         trainer.train(total_timesteps, callback)
-        imit_stats = train.eval_policy(trainer.policy, trainer.venv_train)
+        imit_stats = policy_evaluation.eval_policy(trainer.policy, trainer.venv_train)
 
     # Save final artifacts.
     if checkpoint_interval >= 0:

--- a/src/imitation/scripts/train_imitation.py
+++ b/src/imitation/scripts/train_imitation.py
@@ -21,7 +21,7 @@ from imitation.scripts.ingredients import policy_evaluation
 logger = logging.getLogger(__name__)
 
 
-@train_imitation_ex.capture(prefix="train")
+@train_imitation_ex.capture(prefix="policy")
 def make_policy(
     venv: vec_env.VecEnv,
     policy_cls: Type[policies.BasePolicy],

--- a/src/imitation/scripts/train_imitation.py
+++ b/src/imitation/scripts/train_imitation.py
@@ -16,7 +16,7 @@ from imitation.data import rollout, types
 from imitation.scripts.config.train_imitation import train_imitation_ex
 from imitation.scripts.ingredients import demonstrations, environment, expert
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients import train
+from imitation.scripts.ingredients import policy_evaluation
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +139,7 @@ def train_imitation(
             # TODO(adam): add checkpointing to BC?
             bc_trainer.save_policy(policy_path=osp.join(log_dir, "final.th"))
 
-        imit_stats = train.eval_policy(imit_policy, venv)
+        imit_stats = policy_evaluation.eval_policy(imit_policy, venv)
 
     stats = {"imit_stats": imit_stats}
     trajectories = model._all_demos if use_dagger else expert_trajs

--- a/src/imitation/scripts/train_preference_comparisons.py
+++ b/src/imitation/scripts/train_preference_comparisons.py
@@ -21,9 +21,8 @@ from imitation.scripts.config.train_preference_comparisons import (
 )
 from imitation.scripts.ingredients import environment
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients import reward
+from imitation.scripts.ingredients import policy_evaluation, reward
 from imitation.scripts.ingredients import rl as rl_common
-from imitation.scripts.ingredients import train
 
 
 def save_model(
@@ -279,7 +278,7 @@ def train_preference_comparisons(
         # Storing and evaluating policy only useful if we generated trajectory data
         if bool(trajectory_path is None):
             results = dict(results)
-            results["rollout"] = train.eval_policy(agent, venv)
+            results["rollout"] = policy_evaluation.eval_policy(agent, venv)
 
     if save_preferences:
         main_trainer.dataset.save(log_dir / "preferences.pkl")

--- a/src/imitation/scripts/train_rl.py
+++ b/src/imitation/scripts/train_rl.py
@@ -25,7 +25,7 @@ from imitation.rewards.serialize import load_reward
 from imitation.scripts.config.train_rl import train_rl_ex
 from imitation.scripts.ingredients import environment
 from imitation.scripts.ingredients import logging as logging_ingredient
-from imitation.scripts.ingredients import rl, train
+from imitation.scripts.ingredients import policy_evaluation, rl
 
 
 @train_rl_ex.main
@@ -157,7 +157,7 @@ def train_rl(
             serialize.save_stable_model(output_dir, rl_algo)
 
         # Final evaluation of expert policy.
-        return train.eval_policy(rl_algo, venv)
+        return policy_evaluation.eval_policy(rl_algo, venv)
 
 
 def main_console():

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -100,13 +100,23 @@ ALGO_FAST_CONFIGS = {
         "environment.fast",
         "demonstrations.fast",
         "rl.fast",
-        "train.fast",
+        "policy_evaluation.fast",
         "fast",
     ],
     "eval_policy": ["environment.fast", "fast"],
-    "imitation": ["environment.fast", "demonstrations.fast", "train.fast", "fast"],
-    "preference_comparison": ["environment.fast", "rl.fast", "train.fast", "fast"],
-    "rl": ["environment.fast", "rl.fast", "train.fast", "fast"],
+    "imitation": [
+        "environment.fast",
+        "demonstrations.fast",
+        "policy_evaluation.fast",
+        "fast",
+    ],
+    "preference_comparison": [
+        "environment.fast",
+        "rl.fast",
+        "policy_evaluation.fast",
+        "fast",
+    ],
+    "rl": ["environment.fast", "rl.fast", "fast"],
 }
 
 RL_SAC_NAMED_CONFIGS = ["rl.sac", "train.sac"]

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -304,7 +304,7 @@ def test_train_dagger_warmstart(tmpdir):
         config_updates=dict(
             logging=dict(log_root=tmpdir),
             demonstrations=dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
-            agent_path=policy_path,
+            bc=dict(agent_path=policy_path),
         ),
     )
     assert run_warmstart.status == "COMPLETED"
@@ -426,7 +426,7 @@ def test_train_bc_warmstart(tmpdir):
         config_updates=dict(
             logging=dict(log_root=tmpdir),
             demonstrations=dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
-            agent_path=policy_path,
+            bc=dict(agent_path=policy_path),
         ),
     )
 

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -119,7 +119,7 @@ ALGO_FAST_CONFIGS = {
     "rl": ["environment.fast", "rl.fast", "fast"],
 }
 
-RL_SAC_NAMED_CONFIGS = ["rl.sac", "train.sac"]
+RL_SAC_NAMED_CONFIGS = ["rl.sac", "policy.sac"]
 
 
 @pytest.fixture(
@@ -544,7 +544,7 @@ def _check_train_ex_result(result: dict):
     "named_configs",
     (
         [],
-        ["train.normalize_running", "reward.normalize_input_running"],
+        ["policy.normalize_running", "reward.normalize_input_running"],
         ["reward.normalize_input_disable"],
     ),
 )
@@ -700,7 +700,7 @@ def test_transfer_learning(tmpdir: str) -> None:
     "named_configs_dict",
     (
         dict(pc=[], rl=[]),
-        dict(pc=["rl.sac", "train.sac"], rl=["rl.sac", "train.sac"]),
+        dict(pc=["rl.sac", "policy.sac"], rl=["rl.sac", "policy.sac"]),
         dict(pc=["reward.reward_ensemble"], rl=[]),
     ),
 )
@@ -797,7 +797,7 @@ def test_train_rl_cnn_policy(tmpdir: str, rng):
 
     log_dir_data = os.path.join(tmpdir, "train_rl")
     run = train_rl.train_rl_ex.run(
-        named_configs=["train.cnn_policy"] + ALGO_FAST_CONFIGS["rl"],
+        named_configs=["policy.cnn_policy"] + ALGO_FAST_CONFIGS["rl"],
         config_updates=dict(
             environment=dict(gym_id="AsteroidsNoFrameskip-v4"),
             logging=dict(log_dir=log_dir_data),


### PR DESCRIPTION
## Description

Working towards #79, this PR
- splits the `train` ingredient into a `policy_evaluation` and a `policy` ingredient.
- pulls a `bc` ingredient out of `train_imitation`
- untangles the `BehaviorCloning` and the `DAgger` execution inside of `train_imitation`

## Testing

Description of how you've tested your changes.
