### PR TITLE
Ensure MyST-NB raises an error when rendering a notebook fails.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,9 @@ nb_execution_mode = os.getenv("NB_EXECUTION_MODE", "cache")
 nb_execution_timeout = 120
 nb_merge_streams = True
 nb_output_stderr = "remove"
+nb_execution_raise_on_error = True
+nb_execution_show_tb = True
+
 # Enable LaTeX macros in markdown cells
 myst_enable_extensions = [
     "amsmath",


### PR DESCRIPTION
## Description

As described in #799, failing notebooks don't make the readthedocs job fail.
This PR fixes this by changing the MyST-NB config.

Should fix #799 and #790

## Testing

Checked that the [readthedocs job now properly fails as expected](https://readthedocs.org/projects/imitation/builds/22123183/)
