### PR TITLE
Switch to lualatex to generate the documentation PDF

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,10 @@ nb_output_stderr = "remove"
 nb_execution_raise_on_error = True
 nb_execution_show_tb = True
 
+# The default engine ran into memory issues on some notebooks
+# so we use lualatex instead
+latex_engine = "lualatex"
+
 # Enable LaTeX macros in markdown cells
 myst_enable_extensions = [
     "amsmath",


### PR DESCRIPTION
The documentation pipeline was failing only on the master branch.
This is due to the fact that only for commits on master readthedocs tries to generate a PDF.

PDF generateion failed since latex ran out of memory.

Let's see if luatex can do better.

Note: to test if this PR works we unfortunately need to merge it into master since the PDF output is only generated for 
master builds.