### PR TITLE
Make the default device for policies "cpu"

### DIFF
--- a/src/imitation/algorithms/bc.py
+++ b/src/imitation/algorithms/bc.py
@@ -249,7 +249,7 @@ class BCLogger:
 
 def reconstruct_policy(
     policy_path: str,
-    device: Union[th.device, str] = "auto",
+    device: Union[th.device, str] = "cpu",
 ) -> policies.ActorCriticPolicy:
     """Reconstruct a saved policy.
 
@@ -285,7 +285,7 @@ class BC(algo_base.DemonstrationAlgorithm):
         optimizer_kwargs: Optional[Mapping[str, Any]] = None,
         ent_weight: float = 1e-3,
         l2_weight: float = 0.0,
-        device: Union[str, th.device] = "auto",
+        device: Union[str, th.device] = "cpu",
         custom_logger: Optional[imit_logger.HierarchicalLogger] = None,
     ):
         """Builds BC.

--- a/src/imitation/algorithms/dagger.py
+++ b/src/imitation/algorithms/dagger.py
@@ -100,7 +100,7 @@ def reconstruct_trainer(
     scratch_dir: types.AnyPath,
     venv: vec_env.VecEnv,
     custom_logger: Optional[imit_logger.HierarchicalLogger] = None,
-    device: Union[th.device, str] = "auto",
+    device: Union[th.device, str] = "cpu",
 ) -> "DAggerTrainer":
     """Reconstruct trainer from the latest snapshot in some working directory.
 

--- a/src/imitation/algorithms/sqil.py
+++ b/src/imitation/algorithms/sqil.py
@@ -119,7 +119,7 @@ class SQILReplayBuffer(buffers.ReplayBuffer):
         observation_space: spaces.Space,
         action_space: spaces.Space,
         demonstrations: algo_base.AnyTransitions,
-        device: Union[th.device, str] = "auto",
+        device: Union[th.device, str] = "cpu",
         n_envs: int = 1,
         optimize_memory_usage: bool = False,
     ):


### PR DESCRIPTION
When there is a GPU available, using "auto" as the default device does not seem to be desirable (see #825).

This PR sets the default device to "cpu" which hopefully just works in most cases.

Fixes #825 