### PR TITLE
Pin SB3 version to 1.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ ATARI_REQUIRE = [
     "autorom[accept-rom-license]~=0.6.0",
 ]
 PYTYPE = ["pytype==2022.7.26"] if IS_NOT_WINDOWS else []
-STABLE_BASELINES3 = "stable-baselines3>=1.7.0"
+STABLE_BASELINES3 = "stable-baselines3>=1.7.0,<2.0.0"
 # pinned to 0.21 until https://github.com/DLR-RM/stable-baselines3/pull/780 goes
 # upstream.
 GYM_VERSION_SPECIFIER = "==0.21.0"


### PR DESCRIPTION
## Description

Currently the whole CI is on fire due to the default SB3 version being 2.0.0, which is incompatible with gym. 

This PR pins the version to 1.7.0 (or more precisely, to anything below 2.0.0, in case there's bugfix releases) while the Gymnasium switch is underway (see #735, #734, HumanCompatibleAI/seals#72)
