### PR TITLE
Transition from Models Hub to Datasets Hub for expert trajectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ From [examples/quickstart.sh:](examples/quickstart.sh)
 python -m imitation.scripts.train_rl with pendulum environment.fast policy_evaluation.fast rl.fast fast logging.log_dir=quickstart/rl/
 
 # Train GAIL from demonstrations. Tensorboard logs saved in output/ (default log directory).
-python -m imitation.scripts.train_adversarial gail with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.path=quickstart/rl/rollouts/final.npz
+python -m imitation.scripts.train_adversarial gail with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.path=quickstart/rl/rollouts/final.npz demonstrations.source=local
 
 # Train AIRL from demonstrations. Tensorboard logs saved in output/ (default log directory).
-python -m imitation.scripts.train_adversarial airl with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.path=quickstart/rl/rollouts/final.npz
+python -m imitation.scripts.train_adversarial airl with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.path=quickstart/rl/rollouts/final.npz demonstrations.source=local
 ```
 
 Tips:

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ From [examples/quickstart.sh:](examples/quickstart.sh)
 python -m imitation.scripts.train_rl with pendulum environment.fast policy_evaluation.fast rl.fast fast logging.log_dir=quickstart/rl/
 
 # Train GAIL from demonstrations. Tensorboard logs saved in output/ (default log directory).
-python -m imitation.scripts.train_adversarial gail with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.rollout_path=quickstart/rl/rollouts/final.npz
+python -m imitation.scripts.train_adversarial gail with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.path=quickstart/rl/rollouts/final.npz
 
 # Train AIRL from demonstrations. Tensorboard logs saved in output/ (default log directory).
-python -m imitation.scripts.train_adversarial airl with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.rollout_path=quickstart/rl/rollouts/final.npz
+python -m imitation.scripts.train_adversarial airl with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.path=quickstart/rl/rollouts/final.npz
 ```
 
 Tips:

--- a/benchmarking/example_airl_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_ant_best_hp_eval.json
@@ -6,7 +6,8 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "reward": {

--- a/benchmarking/example_airl_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_ant_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_airl_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_ant_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
@@ -6,7 +6,8 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "reward": {

--- a/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_half_cheetah_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_airl_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_hopper_best_hp_eval.json
@@ -6,7 +6,8 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "reward": {

--- a/benchmarking/example_airl_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_hopper_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_airl_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_hopper_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
@@ -6,7 +6,8 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "expert": {

--- a/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_swimmer_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_airl_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_walker_best_hp_eval.json
@@ -6,7 +6,8 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "expert": {

--- a/benchmarking/example_airl_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_walker_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_airl_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_airl_seals_walker_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_bc_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_ant_best_hp_eval.json
@@ -20,7 +20,8 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "policy": {

--- a/benchmarking/example_bc_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_ant_best_hp_eval.json
@@ -20,7 +20,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_bc_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_ant_best_hp_eval.json
@@ -20,7 +20,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
@@ -20,7 +20,8 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "policy": {

--- a/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
@@ -20,7 +20,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_half_cheetah_best_hp_eval.json
@@ -20,7 +20,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_bc_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_hopper_best_hp_eval.json
@@ -20,7 +20,8 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "policy": {

--- a/benchmarking/example_bc_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_hopper_best_hp_eval.json
@@ -20,7 +20,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_bc_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_hopper_best_hp_eval.json
@@ -20,7 +20,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
@@ -20,7 +20,8 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "policy": {

--- a/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
@@ -20,7 +20,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_swimmer_best_hp_eval.json
@@ -20,7 +20,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_bc_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_walker_best_hp_eval.json
@@ -20,7 +20,8 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "policy": {

--- a/benchmarking/example_bc_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_walker_best_hp_eval.json
@@ -20,7 +20,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_bc_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_bc_seals_walker_best_hp_eval.json
@@ -20,7 +20,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_dagger_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_ant_best_hp_eval.json
@@ -24,7 +24,8 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "policy": {

--- a/benchmarking/example_dagger_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_ant_best_hp_eval.json
@@ -24,7 +24,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_dagger_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_ant_best_hp_eval.json
@@ -24,7 +24,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
@@ -24,7 +24,8 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "policy": {

--- a/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
@@ -24,7 +24,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_half_cheetah_best_hp_eval.json
@@ -24,7 +24,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
@@ -24,7 +24,8 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "policy": {

--- a/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
@@ -24,7 +24,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_hopper_best_hp_eval.json
@@ -24,7 +24,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
@@ -24,7 +24,8 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "policy": {

--- a/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
@@ -24,7 +24,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_swimmer_best_hp_eval.json
@@ -24,7 +24,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_dagger_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_walker_best_hp_eval.json
@@ -24,7 +24,8 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "policy": {

--- a/benchmarking/example_dagger_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_walker_best_hp_eval.json
@@ -24,7 +24,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_dagger_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_dagger_seals_walker_best_hp_eval.json
@@ -24,7 +24,7 @@
     "use_offline_rollouts": false
   },
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_gail_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_ant_best_hp_eval.json
@@ -6,7 +6,8 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "reward": {

--- a/benchmarking/example_gail_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_ant_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_gail_seals_ant_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_ant_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
@@ -6,7 +6,8 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "reward": {

--- a/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_half_cheetah_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_gail_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_hopper_best_hp_eval.json
@@ -6,7 +6,8 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "reward": {

--- a/benchmarking/example_gail_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_hopper_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_gail_seals_hopper_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_hopper_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
@@ -6,7 +6,8 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "expert": {

--- a/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_swimmer_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_gail_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_walker_best_hp_eval.json
@@ -6,7 +6,8 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "ppo-huggingface",
+    "rollout_type": "huggingface",
+    "algo_name": "ppo",
     "n_expert_demos": null
   },
   "expert": {

--- a/benchmarking/example_gail_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_walker_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "type": "huggingface",
+    "source": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/example_gail_seals_walker_best_hp_eval.json
+++ b/benchmarking/example_gail_seals_walker_best_hp_eval.json
@@ -6,7 +6,7 @@
   },
   "checkpoint_interval": 0,
   "demonstrations": {
-    "rollout_type": "huggingface",
+    "type": "huggingface",
     "algo_name": "ppo",
     "n_expert_demos": null
   },

--- a/benchmarking/util.py
+++ b/benchmarking/util.py
@@ -71,7 +71,7 @@ def clean_config_file(file: pathlib.Path, write_path: pathlib.Path, /) -> None:
     # remove key 'agent_path'
     config.pop("agent_path")
     config.pop("seed")
-    config.get("demonstrations", {}).pop("rollout_path")
+    config.get("demonstrations", {}).pop("path")
     config.get("expert", {}).get("loader_kwargs", {}).pop("path", None)
     env_name = config.pop("environment").pop("gym_id")
     config["environment"] = {"gym_id": env_name}

--- a/examples/quickstart.sh
+++ b/examples/quickstart.sh
@@ -4,7 +4,7 @@
 python -m imitation.scripts.train_rl with pendulum environment.fast policy_evaluation.fast rl.fast fast logging.log_dir=quickstart/rl/
 
 # Train GAIL from demonstrations. Tensorboard logs saved in output/ (default log directory).
-python -m imitation.scripts.train_adversarial gail with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.rollout_path=quickstart/rl/rollouts/final.npz
+python -m imitation.scripts.train_adversarial gail with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.path=quickstart/rl/rollouts/final.npz
 
 # Train AIRL from demonstrations. Tensorboard logs saved in output/ (default log directory).
-python -m imitation.scripts.train_adversarial airl with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.rollout_path=quickstart/rl/rollouts/final.npz
+python -m imitation.scripts.train_adversarial airl with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.path=quickstart/rl/rollouts/final.npz

--- a/examples/quickstart.sh
+++ b/examples/quickstart.sh
@@ -4,7 +4,7 @@
 python -m imitation.scripts.train_rl with pendulum environment.fast policy_evaluation.fast rl.fast fast logging.log_dir=quickstart/rl/
 
 # Train GAIL from demonstrations. Tensorboard logs saved in output/ (default log directory).
-python -m imitation.scripts.train_adversarial gail with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.path=quickstart/rl/rollouts/final.npz
+python -m imitation.scripts.train_adversarial gail with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.path=quickstart/rl/rollouts/final.npz demonstrations.source=local
 
 # Train AIRL from demonstrations. Tensorboard logs saved in output/ (default log directory).
-python -m imitation.scripts.train_adversarial airl with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.path=quickstart/rl/rollouts/final.npz
+python -m imitation.scripts.train_adversarial airl with pendulum environment.fast demonstrations.fast policy_evaluation.fast rl.fast fast demonstrations.path=quickstart/rl/rollouts/final.npz demonstrations.source=local

--- a/src/imitation/data/serialize.py
+++ b/src/imitation/data/serialize.py
@@ -5,7 +5,6 @@ import warnings
 from typing import Mapping, Sequence, cast
 
 import datasets
-import huggingface_sb3 as hfsb3
 import numpy as np
 
 from imitation.data import huggingface_utils
@@ -87,14 +86,3 @@ def load_with_rewards(path: AnyPath) -> Sequence[TrajectoryWithRew]:
         )
 
     return cast(Sequence[TrajectoryWithRew], data)
-
-
-def load_rollouts_from_huggingface(
-    algo_name: str,
-    env_name: str,
-    organization: str = "HumanCompatibleAI",
-) -> str:
-    model_name = hfsb3.ModelName(algo_name, hfsb3.EnvironmentName(env_name))
-    repo_id = hfsb3.ModelRepoId(organization, model_name)
-    filename = hfsb3.load_from_hub(repo_id, "rollouts.npz")
-    return filename

--- a/src/imitation/scripts/ingredients/demonstrations.py
+++ b/src/imitation/scripts/ingredients/demonstrations.py
@@ -150,11 +150,12 @@ def _generate_expert_trajs(
 
 @demonstrations_ingredient.capture
 def _download_expert_rollouts(
-        environment: Dict[str, Any],
-        path: Optional[str],
-        organization: Optional[str],
-        algo_name: Optional[str],
-        loader_kwargs: Dict[str, Any]):
+    environment: Dict[str, Any],
+    path: Optional[str],
+    organization: Optional[str],
+    algo_name: Optional[str],
+    loader_kwargs: Dict[str, Any],
+):
     if path is not None:
         repo_id = path
     else:

--- a/src/imitation/scripts/ingredients/demonstrations.py
+++ b/src/imitation/scripts/ingredients/demonstrations.py
@@ -26,12 +26,12 @@ logger = logging.getLogger(__name__)
 @demonstrations_ingredient.config
 def config():
     # Either "local" or "huggingface" or "generated".
-    type = "generated"
+    source = "generated"
 
     # local path or huggingface repo id to load rollouts from.
     path = None
 
-    # passed to `datasets.load_dataset` if `type` is "huggingface"
+    # passed to `datasets.load_dataset` if `source` is "huggingface"
     loader_kwargs: Dict[str, Any] = dict(
         split="train",
     )
@@ -56,40 +56,40 @@ def fast():
 
 @demonstrations_ingredient.capture
 def get_expert_trajectories(
-    type: str,
+    source: str,
     path: str,
 ) -> Sequence[types.Trajectory]:
     """Loads expert demonstrations.
 
     Args:
-        type: Can be either `local` to load rollouts from the disk or to
-            generate them locally or of the format `{algo}-huggingface` to load
-            from the huggingface hub of expert trained using `{algo}`.
-        path: A path containing a pickled sequence of `types.Trajectory`.
+        source: Can be either `local` to load rollouts from the disk,
+            `huggingface` to load from the HuggingFace hub or
+            `generated` to generate the expert trajectories.
+        path: A path containing a pickled sequence of `sources.Trajectory`.
 
     Returns:
         The expert trajectories.
 
     Raises:
-        ValueError: if `type` is not in ["local", "huggingface", "generated"].
+        ValueError: if `source` is not in ["local", "huggingface", "generated"].
     """
-    if type == "local":
+    if source == "local":
         if path is None:
             raise ValueError(
-                "When type is 'local', path must be set.",
+                "When source is 'local', path must be set.",
             )
         return _constrain_number_of_demos(serialize.load(path))
 
-    if type == "huggingface":
+    if source == "huggingface":
         return _constrain_number_of_demos(_download_expert_rollouts())
 
-    if type == "generated":
+    if source == "generated":
         if path is not None:
-            logger.warning("Ignoring path when type is 'generated'")
+            logger.warning("Ignoring path when source is 'generated'")
         return _generate_expert_trajs()
 
     raise ValueError(
-        "`type` can either be `local` or `huggingface` or `generated`.",
+        "`source` can either be `local` or `huggingface` or `generated`.",
     )
 
 

--- a/src/imitation/scripts/ingredients/demonstrations.py
+++ b/src/imitation/scripts/ingredients/demonstrations.py
@@ -1,14 +1,15 @@
 """Ingredient for scripts learning from demonstrations."""
 
 import logging
-import pathlib
 import warnings
-from typing import Optional, Sequence, Union
+from typing import Any, Dict, Optional, Sequence
 
+import datasets
+import huggingface_sb3 as hfsb3
 import numpy as np
 import sacred
 
-from imitation.data import rollout, serialize, types
+from imitation.data import huggingface_utils, rollout, serialize, types
 from imitation.scripts.ingredients import environment, expert
 from imitation.scripts.ingredients import logging as logging_ingredient
 
@@ -59,28 +60,58 @@ def get_expert_trajectories(
     Raises:
         ValueError: if `rollout_type` is not "local" or of the form {algo}-huggingface.
     """
-    if rollout_type.endswith("-huggingface"):
-        if rollout_path is not None:
-            warnings.warn(
-                "Ignoring `rollout_path` since `rollout_type` is set to download the "
-                "rollouts from the huggingface-hub. If you want to load the rollouts "
-                'from disk, set `rollout_type`="local" and the path in `rollout_path`.',
-                RuntimeWarning,
-            )
-        rollout_path = _download_expert_rollouts(rollout_type)
-    elif rollout_type != "local":
+    is_local_rollouts = rollout_type == "local"
+    is_huggingface_rollouts = rollout_type.endswith("-huggingface")
+    is_rollout_path_set = rollout_path is not None
+
+    if not (is_local_rollouts or is_huggingface_rollouts):
         raise ValueError(
             "`rollout_type` can either be `local` or of the form `{algo}-huggingface`.",
         )
 
-    if rollout_path is not None:
-        return load_local_expert_trajs(rollout_path)
+    if is_huggingface_rollouts and is_rollout_path_set:
+        warnings.warn(
+            "Ignoring `rollout_path` since `rollout_type` is set to download the "
+            "rollouts from the huggingface-hub. If you want to load the rollouts "
+            'from disk, set `rollout_type`="local" and the path in `rollout_path`.',
+            RuntimeWarning,
+        )
+
+    if is_huggingface_rollouts:
+        return _constrain_number_of_demos(_download_expert_rollouts(rollout_type))
+    if is_local_rollouts and is_rollout_path_set:
+        logger.info(f"Loading expert trajectories from '{rollout_path}'")
+        return _constrain_number_of_demos(serialize.load(rollout_path))
     else:
-        return generate_expert_trajs()
+        return _generate_expert_trajs()
 
 
 @demonstrations_ingredient.capture
-def generate_expert_trajs(
+def _constrain_number_of_demos(
+    demos: Sequence[types.Trajectory],
+    n_expert_demos: Optional[int],
+) -> Sequence[types.Trajectory]:
+    """Constrains the number of demonstrations to n_expert_demos if it is not None."""
+    if n_expert_demos is None:
+        return demos
+    else:
+        if len(demos) < n_expert_demos:
+            raise ValueError(
+                f"Want to use n_expert_demos={n_expert_demos} trajectories, but only "
+                f"{len(demos)} are available.",
+            )
+        if len(demos) > n_expert_demos:
+            logger.warning(
+                f"Using only the first {n_expert_demos} trajectories out of "
+                f"{len(demos)} available.",
+            )
+            return demos[:n_expert_demos]
+        else:
+            return demos
+
+
+@demonstrations_ingredient.capture
+def _generate_expert_trajs(
     n_expert_demos: Optional[int],
     _rnd: np.random.Generator,
 ) -> Optional[Sequence[types.Trajectory]]:
@@ -100,6 +131,7 @@ def generate_expert_trajs(
     if n_expert_demos is None:
         raise ValueError("n_expert_demos must be specified when rollout_path is None")
 
+    logger.info(f"Generating {n_expert_demos} expert trajectories")
     with environment.make_rollout_venv() as rollout_env:
         return rollout.rollout(
             expert.get_expert_policy(rollout_env),
@@ -109,43 +141,15 @@ def generate_expert_trajs(
         )
 
 
-@demonstrations_ingredient.capture
-def load_local_expert_trajs(
-    rollout_path: Union[str, pathlib.Path],
-    n_expert_demos: Optional[int],
-) -> Sequence[types.Trajectory]:
-    """Loads expert demonstrations from a local path.
-
-    Args:
-        rollout_path: A path containing a pickled sequence of `types.Trajectory`.
-        n_expert_demos: The number of trajectories to load.
-            Dataset is truncated to this length if specified.
-
-    Returns:
-        The expert trajectories.
-
-    Raises:
-        ValueError: There are fewer trajectories than `n_expert_demos`.
-    """
-    expert_trajs = serialize.load(rollout_path)
-    logger.info(f"Loaded {len(expert_trajs)} expert trajectories from '{rollout_path}'")
-    if n_expert_demos is not None:
-        if len(expert_trajs) < n_expert_demos:
-            raise ValueError(
-                f"Want to use n_expert_demos={n_expert_demos} trajectories, but only "
-                f"{len(expert_trajs)} are available via {rollout_path}.",
-            )
-        expert_trajs = expert_trajs[:n_expert_demos]
-        logger.info(f"Truncated to {n_expert_demos} expert trajectories")
-    return expert_trajs
-
-
 @demonstrations_ingredient.capture(prefix="expert")
-def _download_expert_rollouts(rollout_type, loader_kwargs):
+def _download_expert_rollouts(rollout_type: str, loader_kwargs: Dict[str, Any]):
     assert rollout_type.endswith("-huggingface")
     algo_name = rollout_type.split("-")[0]
-    return serialize.load_rollouts_from_huggingface(
+    model_name = hfsb3.ModelName(
         algo_name,
-        env_name=loader_kwargs["env_name"],
-        organization=loader_kwargs["organization"],
+        hfsb3.EnvironmentName(loader_kwargs["env_name"]),
     )
+    repo_id = hfsb3.ModelRepoId(loader_kwargs["organization"], model_name)
+    logger.info(f"Loading expert trajectories from {repo_id}")
+    dataset = datasets.load_dataset(repo_id)["train"]
+    return huggingface_utils.TrajectoryDatasetSequence(dataset)

--- a/src/imitation/scripts/ingredients/demonstrations.py
+++ b/src/imitation/scripts/ingredients/demonstrations.py
@@ -71,7 +71,7 @@ def get_expert_trajectories(
         The expert trajectories.
 
     Raises:
-        ValueError: if `type` is not "local" or of the form {algo}-huggingface.
+        ValueError: if `type` is not in ["local", "huggingface", "generated"].
     """
     if type == "local":
         if path is None:
@@ -136,7 +136,7 @@ def _generate_expert_trajs(
         ValueError: If n_expert_demos is None.
     """
     if n_expert_demos is None:
-        raise ValueError("n_expert_demos must be specified when path is None")
+        raise ValueError("n_expert_demos must be specified when generating demos.")
 
     logger.info(f"Generating {n_expert_demos} expert trajectories")
     with environment.make_rollout_venv() as rollout_env:

--- a/src/imitation/scripts/ingredients/policy_evaluation.py
+++ b/src/imitation/scripts/ingredients/policy_evaluation.py
@@ -46,7 +46,7 @@ def eval_policy(
         `rollout_stats()` on rollouts test-reward-wrapped environment, using the final
         policy (remember that the ground-truth reward can be recovered from the
         "monitor_return" key). "expert_stats" gives the return value of
-        `rollout_stats()` on the expert demonstrations loaded from `rollout_path`.
+        `rollout_stats()` on the expert demonstrations loaded from `path`.
     """
     sample_until_eval = rollout.make_min_episodes(n_episodes_eval)
     if isinstance(rl_algo, base_class.BaseAlgorithm):

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -330,26 +330,12 @@ def test_train_bc_main_with_demonstrations_from_huggingface(tmpdir):
         named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["imitation"],
         config_updates=dict(
             logging=dict(log_root=tmpdir),
-            demonstrations=dict(rollout_type="ppo-huggingface"),
+            demonstrations=dict(
+                rollout_type="huggingface",
+                algo_name="ppo",
+            ),
         ),
     )
-
-
-def test_train_bc_main_with_demonstrations_raises_error_on_wrong_huggingface_format(
-    tmpdir,
-):
-    with pytest.raises(
-        ValueError,
-        match="`rollout_type` can either be `local` or of the form .*-huggingface.S*",
-    ):
-        train_imitation.train_imitation_ex.run(
-            command_name="bc",
-            named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["imitation"],
-            config_updates=dict(
-                logging=dict(log_root=tmpdir),
-                demonstrations=dict(rollout_type="huggingface-ppo"),
-            ),
-        )
 
 
 def test_train_bc_main_with_demonstrations_warns_setting_rollout_type(

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -347,18 +347,23 @@ def test_train_bc_main_with_demonstrations_from_huggingface(tmpdir):
     ],
 )
 def bc_config(tmpdir, request):
-    expert_config = dict(
-        expert_from_path=dict(
+    environment_named_config = "seals_cartpole"
+
+    if request.param == "expert_from_path":
+        expert_config = dict(
             policy_type="ppo",
             loader_kwargs=dict(path=CARTPOLE_TEST_POLICY_PATH / "model.zip"),
-        ),
-        expert_from_huggingface=dict(policy_type="ppo-huggingface"),
-        random_expert=dict(policy_type="random"),
-        zero_expert=dict(policy_type="zero"),
-    )[request.param]
-    # Note: The stored expert, that we have is for the normal cartpole environment while the expert from huggingface is
-    # for the seals cartpole environment.
-    environment_named_config = "cartpole" if request.param == "expert_from_path" else "seals_cartpole"
+        )
+        # Note: we don't have a seals_cartpole expert in our testdata folder,
+        # so we use the cartpole environment in this case.
+        environment_named_config = "cartpole"
+    elif request.param == "expert_from_huggingface":
+        expert_config = dict(policy_type="ppo-huggingface")
+    elif request.param == "random_expert":
+        expert_config = dict(policy_type="random")
+    elif request.param == "zero_expert":
+        expert_config = dict(policy_type="zero")
+
     return dict(
         command_name="bc",
         named_configs=[environment_named_config] + ALGO_FAST_CONFIGS["imitation"],

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -356,9 +356,12 @@ def bc_config(tmpdir, request):
         random_expert=dict(policy_type="random"),
         zero_expert=dict(policy_type="zero"),
     )[request.param]
+    # Note: The stored expert, that we have is for the normal cartpole environment while the expert from huggingface is
+    # for the seals cartpole environment.
+    environment_named_config = "cartpole" if request.param == "expert_from_path" else "seals_cartpole"
     return dict(
         command_name="bc",
-        named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["imitation"],
+        named_configs=[environment_named_config] + ALGO_FAST_CONFIGS["imitation"],
         config_updates=dict(
             logging=dict(log_root=tmpdir),
             expert=expert_config,

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -272,7 +272,7 @@ def test_train_dagger_main(tmpdir):
             named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["imitation"],
             config_updates=dict(
                 logging=dict(log_root=tmpdir),
-                demonstrations=dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+                demonstrations=dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
             ),
         )
     for warning in record:
@@ -292,7 +292,7 @@ def test_train_dagger_warmstart(tmpdir):
         named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["imitation"],
         config_updates=dict(
             logging=dict(log_root=tmpdir),
-            demonstrations=dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+            demonstrations=dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
         ),
     )
     assert run.status == "COMPLETED"
@@ -304,7 +304,7 @@ def test_train_dagger_warmstart(tmpdir):
         named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["imitation"],
         config_updates=dict(
             logging=dict(log_root=tmpdir),
-            demonstrations=dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+            demonstrations=dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
             bc=dict(agent_path=policy_path),
         ),
     )
@@ -313,7 +313,7 @@ def test_train_dagger_warmstart(tmpdir):
 
 
 def test_train_bc_main_with_none_demonstrations_raises_value_error(tmpdir):
-    with pytest.raises(ValueError, match=".*n_expert_demos.*rollout_path.*"):
+    with pytest.raises(ValueError, match="When type is 'local', path must be set."):
         train_imitation.train_imitation_ex.run(
             command_name="bc",
             named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["imitation"],
@@ -331,7 +331,7 @@ def test_train_bc_main_with_demonstrations_from_huggingface(tmpdir):
         config_updates=dict(
             logging=dict(log_root=tmpdir),
             demonstrations=dict(
-                rollout_type="huggingface",
+                type="huggingface",
                 algo_name="ppo",
             ),
         ),
@@ -362,7 +362,7 @@ def bc_config(tmpdir, request):
         config_updates=dict(
             logging=dict(log_root=tmpdir),
             expert=expert_config,
-            demonstrations=dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+            demonstrations=dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
         ),
     )
 
@@ -379,7 +379,7 @@ def test_train_bc_warmstart(tmpdir):
         named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["imitation"],
         config_updates=dict(
             logging=dict(log_root=tmpdir),
-            demonstrations=dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+            demonstrations=dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
             expert=dict(policy_type="ppo-huggingface"),
         ),
     )
@@ -392,7 +392,7 @@ def test_train_bc_warmstart(tmpdir):
         named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["imitation"],
         config_updates=dict(
             logging=dict(log_root=tmpdir),
-            demonstrations=dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+            demonstrations=dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
             bc=dict(agent_path=policy_path),
         ),
     )
@@ -523,7 +523,7 @@ def test_train_adversarial(tmpdir, named_configs, command):
     )
     config_updates = {
         "logging": dict(log_root=tmpdir),
-        "demonstrations": dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+        "demonstrations": dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
         # TensorBoard logs to get extra coverage
         "algorithm_kwargs": dict(init_tensorboard=True),
     }
@@ -541,7 +541,7 @@ def test_train_adversarial_warmstart(tmpdir, command):
     named_configs = ["cartpole"] + ALGO_FAST_CONFIGS["adversarial"]
     config_updates = {
         "logging": dict(log_root=tmpdir),
-        "demonstrations": dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+        "demonstrations": dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
     }
     run = train_adversarial.train_adversarial_ex.run(
         command_name=command,
@@ -575,7 +575,7 @@ def test_train_adversarial_sac(tmpdir, command):
     )
     config_updates = {
         "logging": dict(log_root=tmpdir),
-        "demonstrations": dict(rollout_path=PENDULUM_TEST_ROLLOUT_PATH),
+        "demonstrations": dict(path=PENDULUM_TEST_ROLLOUT_PATH),
     }
     run = train_adversarial.train_adversarial_ex.run(
         command_name=command,
@@ -593,7 +593,7 @@ def test_train_adversarial_algorithm_value_error(tmpdir):
     base_config_updates = collections.ChainMap(
         {
             "logging": dict(log_root=tmpdir),
-            "demonstrations": dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+            "demonstrations": dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
         },
     )
 
@@ -611,7 +611,7 @@ def test_train_adversarial_algorithm_value_error(tmpdir):
             command_name="gail",
             named_configs=base_named_configs,
             config_updates=base_config_updates.new_child(
-                {"demonstrations.rollout_path": "path/BAD_VALUE"},
+                {"demonstrations.path": "path/BAD_VALUE"},
             ),
         )
 
@@ -641,7 +641,7 @@ def test_transfer_learning(tmpdir: str) -> None:
         named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["adversarial"],
         config_updates=dict(
             logging=dict(log_dir=log_dir_train),
-            demonstrations=dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+            demonstrations=dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
         ),
     )
     assert run.status == "COMPLETED"
@@ -792,7 +792,7 @@ PARALLEL_CONFIG_UPDATES = [
         base_named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["adversarial"],
         base_config_updates={
             # Need absolute path because raylet runs in different working directory.
-            "demonstrations.rollout_path": CARTPOLE_TEST_ROLLOUT_PATH.absolute(),
+            "demonstrations.path": CARTPOLE_TEST_ROLLOUT_PATH.absolute(),
         },
         search_space={
             "command_name": tune.grid_search(["gail", "airl"]),
@@ -858,8 +858,8 @@ def _generate_test_rollouts(tmpdir: str, env_named_config: str) -> pathlib.Path:
             logging=dict(log_dir=tmpdir),
         ),
     )
-    rollout_path = tmpdir_path / "rollouts/final.npz"
-    return rollout_path.absolute()
+    path = tmpdir_path / "rollouts/final.npz"
+    return path.absolute()
 
 
 def test_parallel_train_adversarial_custom_env(tmpdir):
@@ -870,7 +870,7 @@ def test_parallel_train_adversarial_custom_env(tmpdir):
         )
 
     env_named_config = "pendulum"
-    rollout_path = _generate_test_rollouts(tmpdir, env_named_config)
+    path = _generate_test_rollouts(tmpdir, env_named_config)
 
     config_updates = dict(
         sacred_ex_name="train_adversarial",
@@ -878,7 +878,7 @@ def test_parallel_train_adversarial_custom_env(tmpdir):
         base_named_configs=[env_named_config] + ALGO_FAST_CONFIGS["adversarial"],
         base_config_updates=dict(
             logging=dict(log_root=tmpdir),
-            demonstrations=dict(rollout_path=rollout_path),
+            demonstrations=dict(path=path),
         ),
         search_space=dict(command_name="gail"),
     )
@@ -893,7 +893,7 @@ def _run_train_adv_for_test_analyze_imit(run_name, sacred_logs_dir, log_dir):
         named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["adversarial"],
         config_updates=dict(
             logging=dict(log_root=log_dir),
-            demonstrations=dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+            demonstrations=dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
             checkpoint_interval=-1,
         ),
         options={"--name": run_name, "--file_storage": sacred_logs_dir},
@@ -907,7 +907,7 @@ def _run_train_bc_for_test_analyze_imit(run_name, sacred_logs_dir, log_dir):
         named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["imitation"],
         config_updates=dict(
             logging=dict(log_dir=log_dir),
-            demonstrations=dict(rollout_path=CARTPOLE_TEST_ROLLOUT_PATH),
+            demonstrations=dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
         ),
         options={"--name": run_name, "--file_storage": sacred_logs_dir},
     )

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -313,7 +313,7 @@ def test_train_dagger_warmstart(tmpdir):
 
 
 def test_train_bc_main_with_none_demonstrations_raises_value_error(tmpdir):
-    with pytest.raises(ValueError, match="When type is 'local', path must be set."):
+    with pytest.raises(ValueError, match="n_expert_demos must be specified"):
         train_imitation.train_imitation_ex.run(
             command_name="bc",
             named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["imitation"],

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -338,26 +338,6 @@ def test_train_bc_main_with_demonstrations_from_huggingface(tmpdir):
     )
 
 
-def test_train_bc_main_with_demonstrations_warns_setting_rollout_type(
-    tmpdir,
-):
-    with pytest.warns(
-        RuntimeWarning,
-        match="Ignoring `rollout_path` .*",
-    ):
-        train_imitation.train_imitation_ex.run(
-            command_name="bc",
-            named_configs=["seals_cartpole"] + ALGO_FAST_CONFIGS["imitation"],
-            config_updates=dict(
-                logging=dict(log_root=tmpdir),
-                demonstrations=dict(
-                    rollout_type="ppo-huggingface",
-                    rollout_path="path",
-                ),
-            ),
-        )
-
-
 @pytest.fixture(
     params=[
         "expert_from_path",

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -331,7 +331,7 @@ def test_train_bc_main_with_demonstrations_from_huggingface(tmpdir):
         config_updates=dict(
             logging=dict(log_root=tmpdir),
             demonstrations=dict(
-                type="huggingface",
+                source="huggingface",
                 algo_name="ppo",
             ),
         ),
@@ -549,7 +549,7 @@ def test_train_adversarial_warmstart(tmpdir, command):
     named_configs = ["cartpole"] + ALGO_FAST_CONFIGS["adversarial"]
     config_updates = {
         "logging": dict(log_root=tmpdir),
-        "demonstrations": dict(path=CARTPOLE_TEST_ROLLOUT_PATH, type="local"),
+        "demonstrations": dict(path=CARTPOLE_TEST_ROLLOUT_PATH, source="local"),
     }
     run = train_adversarial.train_adversarial_ex.run(
         command_name=command,
@@ -601,7 +601,7 @@ def test_train_adversarial_algorithm_value_error(tmpdir):
     base_config_updates = collections.ChainMap(
         {
             "logging": dict(log_root=tmpdir),
-            "demonstrations": dict(path=CARTPOLE_TEST_ROLLOUT_PATH, type="local"),
+            "demonstrations": dict(path=CARTPOLE_TEST_ROLLOUT_PATH, source="local"),
         },
     )
 

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -544,7 +544,7 @@ def test_train_adversarial_warmstart(tmpdir, command):
     named_configs = ["cartpole"] + ALGO_FAST_CONFIGS["adversarial"]
     config_updates = {
         "logging": dict(log_root=tmpdir),
-        "demonstrations": dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
+        "demonstrations": dict(path=CARTPOLE_TEST_ROLLOUT_PATH, type="local"),
     }
     run = train_adversarial.train_adversarial_ex.run(
         command_name=command,
@@ -596,7 +596,7 @@ def test_train_adversarial_algorithm_value_error(tmpdir):
     base_config_updates = collections.ChainMap(
         {
             "logging": dict(log_root=tmpdir),
-            "demonstrations": dict(path=CARTPOLE_TEST_ROLLOUT_PATH),
+            "demonstrations": dict(path=CARTPOLE_TEST_ROLLOUT_PATH, type="local"),
         },
     )
 

--- a/tests/scripts/test_scripts.py
+++ b/tests/scripts/test_scripts.py
@@ -199,7 +199,7 @@ def test_train_preference_comparisons_sac(tmpdir):
 
     # Make sure rl.sac named_config is called after rl.fast to overwrite
     # rl_kwargs.batch_size to None
-    with pytest.raises(Exception, match=".*set 'batch_size' at top-level.*"):
+    with pytest.raises(Exception, match="set 'batch_size' at top-level"):
         train_preference_comparisons.train_preference_comparisons_ex.run(
             named_configs=["pendulum"]
             + RL_SAC_NAMED_CONFIGS
@@ -233,9 +233,9 @@ def test_train_preference_comparisons_sac_reward_relabel(tmpdir):
     assert run.status == "COMPLETED"
     del run
 
-    with pytest.raises(AssertionError, match=".*only ReplayBuffer is supported.*"):
+    with pytest.raises(AssertionError, match="only ReplayBuffer is supported"):
         _run_reward_relabel_sac_preference_comparisons(buffers.DictReplayBuffer)
-    with pytest.raises(AssertionError, match=".*only ReplayBuffer is supported.*"):
+    with pytest.raises(AssertionError, match="only ReplayBuffer is supported"):
         _run_reward_relabel_sac_preference_comparisons(HerReplayBuffer)
 
 
@@ -427,7 +427,7 @@ def test_train_rl_main(tmpdir, rl_train_ppo_config):
 
 def test_train_rl_wb_logging(tmpdir):
     """Smoke test for imitation.scripts.ingredients.logging.wandb_logging."""
-    with pytest.raises(Exception, match=".*api_key not configured.*"):
+    with pytest.raises(Exception, match="api_key not configured"):
         train_rl.train_rl_ex.run(
             named_configs=["cartpole"]
             + ALGO_FAST_CONFIGS["rl"]
@@ -597,7 +597,7 @@ def test_train_adversarial_algorithm_value_error(tmpdir):
         },
     )
 
-    with pytest.raises(TypeError, match=".*BAD_VALUE.*"):
+    with pytest.raises(TypeError, match="BAD_VALUE"):
         train_adversarial.train_adversarial_ex.run(
             command_name="gail",
             named_configs=base_named_configs,
@@ -606,7 +606,7 @@ def test_train_adversarial_algorithm_value_error(tmpdir):
             ),
         )
 
-    with pytest.raises(FileNotFoundError, match=".*BAD_VALUE.*"):
+    with pytest.raises(FileNotFoundError, match="BAD_VALUE"):
         train_adversarial.train_adversarial_ex.run(
             command_name="gail",
             named_configs=base_named_configs,
@@ -616,7 +616,7 @@ def test_train_adversarial_algorithm_value_error(tmpdir):
         )
 
     n_traj = 1234567
-    with pytest.raises(ValueError, match=f".*{n_traj}.*"):
+    with pytest.raises(ValueError, match=f"{n_traj}"):
         train_adversarial.train_adversarial_ex.run(
             command_name="gail",
             named_configs=base_named_configs,
@@ -738,7 +738,7 @@ def test_train_rl_double_normalization(tmpdir: str, rng):
     log_dir_data = os.path.join(tmpdir, "train_rl")
     with pytest.warns(
         RuntimeWarning,
-        match=r"Applying normalization to already normalized reward function.*",
+        match=r"Applying normalization to already normalized reward function",
     ):
         train_rl.train_rl_ex.run(
             named_configs=["cartpole"] + ALGO_FAST_CONFIGS["rl"],
@@ -825,24 +825,24 @@ def test_parallel_arg_errors(tmpdir):
     config_updates.setdefault("base_config_updates", {})["logging.log_root"] = tmpdir
     config_updates = collections.ChainMap(config_updates)
 
-    with pytest.raises(TypeError, match=".*Sequence.*"):
+    with pytest.raises(TypeError, match="Sequence"):
         parallel.parallel_ex.run(
             config_updates=config_updates.new_child(dict(base_named_configs={})),
         )
 
-    with pytest.raises(TypeError, match=".*Mapping.*"):
+    with pytest.raises(TypeError, match="Mapping"):
         parallel.parallel_ex.run(
             config_updates=config_updates.new_child(dict(base_config_updates=())),
         )
 
-    with pytest.raises(TypeError, match=".*Sequence.*"):
+    with pytest.raises(TypeError, match="Sequence"):
         parallel.parallel_ex.run(
             config_updates=config_updates.new_child(
                 dict(search_space={"named_configs": {}}),
             ),
         )
 
-    with pytest.raises(TypeError, match=".*Mapping.*"):
+    with pytest.raises(TypeError, match="Mapping"):
         parallel.parallel_ex.run(
             config_updates=config_updates.new_child(
                 dict(search_space={"config_updates": ()}),


### PR DESCRIPTION
## Description

HuggingFace offers a [**Models** Hub](https://huggingface.co/models) and a [**Datasets** Hub](https://huggingface.co/datasets).

We used to store expert trajectories along with expert models on the HuggingFace **Model** Hub and load them from there using the `imitation.data.serialize.load_rollouts_from_huggingface` function.

Since #677 we have support for [HuggingFace Datasets](https://huggingface.co/docs/datasets/) for storing and loading expert trajectories so it makes more sense to store the expert trajectories on the **Datasets** Hub instead of the **Models** Hub.

As part of this transition, this PR removes the `imitation.data.serialize.load_rollouts_from_huggingface` function, which used to load rollouts from the **Model** Hub.
That function was only used in the `demonstrations` ingredient for the sacred scripts.
This ingredient was changed so it downloads the demonstrations from the **Datasets** hub using `datasets.load_dataset()`.
For this to work, I uploaded the already existing expert trajectories that were stored in a (old-format) `rollouts.npz` along the expert models to their own **Dataset** repositories.
You will find the six new **Dataset** repositories on our [HuggingFace Organization page](https://huggingface.co/HumanCompatibleAI) at the bottom.

## Testing

The existing tests should cover this change.
