### PR TITLE
Faster tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,8 +313,8 @@ jobs:
           name: run tests
           command: |
             Xdummy-entrypoint.py pytest -n ${NUM_CPUS} --cov=/venv/lib/python3.8/site-packages/imitation \
-                   --cov=tests --junitxml=/tmp/test-reports/junit.xml \
-                    -vv tests/
+                  --cov=tests --junitxml=/tmp/test-reports/junit.xml \
+                  --durations=500 -vv tests/
             mv .coverage .coverage.imitation
             coverage combine  # rewrite paths from virtualenv to src/
 


### PR DESCRIPTION
## Description

50x speedup on test_reward_nets.py by moving constants down a bit.

I think we could get similar speedups in other areas by doing some subset of the following:

- Replacing all reward nets/policies/MLPs/CNNs used in the tests with smaller equivalents (e.g. `hid_sizes=(32, 32)` -> `hid_sizes=(3,)`).
- Make rollouts shorter (e.g. `n=5` steps) & wrapping envs with time limits that have `max_episode_steps=n+1` so that a full trajectory doesn't have to be generated to get just a few steps.
- Changing number of gradient updates (& other "how long to train" params) to lower values wherever possible.
- etc.

More extreme ideas:

- Mark some tests as "slow tests" and don't run by default (e.g. checking that trainer improves DAgger perf)
- Make tests fail fast on CI (if they're not already doing that)
- Make it so that later CI steps only run if manually approved (e.g. maybe win tests could run only if manually approved)

## Testing

Changes are to tests.