### PR TITLE
Update the README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ You can find [the documentation here](https://imitation.readthedocs.io/en/latest
 - Python 3.8+
 - (Optional) OpenGL (to render Gym environments)
 - (Optional) FFmpeg (to encode videos of renders)
-- (Optional) MuJoCo (follow instructions to install [mujoco_py v1.5 here](https://github.com/openai/mujoco-py/tree/498b451a03fb61e5bdfcb6956d8d7c881b1098b5#install-mujoco))
 
 ### Installing PyPI release
 

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -4,6 +4,8 @@ The imitation library is benchmarked by running the algorithms BC, DAgger, AIRL 
 on five different environments from the
 [seals environment suite](https://github.com/HumanCompatibleAI/seals)
 each with 10 different random seeds.
+You will find the benchmark results in the release artifacts, e.g. for the v1.0 release
+[here](https://github.com/HumanCompatibleAI/imitation/releases/download/v1.0.0/benchmark_runs.zip).
 
 
 ## Running a Single Benchmark


### PR DESCRIPTION
## Description

This PR updates the README files so they 
1. stop instructing to install the outdated MuJoCo 1.5
2. link to the benchmark results in the release artifacts

## Testing

Documentation-only changes.
