### PR TITLE
Remove FloatReward

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ setup(
         "rich",
         "scikit-learn>=0.21.2",
         "seals~=0.2.1",
-        "stable-baselines3~=2.0",
+        "stable-baselines3~=2.2.1",
         "sacred>=0.8.4",
         "tensorboard>=1.14",
         "huggingface_sb3~=3.0",

--- a/tests/algorithms/conftest.py
+++ b/tests/algorithms/conftest.py
@@ -113,20 +113,10 @@ def pendulum_single_venv(rng) -> VecEnv:
     )
 
 
-# TODO(GH#794): Remove after https://github.com/DLR-RM/stable-baselines3/pull/1676
-# merged and released.
-class FloatReward(gym.RewardWrapper):
-    """Typecasts reward to a float."""
-
-    def reward(self, reward):
-        return float(reward)
-
-
 @pytest.fixture
 def multi_obs_venv() -> VecEnv:
     def make_env():
         env = envs.SimpleMultiObsEnv(channel_last=False)
-        env = FloatReward(env)
         return RolloutInfoWrapper(env)
 
     return DummyVecEnv([make_env, make_env])

--- a/tests/algorithms/conftest.py
+++ b/tests/algorithms/conftest.py
@@ -1,7 +1,6 @@
 """Fixtures common across algorithm tests."""
 from typing import Sequence
 
-import gymnasium as gym
 import pytest
 from stable_baselines3.common import envs
 from stable_baselines3.common.policies import BasePolicy


### PR DESCRIPTION
A quick fix for #794.

After the newest release of SB3 we don't need the FloatReward wrapper any more.

Fixes #794 
