### PR TITLE
Support for stateful policies

### DIFF
--- a/docs/tutorials/6_train_mce.ipynb
+++ b/docs/tutorials/6_train_mce.ipynb
@@ -40,7 +40,7 @@
     "from imitation.data import rollout\n",
     "from imitation.rewards import reward_nets\n",
     "\n",
-    "env_creator = partial(CliffWorldEnv, height=4, horizon=8, width=7, use_xy_obs=True)\n",
+    "env_creator = partial(CliffWorldEnv, height=4, horizon=40, width=7, use_xy_obs=True)\n",
     "env_single = env_creator()\n",
     "\n",
     "state_env_creator = lambda: base_envs.ExposePOMDPStateWrapper(env_creator())\n",

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,3 @@
 [mypy]
 ignore_missing_imports = true
+exclude = output

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -263,8 +263,9 @@ def make_sample_until(
     return sample_until
 
 
-# A PolicyCallable is a function that takes an array of observations
-# and returns an array of corresponding actions.
+# A PolicyCallable is a function that takes an array of observations, an optional
+# array of states, and an optional array of episode starts and returns an array of
+# corresponding actions.
 PolicyCallable = Callable[
     [np.ndarray, Optional[Tuple[np.ndarray, ...]], Optional[np.ndarray]],
     Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]],
@@ -303,7 +304,7 @@ def policy_to_callable(
             assert isinstance(policy, (BaseAlgorithm, BasePolicy))
             # pytype doesn't seem to understand that policy is a BaseAlgorithm
             # or BasePolicy here, rather than a Callable
-            (acts, states) = policy.predict( # pytype: disable=attribute-error
+            (acts, states) = policy.predict(  # pytype: disable=attribute-error
                 observations,
                 state=states,
                 episode_start=episode_starts,

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -300,8 +300,6 @@ def policy_to_callable(
             state: Optional[Tuple[np.ndarray, ...]],
             episode_start: Optional[np.ndarray],
         ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
-            # pytype doesn't seem to understand that policy is a BaseAlgorithm
-            # or BasePolicy here, rather than a Callable
             assert isinstance(policy, (BaseAlgorithm, BasePolicy))
             (acts, state) = policy.predict(
                 observation,

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -301,7 +301,9 @@ def policy_to_callable(
             episode_start: Optional[np.ndarray],
         ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
             assert isinstance(policy, (BaseAlgorithm, BasePolicy))
-            (acts, state) = policy.predict(
+            # pytype doesn't seem to understand that policy is a BaseAlgorithm
+            # or BasePolicy here, rather than a Callable
+            (acts, state) = policy.predict( # pytype: disable=attribute-error
                 observation,
                 state=state,
                 episode_start=episode_start,

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -282,12 +282,12 @@ def policy_to_callable(
     if policy is None:
 
         def get_actions(
-            observation: np.ndarray,
-            state: Optional[Tuple[np.ndarray, ...]],
-            episode_start: Optional[np.ndarray],
+            observations: np.ndarray,
+            states: Optional[Tuple[np.ndarray, ...]],
+            episode_starts: Optional[np.ndarray],
         ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
-            acts = [venv.action_space.sample() for _ in range(len(observation))]
-            return np.stack(acts, axis=0), None  # is None the right state?
+            acts = [venv.action_space.sample() for _ in range(len(observations))]
+            return np.stack(acts, axis=0), None
 
     elif isinstance(policy, (BaseAlgorithm, BasePolicy)):
         # There's an important subtlety here: BaseAlgorithm and BasePolicy
@@ -296,20 +296,20 @@ def policy_to_callable(
         # (which would call .forward()). So this elif clause must come first!
 
         def get_actions(
-            observation: np.ndarray,
-            state: Optional[Tuple[np.ndarray, ...]],
-            episode_start: Optional[np.ndarray],
+            observations: np.ndarray,
+            states: Optional[Tuple[np.ndarray, ...]],
+            episode_starts: Optional[np.ndarray],
         ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
             assert isinstance(policy, (BaseAlgorithm, BasePolicy))
             # pytype doesn't seem to understand that policy is a BaseAlgorithm
             # or BasePolicy here, rather than a Callable
-            (acts, state) = policy.predict( # pytype: disable=attribute-error
-                observation,
-                state=state,
-                episode_start=episode_start,
+            (acts, states) = policy.predict( # pytype: disable=attribute-error
+                observations,
+                state=states,
+                episode_start=episode_starts,
                 deterministic=deterministic_policy,
             )
-            return acts, state
+            return acts, states
 
     elif callable(policy):
         # When a policy callable is passed, by default we will use it directly.

--- a/src/imitation/data/rollout.py
+++ b/src/imitation/data/rollout.py
@@ -301,7 +301,10 @@ def policy_to_callable(
         ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
             # pytype doesn't seem to understand that policy is a BaseAlgorithm
             # or BasePolicy here, rather than a Callable
-            acts, state = policy.predict(  # pytype: disable=attribute-error # type: ignore[union-attr]
+            (
+                acts,
+                state,
+            ) = policy.predict(  # pytype: disable=attribute-error # type: ignore[union-attr]
                 observation,
                 state=state,
                 episode_start=episode_start,
@@ -318,7 +321,7 @@ def policy_to_callable(
                 "Cannot set deterministic_policy=True when policy is a callable, "
                 "since deterministic_policy argument is ignored.",
             )
-        get_actions = policy # type: ignore[assignment]
+        get_actions = policy  # type: ignore[assignment]
 
     else:
         raise TypeError(

--- a/src/imitation/policies/exploration_wrapper.py
+++ b/src/imitation/policies/exploration_wrapper.py
@@ -61,7 +61,7 @@ class ExplorationWrapper:
         state: Optional[Tuple[np.ndarray, ...]],
         episode_start: Optional[np.ndarray],
     ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
-        del state, episode_start
+        del state, episode_start  # Unused
         acts = [self.venv.action_space.sample() for _ in range(len(obs))]
         return np.stack(acts, axis=0), None
 
@@ -78,7 +78,7 @@ class ExplorationWrapper:
         input_state: Optional[Tuple[np.ndarray, ...]],
         episode_start: Optional[np.ndarray],
     ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
-        del episode_start
+        del episode_start  # Unused
 
         if input_state is not None:
             # This checks that we aren't passed a state

--- a/src/imitation/policies/exploration_wrapper.py
+++ b/src/imitation/policies/exploration_wrapper.py
@@ -61,8 +61,10 @@ class ExplorationWrapper:
         state: Optional[Tuple[np.ndarray, ...]],
         episode_start: Optional[np.ndarray],
     ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
+        if state is not None:
+            raise ValueError("Exploration wrapper does not support stateful policies.")
         acts = [self.venv.action_space.sample() for _ in range(len(obs))]
-        return np.stack(acts, axis=0), None  # is this right?
+        return np.stack(acts, axis=0), None
 
     def _switch(self) -> None:
         """Pick a new policy at random."""
@@ -74,10 +76,12 @@ class ExplorationWrapper:
     def __call__(
         self,
         observation: np.ndarray,
-        state: Optional[Tuple[np.ndarray, ...]],
-        episode_start: Optional[np.ndarray],
+        _state: Optional[Tuple[np.ndarray, ...]],
+        _episode_start: Optional[np.ndarray],
     ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
-        acts, state = self.current_policy(observation, state, episode_start)
+        acts, state = self.current_policy(observation, None, None)
+        if state is not None:
+            raise ValueError("Exploration wrapper does not support stateful policies.")
         if self.rng.random() < self.switch_prob:
             self._switch()
-        return acts, state
+        return acts, None

--- a/src/imitation/policies/exploration_wrapper.py
+++ b/src/imitation/policies/exploration_wrapper.py
@@ -58,9 +58,10 @@ class ExplorationWrapper:
     def _random_policy(
         self,
         obs: np.ndarray,
-        _state: Optional[Tuple[np.ndarray, ...]],
-        _episode_start: Optional[np.ndarray],
+        state: Optional[Tuple[np.ndarray, ...]],
+        episode_start: Optional[np.ndarray],
     ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
+        del state, episode_start
         acts = [self.venv.action_space.sample() for _ in range(len(obs))]
         return np.stack(acts, axis=0), None
 
@@ -74,17 +75,21 @@ class ExplorationWrapper:
     def __call__(
         self,
         observation: np.ndarray,
-        state: Optional[Tuple[np.ndarray, ...]],
-        _episode_start: Optional[np.ndarray],
+        input_state: Optional[Tuple[np.ndarray, ...]],
+        episode_start: Optional[np.ndarray],
     ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
-        if state is not None:
+        del episode_start
+
+        if input_state is not None:
+            # This checks that we aren't passed a state
             raise ValueError("Exploration wrapper does not support stateful policies.")
 
-        acts, state = self.current_policy(observation, None, None)
+        acts, output_state = self.current_policy(observation, None, None)
 
-        if state is not None:
+        if output_state is not None:
+            # This checks that the policy doesn't return a state
             raise ValueError("Exploration wrapper does not support stateful policies.")
-        
+
         if self.rng.random() < self.switch_prob:
             self._switch()
         return acts, None

--- a/src/imitation/policies/exploration_wrapper.py
+++ b/src/imitation/policies/exploration_wrapper.py
@@ -58,11 +58,9 @@ class ExplorationWrapper:
     def _random_policy(
         self,
         obs: np.ndarray,
-        state: Optional[Tuple[np.ndarray, ...]],
-        episode_start: Optional[np.ndarray],
+        _state: Optional[Tuple[np.ndarray, ...]],
+        _episode_start: Optional[np.ndarray],
     ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
-        if state is not None:
-            raise ValueError("Exploration wrapper does not support stateful policies.")
         acts = [self.venv.action_space.sample() for _ in range(len(obs))]
         return np.stack(acts, axis=0), None
 
@@ -76,12 +74,17 @@ class ExplorationWrapper:
     def __call__(
         self,
         observation: np.ndarray,
-        _state: Optional[Tuple[np.ndarray, ...]],
+        state: Optional[Tuple[np.ndarray, ...]],
         _episode_start: Optional[np.ndarray],
     ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
-        acts, state = self.current_policy(observation, None, None)
         if state is not None:
             raise ValueError("Exploration wrapper does not support stateful policies.")
+
+        acts, state = self.current_policy(observation, None, None)
+
+        if state is not None:
+            raise ValueError("Exploration wrapper does not support stateful policies.")
+        
         if self.rng.random() < self.switch_prob:
             self._switch()
         return acts, None

--- a/src/imitation/policies/exploration_wrapper.py
+++ b/src/imitation/policies/exploration_wrapper.py
@@ -1,5 +1,7 @@
 """Wrapper to turn a policy into a more exploratory version."""
 
+from typing import Optional, Tuple
+
 import numpy as np
 from stable_baselines3.common import vec_env
 
@@ -53,9 +55,14 @@ class ExplorationWrapper:
         # Choose the initial policy at random
         self._switch()
 
-    def _random_policy(self, obs: np.ndarray) -> np.ndarray:
+    def _random_policy(
+        self,
+        obs: np.ndarray,
+        state: Optional[Tuple[np.ndarray, ...]],
+        episode_start: Optional[np.ndarray],
+    ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
         acts = [self.venv.action_space.sample() for _ in range(len(obs))]
-        return np.stack(acts, axis=0)
+        return np.stack(acts, axis=0), None  # is this right?
 
     def _switch(self) -> None:
         """Pick a new policy at random."""
@@ -64,8 +71,13 @@ class ExplorationWrapper:
         else:
             self.current_policy = self.wrapped_policy
 
-    def __call__(self, obs: np.ndarray) -> np.ndarray:
-        acts = self.current_policy(obs)
+    def __call__(
+        self,
+        observation: np.ndarray,
+        state: Optional[Tuple[np.ndarray, ...]],
+        episode_start: Optional[np.ndarray],
+    ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
+        acts, state = self.current_policy(observation, state, episode_start)
         if self.rng.random() < self.switch_prob:
             self._switch()
-        return acts
+        return acts, state

--- a/tests/data/test_rollout.py
+++ b/tests/data/test_rollout.py
@@ -57,8 +57,8 @@ def _sample_fixed_length_trajectories(
 
         # Simple way to get a valid callable: just use a policies .predict() method
         # (still tests another code path inside generate_trajectories)
-        def policy(x):
-            return random_policy.predict(x)[0]
+        def policy(x, state, mask):
+            return random_policy.predict(x)[0], None
 
     elif policy_type == "random":
         policy = None

--- a/tests/data/test_rollout.py
+++ b/tests/data/test_rollout.py
@@ -58,7 +58,7 @@ def _sample_fixed_length_trajectories(
         # Simple way to get a valid callable: just use a policies .predict() method
         # (still tests another code path inside generate_trajectories)
         def policy(x, state, mask):
-            return random_policy.predict(x)[0], None
+            return random_policy.predict(x, state, mask)
 
     elif policy_type == "random":
         policy = None

--- a/tests/policies/test_exploration_wrapper.py
+++ b/tests/policies/test_exploration_wrapper.py
@@ -9,12 +9,12 @@ from imitation.util import util
 
 
 def constant_policy(obs, state, mask):
-    del state, mask
+    del state, mask  # Unused
     return np.zeros(len(obs), dtype=int), None
 
 
 def fake_stateful_policy(obs, state, mask):
-    del state, mask
+    del state, mask  # Unused
     return np.zeros(len(obs), dtype=int), (np.zeros(1),)
 
 

--- a/tests/policies/test_exploration_wrapper.py
+++ b/tests/policies/test_exploration_wrapper.py
@@ -7,8 +7,8 @@ from imitation.policies import exploration_wrapper
 from imitation.util import util
 
 
-def constant_policy(obs):
-    return np.zeros(len(obs), dtype=int)
+def constant_policy(obs, state, mask):
+    return np.zeros(len(obs), dtype=int), None
 
 
 def make_wrapper(random_prob, switch_prob, rng):
@@ -92,7 +92,7 @@ def test_switch_prob(rng):
     policy = wrapper.current_policy
 
     obs = np.random.rand(100, 2)
-    for action in wrapper(obs):
+    for action in wrapper(obs, None, None)[0]:
         assert venv.action_space.contains(action)
         assert wrapper.current_policy == policy
 
@@ -102,7 +102,7 @@ def test_switch_prob(rng):
         num_constant = 0
         for _ in range(num_steps):
             obs = np.random.rand(1, 2)
-            wrapper(obs)
+            wrapper(obs, None, None)
             if wrapper.current_policy == wrapper._random_policy:
                 num_random += 1
             elif wrapper.current_policy == constant_policy:
@@ -137,5 +137,5 @@ def test_valid_output(rng):
         wrapper, venv = make_wrapper(random_prob=random_prob, switch_prob=0.5, rng=rng)
         np.random.seed(0)
         obs = np.random.rand(100, 2)
-        for action in wrapper(obs):
+        for action in wrapper(obs, None, None)[0]:
             assert venv.action_space.contains(action)

--- a/tests/policies/test_exploration_wrapper.py
+++ b/tests/policies/test_exploration_wrapper.py
@@ -9,10 +9,12 @@ from imitation.util import util
 
 
 def constant_policy(obs, state, mask):
+    del state, mask
     return np.zeros(len(obs), dtype=int), None
 
 
 def fake_stateful_policy(obs, state, mask):
+    del state, mask
     return np.zeros(len(obs), dtype=int), (np.zeros(1),)
 
 
@@ -145,6 +147,7 @@ def test_valid_output(rng):
         for action in wrapper(obs, None, None)[0]:
             assert venv.action_space.contains(action)
 
+
 def test_throws_for_stateful_policy(rng):
     venv = util.make_vec_env(
         "seals/CartPole-v0",
@@ -161,8 +164,14 @@ def test_throws_for_stateful_policy(rng):
 
     np.random.seed(0)
     obs = np.random.rand(100, 2)
-    with pytest.raises(ValueError, match="Exploration wrapper does not support stateful policies."):
+    with pytest.raises(
+        ValueError,
+        match="Exploration wrapper does not support stateful policies.",
+    ):
         wrapper(obs, (np.ones_like(obs)), None)
 
-    with pytest.raises(ValueError, match="Exploration wrapper does not support stateful policies."):
+    with pytest.raises(
+        ValueError,
+        match="Exploration wrapper does not support stateful policies.",
+    ):
         wrapper(obs, None, None)


### PR DESCRIPTION
## Description

Add support for stateful policies

https://github.com/HumanCompatibleAI/imitation/issues/413

## Testing

Unit tests pass, plus new unit test.

The notebook at docs/tutorials/6_train_mce.ipynb learns a slightly different reward function - the expert policies are found with the soft bellman backup, which has a more variable behavior in later time steps. @levmckinney said this is likely due to the fact that there's less future reward so the algorithm focuses more on maximizing entropy. Over longer time horizons he said the old and new policies should be more similar, so I set the horizon to 40. Both learned reward functions changed, but they are more similar (and the new policy is less variable)

Without state (horizon 8):
![image](https://github.com/HumanCompatibleAI/imitation/assets/317704/aa61d6d5-b07c-45ac-8cee-e5a2fceb142a)

With state (horizon 8):

ex 1
![image](https://github.com/HumanCompatibleAI/imitation/assets/317704/71220378-0db5-40b3-a087-0f09e67fd4c9)

ex 2
![image](https://github.com/HumanCompatibleAI/imitation/assets/317704/3cad022e-402b-425b-8b28-e9b7fbf9cd80)

ex 3
![image](https://github.com/HumanCompatibleAI/imitation/assets/317704/3185b6e1-1a90-46b9-9755-35ada8565d6f)

Without state (horizon 40):
![image](https://github.com/HumanCompatibleAI/imitation/assets/317704/51c0fbdb-d4b9-43d7-a7ed-e55bb7a642f1)

With state (horizon 40):

![image](https://github.com/HumanCompatibleAI/imitation/assets/317704/dcf02e25-f8b8-40b9-a742-8f896691e3a4)