### PR TITLE
Enable git lfs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ executors:
     environment:
       # more CPUs visible but we're throttled to 8, which breaks auto-detect
       NUM_CPUS: 8
+      GIT_LFS_SKIP_SMUDGE: 1
   static-analysis-xlarge:
     <<: *defaults
     # darglint is slow enough that we benefit from xlarge even for linting.
@@ -45,6 +46,18 @@ commands:
     description: "Check out and update Python dependencies on Linux."
     steps:
       - checkout
+
+      # Download and cache git-lfs files
+      - run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      - restore_cache:
+          keys:
+            - v1-lfscache-{{ checksum ".lfs-assets-id" }}
+            - v1-lfscache-
+      - run: git lfs pull
+      - save_cache:
+          paths:
+            - .git/lfs
+          key: v1-lfscache-{{ checksum ".lfs-assets-id" }}
 
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ executors:
     environment:
       # more CPUs visible but we're throttled to 8, which breaks auto-detect
       NUM_CPUS: 8
+      # Prevent git lfs from downloading files upon checkout
+      # (we want to do this explicitly, so we can cache them)
+      # see https://naiyer.dev/post/2020/09/05/using-git-lfs-in-ci/ for details
       GIT_LFS_SKIP_SMUDGE: 1
   static-analysis-xlarge:
     <<: *defaults

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # base stage contains just binary dependencies.
 # This is used in the CI build.
-FROM nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04 AS base
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04 AS base
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -q \
@@ -12,6 +12,8 @@ RUN apt-get update -q \
     wget \
     ffmpeg \
     git \
+    git-lfs \
+    ssh \
     libgl1-mesa-dev \
     libgl1-mesa-glx \
     libglew-dev \
@@ -31,6 +33,8 @@ RUN apt-get update -q \
     patchelf  \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN git lfs install
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
## Description

For some testdata we rather want to store it using git LFS. We need this for the new tests in #677 but I decided to pull this out to ensure there is no scope-creep in #677.
I also updated the cuda version along the way.
This is modeled mostly after https://naiyer.dev/post/2020/09/05/using-git-lfs-in-ci/

## Testing

I initially based this on top of `huggingface_datasets` branch because I needed it there. The pipeline there succeeded (with some LFS objects in the history).

- [In this job you can see the cache miss](https://app.circleci.com/pipelines/github/HumanCompatibleAI/imitation/3362/workflows/8ee9d338-8ebc-4acc-be99-9d85d025adaa/jobs/12473)
- [In this job you can see the cache hit working](https://app.circleci.com/pipelines/github/HumanCompatibleAI/imitation/3362/workflows/7cb191a1-8cfb-4393-9c8a-130e9f81207f/jobs/12480) (no more git lfs objects are pulled)

## Before Merging
We need to change the image from `base-alpha` to `base`!!!
