### PR TITLE
Updated Installation Instructions

### DIFF
--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -13,7 +13,7 @@ Prerequisites
 
     pip install -U setuptools==65.5.0 pip==21
 
-- (on M1 Macs) you need to set environment variables due to \
+- (on ARM64 Macs) you need to set environment variables due to \
   `a bug in grpcio <https://stackoverflow.com/questions/66640705/how-can-i-install-grpcio-on-an-apple-m1-silicon-laptop>`_:
 
 .. code-block:: bash

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -6,6 +6,21 @@ Prerequisites
 -------------
 
 - Python 3.8+
+- Specific versions of pip and setuptools due to \
+  `a bug with gym <https://github.com/openai/gym/issues/3176>`_:
+
+.. code-block:: bash
+
+    pip install -U setuptools==65.5.0 pip==21
+
+- (on M1 Macs) you need to set environment variables due to \
+  `a bug in grpcio <https://stackoverflow.com/questions/66640705/how-can-i-install-grpcio-on-an-apple-m1-silicon-laptop>`_:
+
+.. code-block:: bash
+
+    export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+    export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1
+
 - (Optional) OpenGL (to render gym environments)
 - (Optional) FFmpeg (to encode videos of renders)
 - (Optional) MuJoCo (follow instructions to install `mujoco\_py v1.5 here`_)

--- a/docs/main-concepts/experts.rst
+++ b/docs/main-concepts/experts.rst
@@ -12,7 +12,7 @@ learning library.
 For example, BC and DAgger can learn from an expert policy and the command line
 interface of AIRL/GAIL allows one to specify an expert to sample demonstrations from.
 
-In the :doc:`../getting-started/first-steps` tutorial, we first train an expert policy
+In the :doc:`../getting-started/first_steps` tutorial, we first train an expert policy
 using the stable-baselines3 library and then imitate it's behavior using
 :doc:`../algorithms/bc`.
 In practice, you may want to load a pre-trained policy for performance reasons.


### PR DESCRIPTION
## Description

Due to a bug in gym we need specific setuptools an pip version to install `imitation`. Also on M1 Macs we need a workaround to install `grpio` which also is a dependency of `imitation`.
This PR documents both of this in the installation instructions so people do not keep running into the same issues when installing `imitation`.

You find the rendered instructions [here](https://imitation--760.org.readthedocs.build/en/760/getting-started/installation.html).

## Testing
Documentation only changes.
