### PR TITLE
Fix excessive RAM usage of preference comparisons

### DIFF
--- a/src/imitation/algorithms/preference_comparisons.py
+++ b/src/imitation/algorithms/preference_comparisons.py
@@ -650,11 +650,12 @@ class RandomFragmenter(Fragmenter):
             start = self.rng.integers(0, n - fragment_length, endpoint=True)
             end = start + fragment_length
             terminal = (end == n) and traj.terminal
+            # Copy the slices to enable garbage collection of full trajectory.
             fragment = TrajectoryWithRew(
-                obs=traj.obs[start : end + 1],
-                acts=traj.acts[start:end],
-                infos=traj.infos[start:end] if traj.infos is not None else None,
-                rews=traj.rews[start:end],
+                obs=traj.obs[start : end + 1].copy(),
+                acts=traj.acts[start:end].copy(),
+                infos=traj.infos[start:end].copy() if traj.infos is not None else None,
+                rews=traj.rews[start:end].copy(),
                 terminal=terminal,
             )
             fragments.append(fragment)


### PR DESCRIPTION
## Description

Previously we stored a view into the trajectory in the preference comparison dataset. This view is a reference to the original trajectory, and therefore keeps it from getting garbage collected for as long as the view exists (i.e., however long the comparison is stored in the dataset).

This is problematic when trajectories are large and long, e.g., in the case of atari (images) with SEALS (long episodes). It can cause the RAM to fill up quite quickly in that setting.

We can fix it by copying the fragments we want to store. That avoids keeping a reference to the original trajectory alive, we only need to store the fragment. The tradeoff is that copying adds some overhead and overlapping fragments are no longer deduplicated.

## Testing

I trained atari Pong and verified that the RAM usage remains roughly constant after this change. Prior to this change, it kept increasing until the memory ran out.
