### PR TITLE
Fix variable horizon link in 4_train_airl.ipynb

### DIFF
--- a/docs/tutorials/4_train_airl.ipynb
+++ b/docs/tutorials/4_train_airl.ipynb
@@ -14,7 +14,7 @@
    "source": [
     "As usual, we first need an expert. Again, we download one from the HuggingFace model hub for convenience.\n",
     "\n",
-    "Note that we now use a variant of the CartPole environment from the seals package, which has fixed episode durations. Read more about why we do this [here](https://imitation.readthedocs.io/en/latest/getting-started/variable-horizon.html)."
+    "Note that we now use a variant of the CartPole environment from the seals package, which has fixed episode durations. Read more about why we do this [here](https://imitation.readthedocs.io/en/latest/main-concepts/variable_horizon.html)."
    ]
   },
   {


### PR DESCRIPTION
## Description

Fixes the variable horizon concept link from the tutorial for training AIRL. 

## Testing

I've tried the original link in master branch and the link from this PR branch.
