### PR TITLE
Add huggingface_sb3<=2.2.5 version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -207,7 +207,7 @@ setup(
         STABLE_BASELINES3,
         "sacred>=0.8.4",
         "tensorboard>=1.14",
-        "huggingface_sb3>=2.2.1",
+        "huggingface_sb3>=2.2.1,<=2.2.5",
         "datasets>=2.8.0",
     ],
     tests_require=TESTS_REQUIRE,


### PR DESCRIPTION
## Description

To fix CI, let's add this requirement temporarily. The issue is that newer versions try to import `gymnasium` which breaks our CI.
Once we adopt `gymnasium` in `imitation`, this requirement will need to be changed.

## Testing

Let's see if CI passes. ;)
