### PR TITLE
Update gymnasium dependency and render_mode in gym.make

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ setup(
     #   encode only known incompatibilities here. This prevents nasty dependency issues
     #   for our users.
     install_requires=[
-        "gymnasium[classic-control]~=0.28.1",
+        "gymnasium[classic-control]~==0.29",
         "matplotlib",
         "numpy>=1.15",
         "torch>=1.4.0",
@@ -220,7 +220,7 @@ setup(
         "docs": DOCS_REQUIRE,
         "parallel": PARALLEL_REQUIRE,
         "mujoco": [
-            "gymnasium[classic-control,mujoco]~=0.28.1",
+            "gymnasium[classic-control,mujoco]~=0.29",
         ],
         "atari": ATARI_REQUIRE,
     },

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ setup(
     #   encode only known incompatibilities here. This prevents nasty dependency issues
     #   for our users.
     install_requires=[
-        "gymnasium[classic-control]~==0.29",
+        "gymnasium[classic-control]~=0.29",
         "matplotlib",
         "numpy>=1.15",
         "torch>=1.4.0",

--- a/src/imitation/scripts/eval_policy.py
+++ b/src/imitation/scripts/eval_policy.py
@@ -95,7 +95,11 @@ def eval_policy(
     log_dir = logging_ingredient.make_log_dir()
     sample_until = rollout.make_sample_until(eval_n_timesteps, eval_n_episodes)
     post_wrappers = [video_wrapper_factory(log_dir, **video_kwargs)] if videos else None
-    with environment.make_venv(post_wrappers=post_wrappers) as venv:
+    render_mode = "rgb_array" if videos else None
+    with environment.make_venv(
+        post_wrappers=post_wrappers,
+        env_make_kwargs=dict(render_mode=render_mode),
+    ) as venv:
         if render:
             venv = InteractiveRender(venv, render_fps)
 


### PR DESCRIPTION
This PR updates the gymnasium version to 0.29. This change also requires specifying `render_mode="rgb_array"` in `gym.make` when rendering environment videos.
