### PR TITLE
add kwargs in reset

### DIFF
--- a/src/imitation/data/wrappers.py
+++ b/src/imitation/data/wrappers.py
@@ -186,7 +186,7 @@ class RolloutInfoWrapper(gym.Wrapper):
         self._rews = None
 
     def reset(self, **kwargs):
-        new_obs = super().reset()
+        new_obs = super().reset(**kwargs)
         self._obs = [new_obs]
         self._rews = []
         return new_obs


### PR DESCRIPTION


## Description

In those cases that it's necessary to set a seed to maintain a state, the RolloutInfoWrapper loses the seed and doesn't work the env

## Testing

Description of how you've tested your changes.
