### PR TITLE
Fix warning in quickstart.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,6 +365,10 @@ jobs:
             TESTFILES=$(circleci tests glob "tests/**/test*.py" | circleci tests split --split-by=timings)
             echo "This shard testing: ${TESTFILES}"
             pytest -n auto --junitxml=/tmp/test-reports/junit.xml -vv $TESTFILES
+          environment:
+            # This is needed in newer versions of pygam. See
+            # https://github.com/pygame/pygame/issues/3835#issuecomment-1703717368
+            SDL_VIDEODRIVER: dummy
 
       - save-pytest-cache
       - store-test-output-unix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ jobs:
             echo "This shard testing: ${TESTFILES}"
             pytest -n auto --junitxml=/tmp/test-reports/junit.xml -vv $TESTFILES
           environment:
-            # This is needed in newer versions of pygam. See
+            # This is needed in newer versions of pygame. See
             # https://github.com/pygame/pygame/issues/3835#issuecomment-1703717368
             SDL_VIDEODRIVER: dummy
 

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -71,9 +71,16 @@ bc_trainer = bc.BC(
     rng=rng,
 )
 
+evaluation_env = make_vec_env(
+    "seals:seals/CartPole-v0",
+    rng=rng,
+    env_make_kwargs={"render_mode": "human"},  # for rendering
+)
+
+print("Evaluating the untrained policy.")
 reward, _ = evaluate_policy(
     bc_trainer.policy,  # type: ignore[arg-type]
-    env,
+    evaluation_env,
     n_eval_episodes=3,
     render=True,  # comment out to speed up
 )
@@ -82,9 +89,10 @@ print(f"Reward before training: {reward}")
 print("Training a policy using Behavior Cloning")
 bc_trainer.train(n_epochs=1)
 
+print("Evaluating the trained policy.")
 reward, _ = evaluate_policy(
     bc_trainer.policy,  # type: ignore[arg-type]
-    env,
+    evaluation_env,
     n_eval_episodes=3,
     render=True,  # comment out to speed up
 )


### PR DESCRIPTION
Fix warning in `quickstart.py` caused by not properly setting the render mode in the evaluation environment.